### PR TITLE
fix(mixture): invalidate cache on mutation

### DIFF
--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -168,6 +168,7 @@ class MixtureModel:
             raise ValueError("The length of the new logit vector does not match the number of components.")
         self._log_weights = np.asarray(new_log_weights, dtype=float)
         self._cached_weights = None
+        self._sorted_pairs_cache = None
 
     def add_component(self, component: "ContinuousDistribution", weight: float):
         """Adds a new component to the mix, preserving the proportions of the existing component weights.
@@ -197,6 +198,7 @@ class MixtureModel:
 
         self._components.append(component)
         self._cached_weights = None
+        self._sorted_pairs_cache = None
 
     def remove_component(self, component_idx: int):
         """Removes a component from the mixture by its index.
@@ -227,6 +229,7 @@ class MixtureModel:
         self._log_weights = np.delete(self._log_weights, component_idx)
         self._log_weights -= logsumexp(self._log_weights)
         self._cached_weights = None
+        self._sorted_pairs_cache = None
 
     def pdf(self, X: ArrayLike) -> NDArray[float64]:
         """Probability Density Function of the mixture.
@@ -367,7 +370,7 @@ class MixtureModel:
     def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution", float]]:
         """Internal helper to get component-weight pairs, sorted by component hash."""
 
-        if self._sorted_pairs_cache is None:
+        if self._sorted_pairs_cache is None or for_hashing:
             weights_to_use = self.weights
             if for_hashing:
                 weights_to_use = np.round(weights_to_use, 8)

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -470,3 +470,46 @@ class TestMixtureModelComparison:
         )
         assert m1 != m2
         assert hash(m1) != hash(m2)
+
+    def test_hash_changes_after_modifying_weights(self):
+        """Tests that the hash of the model updates after its weights are changed."""
+        model = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2)],
+            weights=[0.4, 0.6],
+        )
+        old_hash = hash(model)
+
+        model.log_weights = np.log([0.5, 0.5])
+        new_hash = hash(model)
+
+        assert old_hash != new_hash
+
+    def test_hash_changes_after_adding_component(self):
+        """Tests that the hash of the model updates after a new component is added."""
+        model = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2)],
+            weights=[0.4, 0.6],
+        )
+        old_hash = hash(model)
+
+        model.add_component(Exponential(99, 3), weight=0.1)
+        new_hash = hash(model)
+        expected_n_components = 3
+
+        assert model.n_components == expected_n_components
+        assert old_hash != new_hash
+
+    def test_hash_changes_after_removing_component(self):
+        """Tests that the hash of the model updates after a component is removed."""
+        model = MixtureModel(
+            components=[Exponential(0, 1), Exponential(10, 2), Exponential(99, 3)],
+            weights=[0.4, 0.5, 0.1],
+        )
+        old_hash = hash(model)
+
+        model.remove_component(1)
+        new_hash = hash(model)
+        expected_n_components = 2
+
+        assert model.n_components == expected_n_components
+        assert old_hash != new_hash


### PR DESCRIPTION
This pull request resolves a bug where the hash of a MixtureModel instance would become stale after the model was mutated.
## Implementation:

* Modified the mutator methods (add_component, remove_component and the log_weights) in the MixtureModel class to reset this cache upon execution.

## Testing:

* Added a new set of tests to the TestMixtureModelComparison suite (test_hash_changes_...).