### PR TITLE
refactor(distributions): Implement value-based equality

### DIFF
--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -2,7 +2,7 @@
 manipulation, and analysis of a finite mixture of continuous probability
 distributions."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -24,6 +24,11 @@ class MixtureModel:
 
     This class encapsulates a collection of distribution components and their
     corresponding weights.
+
+    Instances of this class can be compared for equality (``==``) and
+    inequality (``!=``). Two models are considered equal if they have the
+    same set of components and weights, regardless of the order in which
+    components were added.
 
     Parameters
     ----------
@@ -80,6 +85,8 @@ class MixtureModel:
         self._components = list(components)
         self._log_weights = np.log(weights + 1e-30)
         self._cached_weights: Optional[NDArray[float64]] = None
+
+        self._sorted_pairs_cache: Optional[list[tuple[ContinuousDistribution, float]]] = None
 
     def _validate_weights(self, n_components: int, weights: NDArray[float64]):
         """Validates the component weights.
@@ -342,3 +349,63 @@ class MixtureModel:
         """
 
         return iter(self.components)
+
+    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution", float]]:
+        """Internal helper to get component-weight pairs, sorted by component hash."""
+
+        if self._sorted_pairs_cache is None:
+            weights_to_use = self.weights
+            if for_hashing:
+                weights_to_use = np.round(weights_to_use, 8)
+
+            pairs = sorted(zip(self.components, weights_to_use), key=lambda p: hash(p[0]))
+            if not for_hashing:
+                self._sorted_pairs_cache = pairs
+            return pairs
+        return self._sorted_pairs_cache
+
+    def __eq__(self, other: object) -> bool:
+        """Checks if two mixture models are equal.
+
+        Two mixture models are considered equal if they have the same number of
+        components and the same set of (component, weight) pairs.
+
+        Parameters
+        ----------
+        other : object
+            The object to compare against.
+
+        Returns
+        -------
+        bool
+            True if the mixture models are equal, False otherwise.
+        """
+
+        if not isinstance(other, MixtureModel):
+            return NotImplemented
+
+        if self.n_components != other.n_components:
+            return False
+
+        self_pairs = self._get_sorted_pairs()
+        other_pairs = other._get_sorted_pairs()
+
+        for (self_comp, self_weight), (other_comp, other_weight) in zip(self_pairs, other_pairs):
+            if self_comp != other_comp or not np.isclose(self_weight, other_weight):
+                return False
+
+        return True
+
+    def __hash__(self) -> int:
+        """Computes a hash for the mixture model.
+
+        The hash is computed based on the set of (component, weight) pairs.
+
+        Returns
+        -------
+        int
+            The hash value of the mixture model.
+        """
+
+        sorted_pairs_for_hash = self._get_sorted_pairs(for_hashing=True)
+        return hash(tuple(sorted_pairs_for_hash))

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -2,7 +2,7 @@
 A module providing an abstract class for continuous distributions.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -19,6 +19,10 @@ class ContinuousDistribution(ABC):
     This class defines the basic mathematical functions of distributions
     that must be implemented by specific distributions. This class also
     provides some functions that are common to all distributions.
+
+    Instances of subclasses can be compared for equality (``==``) and
+    inequality (``!=``). Two instances are considered equal if they are of
+    the exact same type and have identical parameter values.
 
     Attributes
     ----------
@@ -279,3 +283,49 @@ class ContinuousDistribution(ABC):
         NDArray[np.float64]
             A NumPy array containing the generated samples.
         """
+
+    def __eq__(self, other: object):
+        """Checks if two distribution objects are equal.
+
+        Two distribution objects are considered equal if they are of the same
+        type and all their parameters have the same values.
+
+        Parameters
+        ----------
+        other : object
+            The object to compare against.
+
+        Returns
+        -------
+        bool
+            True if the distributions are equal, False otherwise.
+        """
+        if not isinstance(other, ContinuousDistribution):
+            return NotImplemented
+
+        if type(self) is not type(other):
+            return False
+
+        sorted_params = sorted(list(self.params))
+
+        return (
+            self.name == other.name
+            and self.params == other.params
+            and self.get_params_vector(sorted_params) == other.get_params_vector(sorted_params)
+        )
+
+    def __hash__(self) -> int:
+        """Computes the hash of the distribution.
+
+        The hash is computed based on the distribution's name, its parameter
+        names, and their corresponding values.
+
+        Returns
+        -------
+        int
+            The hash value of the distribution object.
+        """
+        sorted_params = sorted(list(self.params))
+        param_values = tuple(self.get_params_vector(sorted_params))
+
+        return hash(tuple([self.name, tuple(self.params), param_values]))

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -1,6 +1,6 @@
 """Tests for MixtureModel class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -190,6 +190,8 @@ class TestMixtureModelModification:
         assert isinstance(comp1, Exponential)
         assert isinstance(comp2, Exponential)
 
