### PR TITLE
fix: change target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "refactor/rework-arch"
     groups:
       github-actions:
         patterns:
@@ -12,6 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "refactor/rework-arch"
     commit-message:
       prefix: "deps: "
     groups:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to specify a custom target branch for dependency updates, ensuring that automated dependency changes are directed to the `refactor/rework-arch` branch instead of the default branch.

Configuration changes:

* Added the `target-branch: "refactor/rework-arch"` setting to both the monthly and weekly update schedules in `.github/dependabot.yml`, so dependency updates are created against the `refactor/rework-arch` branch. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R16)