### PR TITLE
fix(docs): remove logging info from API and fix deploy

### DIFF
--- a/docs/source/api/estimators/iterative/index.rst
+++ b/docs/source/api/estimators/iterative/index.rst
@@ -58,16 +58,5 @@ Pruners (`Pruner`):
 
    ~PriorThresholdPruner
 
-Logging Implementations
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: class.rst
-
-   ~IterationsHistory
-   ~IterationRecord
-
 Usage Example
 -------------

--- a/docs/source/api/initializers/index.rst
+++ b/docs/source/api/initializers/index.rst
@@ -4,7 +4,7 @@
 mpest.initializers
 ##################
 
-.. automodule:: rework_pysatl_mpest.Initializers
+.. automodule:: rework_pysatl_mpest.initializers
    :no-members:
 
 Initialization Strategies
@@ -30,76 +30,10 @@ Concrete Implementations
 
    ClusterizeInitializer
 
-Cluster Matching Strategies
----------------------------
-
-Functions for matching clusters to distribution models based on statistical criteria.
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: function.rst
-
-   match_clusters_for_models_akaike
-   match_clusters_for_models_log_likelihood
-
-Parameter Estimation Strategies
--------------------------------
-
-Q-function based parameter estimation with multiple implementations.
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: function.rst
-
-   q_function_strategy
-
-Q-function Strategy Implementations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: function.rst
-
-   q_function_strategy_exponential
-
-Utility Functions
-~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: function.rst
-
-   get_available_q_function_implementations
-
-Detailed Documentation
-~~~~~~~~~~~~~~~~~~~~~~
-
-Main Q-function Strategy
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: rework_pysatl_mpest.Initializers.q_function_strategy
-
-Exponential Distribution Specialization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: rework_pysatl_mpest.Initializers.q_function_strategy_exponential
-
-Implementation Registry
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: rework_pysatl_mpest.Initializers.get_available_q_function_implementations
-
 Strategy Enumerations
 ---------------------
 
 Enumeration types that define available strategies for initialization.
-
-Cluster Matching Strategies (`ClusterMatchStrategy`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
    :toctree: generated
@@ -107,13 +41,4 @@ Cluster Matching Strategies (`ClusterMatchStrategy`)
    :template: class.rst
 
    ClusterMatchStrategy
-
-Parameter Estimation Strategies (`EstimationStrategy`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: class.rst
-
    EstimationStrategy


### PR DESCRIPTION
This pull request primarily cleans up and simplifies the documentation for the `initializers` and `pruners` modules. It removes redundant and overly detailed autosummary/function listings, unifies the module naming to match the actual package structure, and focuses the documentation on the main classes and enumerations.

Documentation cleanup and simplification:

* Removed detailed autosummary listings and function documentation for cluster matching, parameter estimation, Q-function strategies, and utility functions from `docs/source/api/initializers/index.rst`, streamlining the documentation to focus on main strategy enumerations and classes.
* Removed logging implementation documentation (`IterationsHistory`, `IterationRecord`) from the pruner documentation in `docs/source/api/estimators/iterative/index.rst`.

Documentation consistency:

* Updated the automodule directive in `docs/source/api/initializers/index.rst` to use the correct lowercase module name (`rework_pysatl_mpest.initializers` instead of `rework_pysatl_mpest.Initializers`).