+        assert model.components == (components[0], components[2])
+
         expected_comp1_loc = 0
         expected_comp2_loc = 10
 
@@ -328,6 +330,7 @@ class TestMixtureModelDunderMethods:
         """Tests that __getitem__ retrieves the correct component by index."""
 
         assert mixture_model[index] is exp_components[expected_component_index]
+        assert mixture_model[index] == exp_components[expected_component_index]
 
     def test_getitem_out_of_bounds_raises_index_error(self, mixture_model: MixtureModel):
         """Tests that accessing an out-of-bounds index raises an IndexError."""
@@ -352,6 +355,7 @@ class TestMixtureModelDunderMethods:
         iterated_components = list(mixture_model)
         assert iterated_components == list(exp_components)
         assert all(comp_iter is comp_orig for comp_iter, comp_orig in zip(iterated_components, exp_components))
+        assert all(comp_iter == comp_orig for comp_iter, comp_orig in zip(iterated_components, exp_components))
 
     def test_iter_is_reusable(self, mixture_model: MixtureModel):
         """Tests that the model can be iterated over multiple times."""
@@ -362,3 +366,82 @@ class TestMixtureModelDunderMethods:
         assert len(first_pass) == mixture_model.n_components
         assert first_pass is not second_pass  # The lists are different objects
         assert first_pass == second_pass  # But their contents are identical
+
+
+class TestMixtureModelComparison:
+    """Tests the __eq__ and __hash__ methods for MixtureModel."""
+
+    def test_eq_identical_models(self):
+        """Tests that two identical models are equal."""
+
+        c = [Exponential(0, 1), Exponential(10, 2)]
+        m1 = MixtureModel(components=c, weights=[0.4, 0.6])
+        m2 = MixtureModel(components=c, weights=[0.4, 0.6])
+        assert m1 == m2
+
+    def test_eq_order_insensitivity(self):
+        """Tests that models with the same components/weights in a different order are equal."""
+
+        c1 = [Exponential(0, 1), Exponential(10, 2)]
+        w1 = [0.4, 0.6]
+        m1 = MixtureModel(components=c1, weights=w1)
+
+        c2 = [Exponential(10, 2), Exponential(0, 1)]
+        w2 = [0.6, 0.4]
+        m2 = MixtureModel(components=c2, weights=w2)
+
+        assert m1 == m2
+
+    def test_neq_different_weights(self):
+        """Tests that models with different weights are not equal."""
+
+        c = [Exponential(0, 1), Exponential(10, 2)]
+        m1 = MixtureModel(components=c, weights=[0.4, 0.6])
+        m2 = MixtureModel(components=c, weights=[0.41, 0.59])
+        assert m1 != m2
+
+    def test_neq_different_components(self):
+        """Tests that models with different components are not equal."""
+
+        c1 = [Exponential(0, 1), Exponential(10, 2)]
+        c2 = [Exponential(0, 1), Exponential(99, 2)]
+        m1 = MixtureModel(components=c1, weights=[0.4, 0.6])
+        m2 = MixtureModel(components=c2, weights=[0.4, 0.6])
+        assert m1 != m2
+
+    def test_neq_different_n_components(self):
+        """Tests that models with a different number of components are not equal."""
+
+        c1 = [Exponential(0, 1), Exponential(10, 2)]
+        c2 = [Exponential(0, 1)]
+        m1 = MixtureModel(components=c1, weights=[0.4, 0.6])
+        m2 = MixtureModel(components=c2, weights=[1.0])
+        assert m1 != m2
+
+    def test_hash_consistency(self):
+        """Tests that equal models produce the same hash."""
+
+        m1 = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2)],
+            weights=[0.4, 0.6],
+        )
+        m2 = MixtureModel(
+            components=[Exponential(10, 2), Exponential(0, 1)],
+            weights=[0.6, 0.4],
+        )
+        assert m1 == m2
+        assert hash(m1) == hash(m2)
+
+    def test_hash_difference(self):
+        """Tests that non-equal models are likely to have different hashes."""
+
+        m1 = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2)],
+            weights=[0.4, 0.6],
+        )
+        m2 = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2)],
+            weights=[0.5, 0.5],
+        )
+        assert m1 != m2
+        assert hash(m1) != hash(m2)

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -186,17 +186,7 @@ class TestMixtureModelModification:
 
         assert model.n_components == expected_n_components
 
