### PR TITLE
feat: parallelize MaximizationStep

### DIFF
--- a/mpest/em/methods/l_moments_method.py
+++ b/mpest/em/methods/l_moments_method.py
@@ -1,6 +1,7 @@
 """The module in which the L moments method is presented"""
 
 import json
+from concurrent.futures.process import ProcessPoolExecutor
 from math import ceil
 
 import numpy as np
@@ -56,6 +57,18 @@ class LMomentsMStep(AMaximization[EResult]):
             mr_j += p_rk * b_k
         return mr_j
 
+    def _calc_lm_for_dist(
+        self, j: int, d: Distribution, samples: Samples, indicators: np.ndarray
+    ) -> tuple[int, np.ndarray]:
+        """
+        Helper function for multiprocessed.
+        Calculates all L-moments for a single specified mixture component.
+        """
+        moments_for_j = np.zeros(len(d.params))
+        for r in range(len(d.params)):
+            moments_for_j[r] = self.calculate_mr_j(r + 1, j, samples, indicators)
+        return j, moments_for_j
+
     def step(self, e_result: EResult) -> Result:
         """
         A function that performs E step
@@ -76,9 +89,15 @@ class LMomentsMStep(AMaximization[EResult]):
 
         max_params_count = max(len(d.params) for d in mixture)
         l_moments = np.zeros(shape=[len(mixture), max_params_count])
-        for j, d in enumerate(mixture):
-            for r in range(len(d.params)):
-                l_moments[j][r] = self.calculate_mr_j(r + 1, j, samples, indicators)
+
+        with ProcessPoolExecutor() as executor:
+            futures = [
+                executor.submit(self._calc_lm_for_dist, j, d, samples, indicators) for j, d in enumerate(mixture)
+            ]
+
+            for future in futures:
+                j, moments_for_j = future.result()
+                l_moments[j, : len(moments_for_j)] = moments_for_j
 
         for i, d in enumerate(mixture):
             if d.model.name == "WeibullExp" and (l_moments[i][0] * l_moments[i][1] < 0):

--- a/mpest/em/methods/likelihood_method.py
+++ b/mpest/em/methods/likelihood_method.py
@@ -1,15 +1,18 @@
 """The module in which the maximum likelihood method is presented"""
 
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import partial
+from typing import Optional
 
 import numpy as np
 from scipy.stats import FitError, norm, weibull_min
 
+from mpest import Params, Samples
 from mpest.core.distribution import Distribution
 from mpest.core.mixture_distribution import MixtureDistribution
 from mpest.core.problem import Problem, Result
 from mpest.em.methods.abstract_steps import AExpectation, AMaximization
-from mpest.exceptions import EStepError, SampleError
+from mpest.exceptions import EStepError, MStepError, SampleError
 from mpest.models import AModel, AModelDifferentiable, WeibullModelExp
 from mpest.optimizers import AOptimizerJacobian, TOptimizer
 from mpest.utils import ResultWithError
@@ -262,6 +265,40 @@ class LikelihoodMStep(AMaximization[EResult]):
         """
         self.optimizer = optimizer
 
