### PR TITLE
fix(pipeline): replace deepcopy with __copy__

### DIFF
--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -8,6 +8,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from collections.abc import Iterator, Sequence
+from copy import copy
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
@@ -349,6 +350,19 @@ class MixtureModel:
         """
 
         return iter(self.components)
+
+    def __copy__(self) -> "MixtureModel":
+        """Creates a copy of the mixture model instance.
+
+        Returns
+        -------
+        MixtureModel
+            A new instance of the distribution, identical to the original.
+        """
+
+        copied_components = [copy(component) for component in self._components]
+        new_mixture = MixtureModel(components=copied_components, weights=self.weights.copy())
+        return new_mixture
 
     def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution", float]]:
         """Internal helper to get component-weight pairs, sorted by component hash."""

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -284,6 +284,21 @@ class ContinuousDistribution(ABC):
             A NumPy array containing the generated samples.
         """
 
+    def __copy__(self) -> "ContinuousDistribution":
+        """Creates a copy of the distribution instance.
+
+        Returns
+        -------
+        ContinuousDistribution
+            A new instance of the distribution, identical to the original.
+        """
+        params_dict = {p: getattr(self, p) for p in self.params}
+
+        new_instance = self.__class__(**params_dict)
+        new_instance._fixed_params = self._fixed_params.copy()
+
+        return new_instance
+
     def __eq__(self, other: object):
         """Checks if two distribution objects are equal.
 

--- a/rework_pysatl_mpest/estimators/iterative/pipeline.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline.py
@@ -13,7 +13,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import warnings
 from collections.abc import Sequence
-from copy import deepcopy
+from copy import copy
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -164,14 +164,13 @@ class Pipeline(BaseEstimator):
         """
 
         X = np.asarray(X, dtype=np.float64)
-        copied_mixture = deepcopy(mixture)  # Copy to avoid modifying the original object
+        copied_mixture = copy(mixture)  # Copy to avoid modifying the original object
 
         state = PipelineState(X, None, None, copied_mixture, None)
 
         while True:
             # Updating the state before starting an iteration
-            # TODO: remove heavy deepcopy
-            state.prev_mixture = deepcopy(state.curr_mixture)
+            state.prev_mixture = copy(state.curr_mixture)
 
             # Performing steps
             for step in self.steps:

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from collections.abc import Sequence
+from copy import copy
 from typing import Any
 
 import numpy as np
@@ -354,6 +355,42 @@ class TestMixtureModelDunderMethods:
         assert len(first_pass) == mixture_model.n_components
         assert first_pass is not second_pass  # The lists are different objects
         assert first_pass == second_pass  # But their contents are identical
+
+
+class TestMixtureModelCopying:
+    """Tests the __copy__ method for MixtureModel."""
+
+    def test_copy_creates_new_equal_instance(self, mixture_model: MixtureModel):
+        """Tests that copy.copy() creates a new instance that is equal to the original."""
+
+        copied_model = copy(mixture_model)
+
+        assert copied_model is not mixture_model
+        assert copied_model == mixture_model
+
+    def test_copy_is_independent_weights(self, mixture_model: MixtureModel):
+        """Tests that modifying the copied model's weights does not affect the original."""
+
+        copied_model = copy(mixture_model)
+        copied_model.log_weights = np.log([0.1, 0.9])
+
+        np.testing.assert_allclose(mixture_model.weights, [0.5, 0.5])
+        np.testing.assert_allclose(copied_model.weights, [0.1, 0.9])
+
+    def test_copy_is_independent_components(self, mixture_model: MixtureModel):
+        """Tests that the components in the copied model are also independent copies."""
+
+        copied_model = copy(mixture_model)
+
+        # Check that component objects are new instances
+        assert copied_model.components[0] is not mixture_model.components[0]
+        assert copied_model.components[1] is not mixture_model.components[1]
+
+        # Modify a parameter in a component of the copied model
+        copied_model.components[0].rate = 999.0
+
+        # Verify the original model's component is unchanged
+        assert mixture_model.components[0].rate != copied_model.components[0].rate
 
 
 class TestMixtureModelComparison:

--- a/rework_tests/unit/distributions/test_continuous_distribution.py
+++ b/rework_tests/unit/distributions/test_continuous_distribution.py
@@ -5,6 +5,8 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
+from copy import copy
+
 import numpy as np
 import pytest
 from numpy.typing import ArrayLike, NDArray
@@ -234,6 +236,47 @@ class TestContinuousDistribution:
 
         with pytest.raises(ValueError, match=error_msg_match):
             dummy_dist.set_params_from_vector(param_names, vector)
+
+
+class TestContinuousDistributionCopying:
+    """Tests the __copy__ method implementation for ContinuousDistribution."""
+
+    def test_copy_creates_new_equal_instance(self, dummy_dist: DummyDistribution):
+        """Tests that copy.copy() creates a new instance that is equal to the original."""
+
+        copied_dist = copy(dummy_dist)
+
+        assert copied_dist is not dummy_dist
+        assert copied_dist == dummy_dist
+
+    def test_copy_is_independent(self, dummy_dist: DummyDistribution):
+        """Tests that modifying the copied instance does not affect the original."""
+
+        MODIFIED_PARAM_VALUE = 999.0
+        copied_dist = copy(dummy_dist)
+
+        original_param1_value = dummy_dist.param1
+
+        # Modify a parameter in the copied distribution
+        copied_dist.param1 = MODIFIED_PARAM_VALUE
+
+        # Assert that the original object's parameter remains unchanged
+        assert dummy_dist.param1 == original_param1_value
+        assert copied_dist.param1 == MODIFIED_PARAM_VALUE
+
+    def test_copy_replicates_fixed_params_independently(self, dummy_dist: DummyDistribution):
+        """Tests that the set of fixed parameters is also copied independently."""
+
+        dummy_dist.fix_param("param1")
+        copied_dist = copy(dummy_dist)
+
+        assert copied_dist._fixed_params == {"param1"}
+
+        # Modify the copy's fixed params
+        copied_dist.unfix_param("param1")
+
+        # Ensure the original is unchanged
+        assert dummy_dist._fixed_params != copied_dist._fixed_params
 
 
 class TestContinuousDistributionComparison:

--- a/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
+++ b/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
@@ -29,7 +29,7 @@ class DummyDistribution(ContinuousDistribution):
 
     @property
     def params(self) -> set[str]:
-        return set()
+        return {"name"}
 
     def pdf(self, X: ArrayLike) -> NDArray[float64]:
         pass


### PR DESCRIPTION
This pull request refactors the object copying mechanism for MixtureModel and ContinuousDistribution.

## Implementation:
* Replaced the deepcopy() operation in the Pipeline class with copy.copy(), which now utilizes the custom __copy__ implementation on the models.
* Introduced the __copy__ magic method to the ContinuousDistribution base class to provide a standard copying mechanism for all distribution subclasses.
* Added a __copy__ implementation to MixtureModel to handle the copying of its internal components and weights.

## Testing:
* Added new test suites (TestContinuousDistributionCopying and TestMixtureModelCopying) to verify the behavior of the __copy__ implementation and ensure copied objects are independent.