-        comp1, comp2 = model.components
-        assert isinstance(comp1, Exponential)
-        assert isinstance(comp2, Exponential)
-
         assert model.components == (components[0], components[2])
-
-        expected_comp1_loc = 0
-        expected_comp2_loc = 10
-
-        assert comp1.loc == expected_comp1_loc
-        assert comp2.loc == expected_comp2_loc
 
         expected_weights = np.array([0.2, 0.3]) / (0.2 + 0.3)
         np.testing.assert_allclose(model.weights, expected_weights)
@@ -329,7 +319,6 @@ class TestMixtureModelDunderMethods:
     ):
         """Tests that __getitem__ retrieves the correct component by index."""
 
-        assert mixture_model[index] is exp_components[expected_component_index]
         assert mixture_model[index] == exp_components[expected_component_index]
 
     def test_getitem_out_of_bounds_raises_index_error(self, mixture_model: MixtureModel):
@@ -354,7 +343,6 @@ class TestMixtureModelDunderMethods:
 
         iterated_components = list(mixture_model)
         assert iterated_components == list(exp_components)
-        assert all(comp_iter is comp_orig for comp_iter, comp_orig in zip(iterated_components, exp_components))
         assert all(comp_iter == comp_orig for comp_iter, comp_orig in zip(iterated_components, exp_components))
 
     def test_iter_is_reusable(self, mixture_model: MixtureModel):

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -146,12 +146,6 @@ class TestBetaInitialization:
         assert repr_str == "Beta(alpha=1.0, beta=2.0, lower_bound=10.0, upper_bound=20.0)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Beta)
-        assert recreated_dist.alpha == dist.alpha
-        assert recreated_dist.beta == dist.beta
-        assert recreated_dist.lower_bound == dist.lower_bound
-        assert recreated_dist.upper_bound == dist.upper_bound
-
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -1,6 +1,6 @@
 """Tests for Beta class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -151,6 +151,8 @@ class TestBetaInitialization:
         assert recreated_dist.beta == dist.beta
         assert recreated_dist.lower_bound == dist.lower_bound
         assert recreated_dist.upper_bound == dist.upper_bound
+
+        assert dist == recreated_dist
 
 
 class TestBetaPDF:

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -70,10 +70,6 @@ class TestCauchyInitialization:
         assert repr_str == "Cauchy(loc=1.23, scale=4.56)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Cauchy)
-        assert recreated_dist.loc == dist.loc
-        assert recreated_dist.scale == dist.scale
-
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -1,6 +1,6 @@
 """Tests for cauchy class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -73,6 +73,8 @@ class TestCauchyInitialization:
         assert isinstance(recreated_dist, Cauchy)
         assert recreated_dist.loc == dist.loc
         assert recreated_dist.scale == dist.scale
+
+        assert dist == recreated_dist
 
 
 class TestCauchyPDF:

--- a/rework_tests/unit/distributions/test_continuous_distribution.py
+++ b/rework_tests/unit/distributions/test_continuous_distribution.py
@@ -1,6 +1,6 @@
 """Tests for ContinuousDistribution class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -21,12 +21,13 @@ class DummyDistribution(ContinuousDistribution):
     and test the non-abstract methods of the base class.
     """
 
-    def __init__(self, param1: float = 1.0, param2: float = 2.0):
+    def __init__(self, param1: float = 1.0, param2: float = 2.0, name: str = "Dummy"):
         """Initializes with two simple parameters."""
 
         super().__init__()
         self._param1 = param1
         self._param2 = param2
+        self._name = name
 
     @property
     def param1(self):
@@ -46,7 +47,7 @@ class DummyDistribution(ContinuousDistribution):
 
     @property
     def name(self) -> str:
-        return "Dummy"
+        return self._name
 
     @property
     def params(self) -> set[str]:
@@ -233,3 +234,59 @@ class TestContinuousDistribution:
 
         with pytest.raises(ValueError, match=error_msg_match):
             dummy_dist.set_params_from_vector(param_names, vector)