+    def _run_m_step_for_component(self, j: int, ch, d: Distribution, samples: Samples, optimizer: TOptimizer):
+        """
+        Helper function for multiprocessed.
+        Performs the M-step for a single mixture component.
+        """
+
+        def log_likelihood(params, ch, model: AModel):
+            array_ldpf = np.array([model.lpdf(x, params) for x in samples])
+            finite_mask = np.isfinite(array_ldpf)
+            return -np.sum(ch[finite_mask] * array_ldpf[finite_mask])
+
+        def jacobian(params, ch, model: AModelDifferentiable):
+            return -np.sum(
+                ch * np.swapaxes([model.ld_params(x, params) for x in samples], 0, 1),
+                axis=1,
+            )
+
+        if isinstance(optimizer, AOptimizerJacobian):
+            if not isinstance(d.model, AModelDifferentiable):
+                raise TypeError
+
+            new_params = optimizer.minimize(
+                partial(log_likelihood, ch=ch, model=d.model),
+                d.params,
+                jacobian=partial(jacobian, ch=ch, model=d.model),
+            )
+        else:
+            new_params = optimizer.minimize(
+                func=partial(log_likelihood, ch=ch, model=d.model),
+                params=d.params,
+            )
+
+        return j, new_params
+
     def step(self, e_result: EResult) -> Result:
         """
         A function that performs E step
@@ -281,36 +318,26 @@ class LikelihoodMStep(AMaximization[EResult]):
         mixture = problem.distributions
 
         new_w = np.sum(h, axis=1) / m
-        new_distributions: list[Distribution] = []
-        for j, ch in enumerate(h[:]):
-            d = mixture[j]
+        num_distributions = len(mixture)
+        calculated_params: list[Optional[Params]] = [None] * num_distributions
 
-            def log_likelihood(params, ch, model: AModel):
-                array_ldpf = np.array([model.lpdf(x, params) for x in samples])
-                finite_mask = np.isfinite(array_ldpf)
-                return -np.sum(ch[finite_mask] * array_ldpf[finite_mask])
+        with ProcessPoolExecutor() as executor:
+            tasks_args = [(j, h[j], mixture[j], samples, optimizer) for j in range(len(mixture))]
 
-            def jacobian(params, ch, model: AModelDifferentiable):
-                return -np.sum(
-                    ch * np.swapaxes([model.ld_params(x, params) for x in samples], 0, 1),
-                    axis=1,
-                )
+            futures = [executor.submit(self._run_m_step_for_component, *args) for args in tasks_args]
 
-            # maximizing log of likelihood function for every active distribution
-            if isinstance(optimizer, AOptimizerJacobian):
-                if not isinstance(d.model, AModelDifferentiable):
-                    raise TypeError
+            for future in as_completed(futures):
+                try:
+                    j, new_params = future.result()
+                    calculated_params[j] = new_params
+                except Exception as e:
+                    raise e
 
-                new_params = optimizer.minimize(
-                    partial(log_likelihood, ch=ch, model=d.model),
-                    d.params,
-                    jacobian=partial(jacobian, ch=ch, model=d.model),
-                )
-            else:
-                new_params = optimizer.minimize(
-                    func=partial(log_likelihood, ch=ch, model=d.model),
-                    params=d.params,
-                )
+            if any(p is None for p in calculated_params):
+                raise MStepError("Failed to compute all parameters, but no TypeError was raised.")
 
-            new_distributions.append(Distribution(d.model, new_params))
-        return ResultWithError(MixtureDistribution.from_distributions(new_distributions, new_w))
+            final_params: list[Params] = [p for p in calculated_params if p is not None]
+
+            new_distributions = [Distribution(mixture[i].model, final_params[i]) for i in range(num_distributions)]
+
+            return ResultWithError(MixtureDistribution.from_distributions(new_distributions, new_w))

--- a/mpest/em/methods/moments_method.py
+++ b/mpest/em/methods/moments_method.py
@@ -1,5 +1,7 @@
 """The module in which the moments method is presented"""
 
+from concurrent.futures.process import ProcessPoolExecutor
+
 import numpy as np
 
 from mpest import Samples
@@ -41,6 +43,18 @@ class MomentsMStep(AMaximization[EResult]):
 
         return numerator / sum_j_row_probabilities
 
+    def _calc_m_for_dist(
+        self, j: int, d: Distribution, samples: Samples, indicators: np.ndarray
+    ) -> tuple[int, np.ndarray]:
+        """
+        Helper function for multiprocessed.
+        Calculates all moments for a single specified mixture component.
+        """
+        moments_for_j = np.zeros(len(d.params))
+        for r in range(len(d.params)):
+            moments_for_j[r] = self.calc_order_moment_of_index_element(r + 1, j, samples, indicators)
+        return j, moments_for_j
+
     def step(self, e_result: EResult) -> Result:
         """
         A function that performs M step
@@ -62,9 +76,12 @@ class MomentsMStep(AMaximization[EResult]):
         max_params_count = max(len(d.params) for d in mixture)
         moments = np.zeros(shape=[len(mixture), max_params_count])
 
-        for j, d in enumerate(mixture):
-            for r in range(len(d.params)):
-                moments[j][r] = self.calc_order_moment_of_index_element(r + 1, j, samples, indicators)
+        with ProcessPoolExecutor() as executor:
+            futures = [executor.submit(self._calc_m_for_dist, j, d, samples, indicators) for j, d in enumerate(mixture)]
+
+            for future in futures:
+                j, moments_for_j = future.result()
+                moments[j, : len(moments_for_j)] = moments_for_j
 
         for i, d in enumerate(mixture):
             if d.model.name == "WeibullExp" and (moments[i][0] * moments[i][1] < 0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration file to set a safe multiprocessing start method."""
+
+import multiprocessing
+import sys
+from contextlib import suppress
+
+
+def pytest_sessionstart(session):
+    """
+    Pytest hook called before test collection and execution begins.
+    """
+    if sys.platform.startswith("linux"):
+        with suppress(RuntimeError):
+            multiprocessing.set_start_method("spawn")


### PR DESCRIPTION
This pull request focuses on accelerating the M-step in various EM algorithm implementations by introducing parallel computations.
## M-Step Parallelization
### Parallelism Implementation using ProcessPoolExecutor: 

* moments_method.py: In the MomentsMStep class, the calculation of moments for each component (_calc_m_for_dist) is now executed in a separate process.

* ll_moments_method.py: Similarly..

* likelihood_method.py: In LikelihoodMStep, the optimization task to find the parameters of each component (_run_m_step_for_component).

### Test Environment Configuration

*   **Addition of `conftest.py`**: A `conftest.py` file has been added to improve the stability of tests that use multiprocessing.