+
+
+class TestContinuousDistributionComparison:
+    """Tests the __eq__ and __hash__ methods of the ContinuousDistribution base class."""
+
+    def test_eq_same_type_and_params(self):
+        """Tests that two instances with the same type and parameters are equal."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0)
+        assert d1 == d2
+
+    def test_neq_different_params(self):
+        """Tests that two instances with different parameters are not equal."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=99.0, param2=2.0)
+        assert d1 != d2
+
+    def test_neq_different_type(self):
+        """Tests that two instances with different types are not equal."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0, name="Dummy2")
+        assert d1 != d2
+
+    def test_neq_other_object(self):
+        """Tests that a distribution instance is not equal to an object of a different class."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        other = "not_a_distribution"
+        assert d1 != other
+
+    def test_hash_consistency(self):
+        """Tests that two equal distribution instances have the same hash."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0)
+        assert d1 == d2
+        assert hash(d1) == hash(d2)
+
+    def test_hash_inequality(self):
+        """Tests that two non-equal distribution instances have different hashes."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=99.0, param2=2.0)
+        assert d1 != d2
+        assert hash(d1) != hash(d2)
+
+    def test_hash_inequality_name(self):
+        """Tests that two non-equal type distribution instances have different hashes."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0, name="Dummy2")
+        assert d1 != d2
+        assert hash(d1) != hash(d2)

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -70,10 +70,6 @@ class TestExponentialInitialization:
         assert repr_str == "Exponential(loc=1.23, rate=4.56)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Exponential)
-        assert recreated_dist.loc == dist.loc
-        assert recreated_dist.rate == dist.rate
-
         assert recreated_dist == dist
 
 

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -1,6 +1,6 @@
 """Tests for Exponential class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -73,6 +73,8 @@ class TestExponentialInitialization:
         assert isinstance(recreated_dist, Exponential)
         assert recreated_dist.loc == dist.loc
         assert recreated_dist.rate == dist.rate
+
+        assert recreated_dist == dist
 
 
 class TestExponentialPDF:

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -59,11 +59,8 @@ class TestNormalInitialization:
         dist = Normal(loc=1.23, scale=4.56)
         repr_str = repr(dist)
         assert repr_str == "Normal(loc=1.23, scale=4.56)"
-        recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Normal)
-        assert recreated_dist.loc == dist.loc
-        assert recreated_dist.scale == dist.scale
 
+        recreated_dist = eval(repr_str)
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -1,6 +1,6 @@
 """Tests for Normal class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -63,6 +63,8 @@ class TestNormalInitialization:
         assert isinstance(recreated_dist, Normal)
         assert recreated_dist.loc == dist.loc
         assert recreated_dist.scale == dist.scale
+
+        assert dist == recreated_dist
 
 
 class TestNormalPDF:

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -105,10 +105,6 @@ class TestParetoInitialization:
         assert repr_str == "Pareto(shape=1.23, scale=4.56)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Pareto)
-        assert recreated_dist.shape == dist.shape
-        assert recreated_dist.scale == dist.scale
-
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -1,6 +1,6 @@
 """Tests for Pareto class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -108,6 +108,8 @@ class TestParetoInitialization:
         assert isinstance(recreated_dist, Pareto)
         assert recreated_dist.shape == dist.shape
         assert recreated_dist.scale == dist.scale
+
+        assert dist == recreated_dist
 
 
 class TestParetoPDF:

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -72,10 +72,6 @@ class TestUniformInitialization:
         assert repr_str == "Uniform(left_border=1.23, right_border=4.56)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Uniform)
-        assert recreated_dist.left_border == dist.left_border
-        assert recreated_dist.right_border == dist.right_border
-
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -1,6 +1,6 @@
 """Tests for Uniform class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -75,6 +75,8 @@ class TestUniformInitialization:
         assert isinstance(recreated_dist, Uniform)
         assert recreated_dist.left_border == dist.left_border
         assert recreated_dist.right_border == dist.right_border
+
+        assert dist == recreated_dist
 
 
 class TestUniformPDF:

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -72,11 +72,6 @@ class TestWeibullInitialization:
         assert repr_str == "Weibull(shape=1.23, loc=4.56, scale=7.89)"
 
         recreated_dist = eval(repr_str)
-        assert isinstance(recreated_dist, Weibull)
-        assert recreated_dist.shape == dist.shape
-        assert recreated_dist.loc == dist.loc
-        assert recreated_dist.scale == dist.scale
-
         assert dist == recreated_dist
 
 

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -1,6 +1,6 @@
 """Tests for Weibull class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -76,6 +76,8 @@ class TestWeibullInitialization:
         assert recreated_dist.shape == dist.shape
         assert recreated_dist.loc == dist.loc
         assert recreated_dist.scale == dist.scale
+
+        assert dist == recreated_dist
 
 
 class TestWeibullPDF:


### PR DESCRIPTION
This pull request introduces value-based equality for the ContinuousDistribution and MixtureModel classes by implementing the __eq__ and __hash__ methods.

## Testing


* Updated the existing test suite to use direct == assertions for distribution and mixture objects.

* Added new test classes (TestContinuousDistributionComparison and TestMixtureModelComparison) to specifically validate the new equality and hashing logic.