### PR TITLE
refactor(distributions): standardize output types

### DIFF
--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -274,8 +274,7 @@ class MixtureModel(Generic[DType]):
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        component_pdfs = np.array([comp.pdf(X) for comp in self.components])
-        return np.dot(self.weights, component_pdfs)
+        return np.exp(self.lpdf(X))
 
     def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Logarithms of the Probability Density Function.
@@ -292,13 +291,17 @@ class MixtureModel(Generic[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         component_lpdfs = np.array([comp.lpdf(X) for comp in self.components])
         broadcast_shape = (self.n_components,) + (1,) * X.ndim
         log_weights = self.log_weights.reshape(broadcast_shape)
         log_terms = log_weights + component_lpdfs
 
-        return logsumexp(log_terms, axis=0)
+        result = logsumexp(log_terms, axis=0)
+        if is_scalar:
+            return result[()]
+        return result
 
     def loglikelihood(self, X: ArrayLike) -> DType:
         """Log-likelihood of the complete data :attr:`X`.
@@ -320,7 +323,7 @@ class MixtureModel(Generic[DType]):
         X = np.asarray(X, dtype=self.dtype)
         return np.sum(self.lpdf(X))
 
-    def generate(self, size: int) -> NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
         """Generates random samples from the mixture model.
 
         First, a component is chosen based on the mixture weights. Then, a
@@ -329,28 +332,43 @@ class MixtureModel(Generic[DType]):
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             A NumPy array containing the generated samples. Returns an
             empty array if :attr:`size` is not positive.
         """
 
-        if size == 0:
-            return np.array([], dtype=self.dtype)
+        if size is None:
+            n_samples = 1
+        elif isinstance(size, int):
+            n_samples = size
+            if n_samples == 0:
+                return np.array([], dtype=self.dtype)
+        else:
+            n_samples = int(np.prod(size))
+            if n_samples == 0:
+                return np.empty(size, dtype=self.dtype)
 
-        component_choices = np.random.choice(self.n_components, size=size, p=self.weights)
-
+        component_choices = np.random.choice(self.n_components, size=n_samples, p=self.weights)
         counts = np.bincount(component_choices, minlength=self.n_components)
 
         samples_list = [self.components[i].generate(size=count) for i, count in enumerate(counts) if count > 0]
 
         samples = np.concatenate(samples_list)
         np.random.shuffle(samples)
-        return samples
+
+        if size is None:
+            return samples[0]
+
+        target_shape = (size,) if isinstance(size, int) else size
+        return samples.reshape(target_shape)
 
     def astype(self, new_dtype: type[DType]) -> "MixtureModel[DType]":
         """Creates a copy of the MixtureModel with a new data type.

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -255,7 +255,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def pdf(self, X: ArrayLike) -> NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Probability Density Function of the mixture.
 
         The PDF is computed as the weighted sum of the PDFs of its
@@ -268,15 +268,16 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
         component_pdfs = np.array([comp.pdf(X) for comp in self.components])
-        return np.asarray(np.dot(self.weights, component_pdfs))
+        return np.dot(self.weights, component_pdfs)
 
-    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Logarithms of the Probability Density Function.
 
         Parameters
@@ -286,15 +287,18 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
-        X = np.atleast_1d(X).astype(self.dtype)
+        X = np.asarray(X, dtype=self.dtype)
         component_lpdfs = np.array([comp.lpdf(X) for comp in self.components])
-        log_weights = self.log_weights
-        log_terms = log_weights[:, np.newaxis] + component_lpdfs
-        return logsumexp(log_terms, axis=0)  # type: ignore
+        broadcast_shape = (self.n_components,) + (1,) * X.ndim
+        log_weights = self.log_weights.reshape(broadcast_shape)
+        log_terms = log_weights + component_lpdfs
+
+        return logsumexp(log_terms, axis=0)
 
     def loglikelihood(self, X: ArrayLike) -> DType:
         """Log-likelihood of the complete data :attr:`X`.

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -191,6 +191,7 @@ class Beta(ContinuousDistribution):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
@@ -199,6 +200,8 @@ class Beta(ContinuousDistribution):
         log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta).astype(dtype)
         result = log_pdf_standard - np.log(self.right_border - self.left_border)
 
+        if is_scalar:
+            return result[()]
         return result
 
     def _dlog_alpha(self, X):
@@ -420,26 +423,30 @@ class Beta(ContinuousDistribution):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(
-            beta_dist.rvs(
-                self.alpha, self.beta, loc=self.left_border, scale=self.right_border - self.left_border, size=size
-            ),
-            dtype=self.dtype,
+        samples = beta_dist.rvs(
+            self.alpha, self.beta, loc=self.left_border, scale=self.right_border - self.left_border, size=size
         )
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -109,10 +109,12 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
 
         """
+
         X = np.asarray(X, dtype=self.dtype)
         return np.exp(self.lpdf(X))
 
@@ -137,13 +139,16 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1),
             (
                 self.left_border
@@ -151,6 +156,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(np.nan),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -177,8 +186,9 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -189,7 +199,7 @@ class Beta(ContinuousDistribution):
         log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta).astype(dtype)
         result = log_pdf_standard - np.log(self.right_border - self.left_border)
 
-        return np.atleast_1d(result)
+        return result
 
     def _dlog_alpha(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`alpha` parameter.
@@ -214,21 +224,27 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`alpha` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             np.log(X - self.left_border)
             - np.log(self.right_border - self.left_border)
             - (dtype(digamma(self.alpha)) - dtype(digamma(self.alpha + self.beta))),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_beta(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`beta` parameter.
@@ -253,21 +269,27 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`beta` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             np.log(self.right_border - X)
             - np.log(self.right_border - self.left_border)
             - (dtype(digamma(self.beta)) - dtype(digamma(self.alpha + self.beta))),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_left_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`left_border` parameter.
@@ -290,15 +312,17 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             (
                 ((self.alpha + self.beta - dtype(1)) / (self.right_border - self.left_border))
@@ -306,6 +330,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_right_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`right_border` parameter.
@@ -328,14 +356,17 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             (
                 ((self.beta - dtype(1)) / (self.right_border - X))
@@ -343,6 +374,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -361,7 +396,10 @@ class Beta(ContinuousDistribution):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -378,6 +416,8 @@ class Beta(ContinuousDistribution):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -82,14 +82,13 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        return dtype(1.0) / (dtype(np.pi) * self.scale * (dtype(1.0) + ((X - self.loc) / self.scale) ** 2))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -110,13 +109,16 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1),
             np.where(
                 (P == 0) | (P == 1),
@@ -125,6 +127,9 @@ class Cauchy(ContinuousDistribution[DType]):
             ),
             dtype(np.nan),
         )
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -145,8 +150,9 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -179,14 +185,20 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (dtype(2) * X - dtype(2) * self.loc) / (self.scale**2 + X**2 - dtype(2) * self.loc * X + self.loc**2)
+        result = (dtype(2) * X - dtype(2) * self.loc) / (self.scale**2 + X**2 - dtype(2) * self.loc * X + self.loc**2)
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -208,15 +220,22 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (-(self.scale**2) + X**2 - dtype(2) * self.loc * X + self.loc**2) / (
+        result = (-(self.scale**2) + X**2 - dtype(2) * self.loc * X + self.loc**2) / (
             self.scale**3 + self.scale * (X**2) - dtype(2) * self.loc * self.scale * X + self.scale * self.loc**2
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -235,7 +254,10 @@ class Cauchy(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -250,6 +272,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -155,15 +155,20 @@ class Cauchy(ContinuousDistribution[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (
+        result = (
             np.log(dtype(1.0))
             - np.log(dtype(np.pi))
             - np.log(self.scale)
             - np.log(dtype(1.0) + ((X - self.loc) / self.scale) ** 2)
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -276,21 +281,28 @@ class Cauchy(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(cauchy.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = cauchy.rvs(loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -202,6 +202,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
     @property
     def dtype(self) -> type[DType]:
         """type[DType]: The numpy data type of the distribution's outputs."""
+
         return self._dtype
 
     @property
@@ -221,7 +222,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         return self.params - self._fixed_params
 
     @abstractmethod
-    def pdf(self, X: ArrayLike) -> NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Probability Density Function.
 
         Parameters
@@ -231,8 +232,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -249,8 +251,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -268,8 +271,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -325,6 +329,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
+
         if self._dtype is new_dtype:
             return self
 
@@ -343,6 +348,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         ContinuousDistribution[DType]
             A new instance of the distribution, identical to the original.
         """
+
         params_dict = {p: getattr(self, p) for p in self.params}
 
         new_instance = self.__class__(**params_dict, dtype=self.dtype)
@@ -366,6 +372,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         bool
             True if the distributions are equal, False otherwise.
         """
+
         if not isinstance(other, ContinuousDistribution):
             return NotImplemented
 
@@ -392,6 +399,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         int
             The hash value of the distribution object.
         """
+
         sorted_params = sorted(list(self.params))
         param_values = tuple(self.get_params_vector(sorted_params))
 

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -297,18 +297,21 @@ class ContinuousDistribution(ABC, Generic[DType]):
         """
 
     @abstractmethod
-    def generate(self, size: int) -> NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
     def astype(self, new_dtype: type[DType]) -> "ContinuousDistribution[DType]":

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -87,9 +87,7 @@ class Exponential(ContinuousDistribution[DType]):
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        return np.where(self.loc <= X, self.rate * np.exp(-self.rate * (X - self.loc)), dtype(0.0))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -107,14 +105,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.loc - np.log(dtype(1) - P) / self.rate, dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), self.loc - np.log(dtype(1) - P) / self.rate, dtype(np.nan))
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -132,14 +135,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), dtype(-np.inf))
+        result = np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), dtype(-np.inf))
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -159,14 +167,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.loc <= X, self.rate, dtype(0.0))
+        result = np.where(self.loc <= X, self.rate, dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_rate(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`rate` parameter.
@@ -186,13 +199,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
-        return np.where(self.loc <= X, dtype(1.0) / self.rate - (X - self.loc), dtype(0.0))
+
+        result = np.where(self.loc <= X, dtype(1.0) / self.rate - (X - self.loc), dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -211,8 +230,10 @@ class Exponential(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -227,6 +248,8 @@ class Exponential(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -252,21 +252,28 @@ class Exponential(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(expon.rvs(loc=self.loc, scale=1 / self.rate, size=size), dtype=self.dtype)
+        samples = expon.rvs(loc=self.loc, scale=1 / self.rate, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -83,15 +83,13 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-        return np.exp(-(z**2) / dtype(2.0)) / (self.scale * np.sqrt(dtype(2.0) * dtype(np.pi)))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -107,13 +105,17 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         result = norm.ppf(P, loc=self.loc, scale=self.scale)
 
+        if is_scalar:
+            return self.dtype(result)
         return np.asarray(result, dtype=self.dtype)
 
     def lpdf(self, X):
@@ -133,8 +135,9 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -173,8 +176,10 @@ class Normal(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -188,6 +193,9 @@ class Normal(ContinuousDistribution[DType]):
             return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
+
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -140,26 +140,41 @@ class Normal(ContinuousDistribution[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
-        return -np.log(self.scale) - dtype(0.5) * np.log(dtype(2.0) * dtype(np.pi)) - dtype(0.5) * z**2
+        result = -np.log(self.scale) - dtype(0.5) * np.log(dtype(2.0) * dtype(np.pi)) - dtype(0.5) * z**2
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
-        return (X - self.loc) / (self.scale**2)
+        result = (X - self.loc) / (self.scale**2)
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z_sq = ((X - self.loc) / self.scale) ** 2
-        return (z_sq - dtype(1.0)) / self.scale
+        result = (z_sq - dtype(1.0)) / self.scale
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -198,23 +213,30 @@ class Normal(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         This implementation relies on `scipy.stats.norm.rvs`.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(norm.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = norm.rvs(loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -77,13 +77,21 @@ class Pareto(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the :attr:`shape` parameter and :math:`\\beta` is the
         :attr:`scale` parameter. The function is zero for :math:`x < \\beta`.
-        """
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
 
-        return np.where(
-            self.scale <= X, (self.shape * (self.scale**self.shape)) / X ** (self.shape + dtype(1)), dtype(0.0)
-        )
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points at which to evaluate the PDF.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
+        """
+
+        X = np.asarray(X, dtype=self.dtype)
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -101,14 +109,20 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.scale * (dtype(1) - P) ** (dtype(-1.0) / self.shape), dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), self.scale * (dtype(1) - P) ** (dtype(-1.0) / self.shape), dtype(np.nan))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -129,18 +143,24 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             self.scale <= X,
             np.log(self.shape) + self.shape * np.log(self.scale) - (dtype(1) + self.shape) * np.log(X),
             dtype(-np.inf),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_shape(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`shape` parameter.
@@ -162,14 +182,20 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`shape` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.scale <= X, dtype(1.0) / self.shape + np.log(self.scale) - np.log(X), dtype(0.0))
+        result = np.where(self.scale <= X, dtype(1.0) / self.shape + np.log(self.scale) - np.log(X), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -190,14 +216,19 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.scale <= X, self.shape / self.scale, dtype(0.0))
+        result = np.where(self.scale <= X, self.shape / self.scale, dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -216,8 +247,10 @@ class Pareto(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -232,6 +265,8 @@ class Pareto(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -269,21 +269,28 @@ class Pareto(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(pareto.rvs(scale=self.scale, b=self.shape, size=size), dtype=self.dtype)
+        samples = pareto.rvs(scale=self.scale, b=self.shape, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -97,17 +97,13 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
 
-        return np.where(
-            (self.left_border <= X) & (self.right_border >= X),
-            dtype(1.0) / (self.right_border - self.left_border),
-            dtype(0.0),
-        )
+        X = np.asarray(X, dtype=self.dtype)
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -128,15 +124,22 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1), self.left_border + P * (self.right_border - self.left_border), dtype(np.nan)
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -158,15 +161,22 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
         valid_dist = self.right_border > self.left_border
-        return np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), dtype(-np.inf))
+        result = np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), dtype(-np.inf))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_left_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`left_border` parameter.
@@ -177,13 +187,29 @@ class Uniform(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the left_border parameter and :math:`\\beta` is the
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
+
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, dtype(1.0) / (self.right_border - self.left_border), dtype(0.0))
+        result = np.where(in_range, dtype(1.0) / (self.right_border - self.left_border), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_right_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`right_border` parameter.
@@ -194,13 +220,29 @@ class Uniform(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the left_border parameter and :math:`\\beta` is the
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
+
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, dtype(-1.0) / (self.right_border - self.left_border), dtype(0.0))
+        result = np.where(in_range, dtype(-1.0) / (self.right_border - self.left_border), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -219,8 +261,10 @@ class Uniform(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -235,6 +279,8 @@ class Uniform(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.asarray(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -283,23 +283,28 @@ class Uniform(ContinuousDistribution[DType]):
             return np.asarray(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(
-            uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size), dtype=self.dtype
-        )
+        samples = uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -91,21 +91,13 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-
-        # PDF is 0 for x < loc, and handle cases where z=0 and shape<1
-        # which would lead to division by zero.
-        with np.errstate(divide="ignore", invalid="ignore"):
-            pdf_vals = (self.shape / self.scale) * np.power(z, self.shape - dtype(1)) * np.exp(-np.power(z, self.shape))
-
-        return np.where(self.loc <= X, np.nan_to_num(pdf_vals, nan=dtype(0.0), posinf=dtype(np.inf)), dtype(0.0))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -124,15 +116,21 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
         ppf_vals = self.loc + self.scale * np.power(-np.log(dtype(1) - P), dtype(1.0) / self.shape)
-        return np.where((P >= 0) & (P <= 1), ppf_vals, dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), ppf_vals, dtype(np.nan))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -152,34 +150,55 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-        with np.errstate(divide="ignore"):
-            lpdf_vals = (
-                np.log(self.shape) - np.log(self.scale) + (self.shape - dtype(1)) * np.log(z) - np.power(z, self.shape)
-            )
-        return np.where(self.loc < X, lpdf_vals, dtype(-np.inf))
-
-    def _dlog_shape(self, X):
-        """Partial derivative of the lpdf w.r.t. the shape parameter."""
-
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
         with np.errstate(divide="ignore", invalid="ignore"):
-            grad = dtype(1.0) / self.shape + np.log(z) - np.power(z, self.shape) * np.log(z)
-        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+            # Handle potential NaN from 0 * -inf when shape=1 and z=0
+            # This term's limit is 0, so we replace NaN with 0.
+            lpdf_vals = (
+                np.log(self.shape)
+                - np.log(self.scale)
+                + np.nan_to_num((self.shape - dtype(1)) * np.log(z), nan=dtype(0.0))
+                - np.power(z, self.shape)
+            )
+        result = np.where(self.loc < X, lpdf_vals, dtype(-np.inf))
+
+        if is_scalar:
+            return result[()]
+        return result
+
+    def _dlog_shape(self, X):
+        """Partial derivative of the lpdf w.r.t. the shape parameter."""
+
+        is_scalar = np.isscalar(X)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        z = (X - self.loc) / self.scale
+        with np.errstate(divide="ignore", invalid="ignore"):
+            # Handle z^k * ln(z), which -> 0 as z -> 0.
+            # This prevents NaN from 0 * -inf.
+            grad = (
+                dtype(1.0) / self.shape + np.log(z) - np.nan_to_num(np.power(z, self.shape) * np.log(z), nan=dtype(0.0))
+            )
+        result = np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
@@ -188,17 +207,26 @@ class Weibull(ContinuousDistribution[DType]):
             grad = -(self.shape - dtype(1)) / (X - self.loc) + (self.shape / self.scale) * np.power(
                 z, self.shape - dtype(1)
             )
-        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+        result = np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
         grad = -self.shape / self.scale + (self.shape / self.scale) * np.power(z, self.shape)
-        return np.where(self.loc < X, grad, dtype(0.0))
+        result = np.where(self.loc < X, grad, dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -215,7 +243,10 @@ class Weibull(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -231,6 +262,8 @@ class Weibull(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -266,21 +266,28 @@ class Weibull(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -381,26 +381,31 @@ class TestMixtureModelCalculations:
 class TestMixtureModelGenerate:
     """Statistical tests for the `generate` method."""
 
-    def test_generate_returns_correct_size(self, mixture_model: MixtureModel):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+            ((2, 0), (2, 0), False),
+        ],
+    )
+    def test_generate_returns_correct_size(self, mixture_model: MixtureModel, size, expected_shape, is_scalar):
         """Tests that generate returns an array of the requested size."""
-
-        size = 100
-        dtype = mixture_model.dtype
 
         samples = mixture_model.generate(size=size)
 
-        assert len(samples) == size
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-
-    def test_generate_with_size_zero(self, mixture_model):
-        """Tests that generating with size = 0 returns an empty array."""
-
-        dtype = mixture_model.dtype
-
-        samples = mixture_model.generate(0)
-        assert len(samples) == 0
-        assert samples.dtype == dtype
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, mixture_model.dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == mixture_model.dtype
+            if 0 in expected_shape:
+                assert samples.size == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_with_negative_size(self, mixture_model: MixtureModel, size: int):

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.core import MixtureModel
 from rework_pysatl_mpest.distributions import ContinuousDistribution, Exponential
 
@@ -291,45 +292,84 @@ class TestMixtureModelModification:
             mixture_model.remove_component(2)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestMixtureModelCalculations:
     """Tests for calculation methods like pdf, lpdf, etc."""
 
-    @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
-    def test_pdf_calculation(self, mixture_model: MixtureModel, X):
+    @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_pdf_calculation_for_array(self, x, dtype):
         """Tests the PDF calculation against the definition."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         c1, c2 = mixture_model.components
         w1, w2 = mixture_model.weights
 
-        expected_pdf = w1 * c1.pdf(X) + w2 * c2.pdf(X)
-        calculated_pdf = mixture_model.pdf(X)
+        expected_pdf = w1 * c1.pdf(x) + w2 * c2.pdf(x)
+        calculated_pdf = mixture_model.pdf(x)
 
         assert calculated_pdf.dtype == dtype
-        if not np.isscalar(X):
+        if not np.isscalar(x):
             assert isinstance(calculated_pdf, np.ndarray)
 
-        np.testing.assert_allclose(calculated_pdf, expected_pdf, rtol=np.finfo(dtype).eps)
+        np.testing.assert_allclose(calculated_pdf, expected_pdf, atol=np.finfo(dtype).eps)
 
-    @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
-    def test_lpdf_calculation(self, mixture_model: MixtureModel, X):
-        """Tests the LPDF calculation against the definition."""
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_calculation_for_scalar(self, x, dtype):
+        """Tests the PDF calculation against the definition."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         c1, c2 = mixture_model.components
         w1, w2 = mixture_model.weights
 
-        expected_lpdf = np.log(w1 * c1.pdf(X) + w2 * c2.pdf(X))
-        calculated_lpdf = mixture_model.lpdf(X)
+        expected_pdf = w1 * c1.pdf(x) + w2 * c2.pdf(x)
+        calculated_pdf = mixture_model.pdf(x)
 
-        assert isinstance(calculated_lpdf, np.ndarray)
+        assert np.isscalar(calculated_pdf)
+        assert isinstance(calculated_pdf, dtype)
+        np.testing.assert_allclose(calculated_pdf, expected_pdf, atol=np.finfo(dtype).eps)
+
+    @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_lpdf_calculation_for_array(self, x, dtype):
+        """Tests the LPDF calculation against the definition."""
+
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
+
+        expected_pdf = mixture_model.pdf(x)
+        calculated_lpdf = mixture_model.lpdf(x)
+
+        if not np.isscalar(x):
+            assert isinstance(calculated_lpdf, np.ndarray)
+
         assert calculated_lpdf.dtype == dtype
-        np.testing.assert_allclose(calculated_lpdf, expected_lpdf, rtol=np.finfo(dtype).eps)
+        np.testing.assert_allclose(np.exp(calculated_lpdf), expected_pdf, atol=np.finfo(dtype).eps)
 
-    def test_loglikelihood_calculation(self, mixture_model: MixtureModel):
+    @given(x=st.floats(-1e6, 1e6))
+    def test_lpdf_calculation_for_scalar(self, x, dtype):
+        """Tests the LPDF calculation against the definition."""
+
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
+
+        expected_pdf = mixture_model.pdf(x)
+        calculated_lpdf = mixture_model.lpdf(x)
+
+        assert np.isscalar(calculated_lpdf)
+        assert calculated_lpdf.dtype == dtype
+        np.testing.assert_allclose(np.exp(calculated_lpdf), expected_pdf, atol=np.finfo(dtype).eps)
+
+    def test_loglikelihood_calculation(self, dtype):
         """Tests that loglikelihood is the sum of LPDF values."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         X = np.array([1.0, 1.5, 6.0])
         expected_loglikelihood = np.sum(mixture_model.lpdf(X))
         calculated_loglikelihood = mixture_model.loglikelihood(X)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -50,8 +50,8 @@ def load_r_test_cases():
 
 
 @st.composite
-def st_params_and_x_for_grad(draw):
-    """Generator of valid params with x for gradient test"""
+def st_params_and_array_x_for_grad(draw):
+    """Generator of valid params with an array x for gradient test"""
     shape1 = draw(st.floats(0.1, 100))
     shape2 = draw(st.floats(0.1, 100))
     left = draw(st.floats(-100, 100))
@@ -61,13 +61,26 @@ def st_params_and_x_for_grad(draw):
     x = draw(
         arrays(
             np.float64,
-            shape=draw(st.integers(1, 5)),
+            shape=draw(st.integers(2, 5)),
             elements=st.floats(
                 min_value=left + margin, max_value=right - margin, allow_nan=False, allow_infinity=False
             ),
         )
     )
     return (shape1, shape2, left, right, x)
+
+
+@st.composite
+def st_params_and_scalar_x_for_grad(draw):
+    """Generator of valid params with a scalar x for gradient test"""
+    shape1 = draw(st.floats(0.1, 100))
+    shape2 = draw(st.floats(0.1, 100))
+    lower = draw(st.floats(-100, 100))
+    upper = draw(st.floats(lower + 0.1, lower + 100))
+
+    margin = 1e-2
+    x = draw(st.floats(min_value=lower + margin, max_value=upper - margin, allow_nan=False, allow_infinity=False))
+    return (shape1, shape2, lower, upper, x)
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
@@ -161,8 +174,8 @@ class TestBetaPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         alpha, beta, left_border, right_border = 1.0, 1.0, 2.9, 10.0
         dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
@@ -171,6 +184,18 @@ class TestBetaPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = 1.0, 1.0, 2.9, 10.0
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @pytest.mark.parametrize("x,shape1,shape2,left_border,right_border,expected_pdf", load_r_test_cases())
     def test_pdf_against_R(self, x, shape1, shape2, left_border, right_border, expected_pdf):
@@ -203,8 +228,8 @@ class TestBetaLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(params=st_valid_params(), x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, params, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, params, x, dtype):
+        """Tests that for an array input, the LPDF returns an array with the correct type and shape."""
 
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -212,6 +237,17 @@ class TestBetaLPDF:
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(params=st_valid_params(), x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, params, x, dtype):
+        """Tests that for a scalar input, the LPDF returns a scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = params
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(params=st_valid_params(), x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, params, x):
@@ -244,8 +280,8 @@ class TestBetaPPF:
     @given(
         params=st_valid_params(), p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, params, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, params, p, dtype):
+        """Tests that for an array input, the PPDF returns an array with the correct type and shape."""
 
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -253,6 +289,17 @@ class TestBetaPPF:
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(params=st_valid_params(), p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, params, p, dtype):
+        """Tests that for a scalar input, the PPDF returns a scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = params
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(params=st_valid_params(), p=st.floats(0, 1))
     def test_ppf_against_scipy(self, params, p):
@@ -278,8 +325,8 @@ class TestBetaGradients:
 
     h = 1e-6
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape1_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_shape1_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'shape1' against a numerical approximation."""
 
         shape1, shape2, left_border, right_border, x = params_x
@@ -298,9 +345,22 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape2_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_shape1_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'shape1' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_alpha(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_shape2_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'shape2' against a numerical approximation."""
+
         shape1, shape2, left_border, right_border, x = params_x
 
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -317,9 +377,22 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_left_border_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_shape2_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'shape2' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_beta(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_left_border_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'left_border' against a numerical approximation."""
+
         shape1, shape2, left_border, right_border, x = params_x
 
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -336,8 +409,20 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_right_border_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_left_border_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'left_border' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_left_border(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_right_border_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'right_border' against a numerical approximation."""
         shape1, shape2, left_border, right_border, x = params_x
 
@@ -354,6 +439,18 @@ class TestBetaGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_right_border_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'right_border' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_right_border(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -391,6 +488,19 @@ class TestBetaGradients:
         if "right_border" in expected_params:
             idx = sorted(expected_params).index("right_border")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
+
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_log_gradients_for_scalar_input(self, params_x, dtype):
+        """Checks that the log_gradients for a scalar input returns 1D-array."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -507,21 +507,30 @@ class TestBetaGradients:
 class TestBetaGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -309,23 +309,31 @@ class TestCauchyGradients:
 class TestCauchyGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Cauchy(loc=0.0, scale=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -81,16 +81,26 @@ class TestCauchyPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
-        loc, scale = 0.0, 1.0
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, loc, scale, x):
@@ -111,19 +121,29 @@ class TestCauchyPDF:
         np.testing.assert_allclose(1.0, integral, rtol=1e-5)
 
 
-class TestLogCauchyPDF:
+class TestCauchyLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, loc, scale, x):
@@ -142,14 +162,24 @@ class TestCauchyPPF:
     @given(
         loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
     def test_ppf_against_scipy(self, loc, scale, p):
@@ -175,8 +205,8 @@ class TestCauchyGradients:
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -194,9 +224,21 @@ class TestCauchyGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > loc + self.h)
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -213,6 +255,18 @@ class TestCauchyGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > loc + self.h)
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -238,6 +292,17 @@ class TestCauchyGradients:
         if "scale" in expected_params:
             idx = sorted(expected_params).index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
@@ -270,6 +335,23 @@ class TestCauchyGenerate:
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
+
+    def test_generate_statistical_properties(self, dtype):
+        """Tests if the generated samples have the correct statistical properties (median)."""
+
+        np.random.seed(123)
+        random.seed(123)
+        loc, scale = 5.0, 2.0
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        size = 5000
+
+        samples = dist.generate(size=size)
+
+        # The mean and variance of the Cauchy distribution are undefined.
+        # The median is equal to the location parameter 'loc'.
+        theoretical_median = loc
+
+        assert np.median(samples) == pytest.approx(theoretical_median, rel=0.1)
 
     def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -325,23 +325,31 @@ class TestExponentialGradients:
 class TestExponentialGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Exponential(loc=0.0, rate=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -81,8 +81,8 @@ class TestExponentialPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, rate, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, rate, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -90,6 +90,17 @@ class TestExponentialPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, rate, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, loc, rate, x):
@@ -124,14 +135,24 @@ class TestExponentialLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, rate, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, rate, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, rate, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, loc, rate, x):
@@ -160,14 +181,24 @@ class TestExponentialPPF:
     @given(
         loc=st_loc, rate=st_rate, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, rate, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, rate, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, rate, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
     def test_ppf_against_scipy(self, loc, rate, p):
@@ -193,8 +224,8 @@ class TestExponentialGradients:
     h = 1e-6
 
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, rate, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, rate, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -212,9 +243,20 @@ class TestExponentialGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > (loc + self.h))
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_rate_numerical(self, loc, rate, x, dtype):
-        """Checks the analytical gradient for 'rate' against a numerical approximation."""
+    def test_dlog_rate_numerical_for_array_input(self, loc, rate, x, dtype):
+        """Checks the analytical gradient for 'rate' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -231,6 +273,17 @@ class TestExponentialGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_dlog_rate_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the gradient for 'rate' for a scalar input returns a scalar."""
+
+        assume(x > (loc + self.h))
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        analytical_grad = dist._dlog_rate(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -256,6 +309,16 @@ class TestExponentialGradients:
         if "rate" in expected_params:
             idx = sorted(expected_params).index("rate")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_rate(x))
+
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -296,20 +296,29 @@ class TestNormalGradients:
 class TestNormalGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
-        samples = dist.generate(size=100)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (100,)
+        samples = dist.generate(size=size)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -81,8 +81,8 @@ class TestNormalPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -90,6 +90,17 @@ class TestNormalPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
     def test_pdf_against_scipy(self, loc, scale, x):
@@ -114,14 +125,24 @@ class TestNormalLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
     def test_lpdf_against_scipy(self, loc, scale, x):
@@ -138,14 +159,24 @@ class TestNormalPPF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1)))
-    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(1e-6, 1.0 - 1e-6))
     def test_ppf_against_scipy(self, loc, scale, p):
@@ -156,6 +187,13 @@ class TestNormalPPF:
         scipy_ppf = norm.ppf(p, loc=loc, scale=scale)
         np.testing.assert_allclose(custom_ppf, scipy_ppf, atol=1e-9)
 
+    @pytest.mark.parametrize("p_val", [-0.5, 1.1, 1.5])
+    def test_ppf_invalid_input(self, p_val):
+        """Tests that PPF returns NaN for probabilities outside the [0, 1] range."""
+
+        dist = Normal(loc=0.0, scale=1.0)
+        assert np.isnan(dist.ppf(p_val))
+
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestNormalGradients:
@@ -164,8 +202,8 @@ class TestNormalGradients:
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
@@ -181,9 +219,19 @@ class TestNormalGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
@@ -199,11 +247,21 @@ class TestNormalGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
         [([], 2, ["loc", "scale"]), (["loc"], 1, ["scale"]), (["scale"], 1, ["loc"]), (["loc", "scale"], 0, [])],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params, dtype):
+    def test_log_gradients_structure_for_array_input(self, fixed_params, expected_cols, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
         dist = Normal(loc=1.0, scale=2.0, dtype=dtype)
@@ -221,6 +279,17 @@ class TestNormalGradients:
         if "scale" in expected_params:
             idx = sorted_params.index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -380,23 +380,31 @@ class TestParetoGradients:
 class TestParetoGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -116,8 +116,8 @@ class TestParetoPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e2, 1e2)))
-    def test_pdf_properties(self, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -125,6 +125,18 @@ class TestParetoPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e2, 1e2))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        shape, scale = 1.0, 2.0
+        dist = Pareto(shape, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @pytest.mark.parametrize("x,shape,scale,expected_pdf", load_r_test_cases())
     def test_pdf_against_R(self, shape, scale, x, expected_pdf):
@@ -171,8 +183,8 @@ class TestParetoLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, shape, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, shape, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
@@ -180,9 +192,20 @@ class TestParetoLPDF:
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, shape, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
+
     @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3, allow_infinity=False, allow_nan=False))
     def test_lpdf_against_scipy(self, shape, scale, x):
         """Compares the custom LPDF implementation against scipy's implementation."""
+
         assume(np.isfinite(pareto.logpdf(x, scale=scale, b=shape, loc=0.0)))
         dist = Pareto(shape=shape, scale=scale)
         custom_lpdf = dist.lpdf(x)
@@ -207,14 +230,24 @@ class TestParetoPPF:
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, shape, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, shape, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(shape=st_shape, scale=st_scale, p=st.floats(0, 1))
     def test_ppf_against_scipy(self, shape, scale, p):
@@ -241,8 +274,8 @@ class TestParetoGradients:
 
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_shape_numerical(self, shape, scale, x, dtype):
-        """Checks the analytical gradient for 'shape' against a numerical approximation."""
+    def test_dlog_shape_numerical_for_array_input(self, shape, scale, x, dtype):
+        """Checks the analytical gradient for 'shape' against a numerical approximation for array input."""
 
         assume(np.all(x > scale))
 
@@ -260,10 +293,20 @@ class TestParetoGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_shape_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the gradient for 'shape' for a scalar input returns a scalar."""
+
+        assume(x > scale)
+        dist = Pareto(shape, scale, dtype=dtype)
+        analytical_grad = dist._dlog_shape(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, shape, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, shape, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > scale + self.h))
 
@@ -280,6 +323,16 @@ class TestParetoGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > scale + self.h)
+        dist = Pareto(shape, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -310,6 +363,17 @@ class TestParetoGradients:
         if "scale" in expected_params:
             idx = sorted(expected_params).index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        assume(x > scale + self.h)
+        dist = Pareto(shape, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -399,23 +399,31 @@ class TestUniformGradients:
 class TestUniformGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Uniform(left_border=0.0, right_border=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -21,6 +21,7 @@ DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 @st.composite
 def st_valid_border(draw):
     """Generates valid borders"""
+
     left_border = draw(st.floats(min_value=-1e3, max_value=1e3 - 1, allow_nan=False, allow_infinity=False))
     right_border = draw(
         st.floats(min_value=left_border + 1e-6, max_value=left_border + 1e3, allow_nan=False, allow_infinity=False)
@@ -56,6 +57,7 @@ class TestUniformInitialization:
 
     def test_invariant_violation(self, dtype):
         """Tests that initializing with a infinite borders or left border bigger right border  raises a ValueError."""
+
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
             Uniform(0.0, -1.0, dtype=dtype)
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
@@ -89,8 +91,9 @@ class TestUniformPDF:
         borders=st_valid_border(),
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, borders, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, borders, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
+
         left_border, right_border = borders
 
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
@@ -100,9 +103,22 @@ class TestUniformPDF:
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        left_border, right_border = -1.0, 12.0
+        dist = Uniform(left_border, right_border, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
+
     @given(borders=st_valid_border(), x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, borders, x):
         """Compares the custom PDF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_pdf = dist.pdf(x)
@@ -112,6 +128,7 @@ class TestUniformPDF:
     @given(borders=st_valid_border())
     def test_pdf_integral_is_one(self, borders):
         """Tests that the integral of the PDF over its support is equal to 1."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         integral, error = quad(lambda x: dist.pdf(x).item(), left_border, right_border)
@@ -120,6 +137,7 @@ class TestUniformPDF:
     @given(borders=st_valid_border(), x=st.floats(max_value=-1e9, allow_infinity=False))
     def test_pdf_outside_support(self, borders, x):
         """Tests that the PDF is zero for values not in range of parameters."""
+
         left_border, right_border = borders
         x_val = left_border - abs(x)
         dist = Uniform(left_border=left_border, right_border=right_border)
@@ -134,8 +152,9 @@ class TestUniformLPDF:
         borders=st_valid_border(),
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_lpdf_return_type_and_shape(self, borders, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, borders, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         lpdf_values = dist.lpdf(x)
@@ -143,9 +162,21 @@ class TestUniformLPDF:
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(borders=st_valid_border(), x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, borders, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
+
     @given(borders=st_valid_border(), x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, borders, x):
         """Compares the custom LPDF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_lpdf = dist.lpdf(x)
@@ -155,6 +186,7 @@ class TestUniformLPDF:
     @given(borders=st_valid_border(), x=st.floats(min_value=1e-6))
     def test_lpdf_outside_support(self, borders, x):
         """Tests that the LPDF is -inf for values outside the support."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         assert dist.lpdf(left_border - x) == -np.inf
@@ -169,8 +201,9 @@ class TestUniformPPF:
         borders=st_valid_border(),
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, borders, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, borders, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         ppf_values = dist.ppf(p)
@@ -178,9 +211,21 @@ class TestUniformPPF:
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(borders=st_valid_border(), p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, borders, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
+
     @given(borders=st_valid_border(), p=st.floats(0, 1))
     def test_ppf_against_scipy(self, borders, p):
         """Compares the custom PPF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_ppf = dist.ppf(p)
@@ -196,8 +241,9 @@ class TestUniformPPF:
 
 
 @st.composite
-def st_valid_grad_input(draw):
-    """Generates valid borders to calculate gradient"""
+def st_valid_grad_input_array(draw):
+    """Generates valid borders to calculate gradient for an array of x."""
+
     left_border = draw(st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False))
     right_border = draw(
         st.floats(min_value=left_border + 0.1, max_value=left_border + 20.0, allow_nan=False, allow_infinity=False)
@@ -217,15 +263,35 @@ def st_valid_grad_input(draw):
     return (left_border, right_border), x_values
 
 
+@st.composite
+def st_valid_grad_input_scalar(draw):
+    """Generates valid borders to calculate gradient for a scalar x."""
+
+    left_border = draw(st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False))
+    right_border = draw(
+        st.floats(min_value=left_border + 0.1, max_value=left_border + 20.0, allow_nan=False, allow_infinity=False)
+    )
+
+    margin = 0.01
+    x_value = draw(
+        st.floats(
+            min_value=left_border + margin, max_value=right_border - margin, allow_nan=False, allow_infinity=False
+        )
+    )
+
+    return (left_border, right_border), x_value
+
+
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestUniformGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
-    @given(input_data=st_valid_grad_input())
-    def test_dlog_left_border_numerical(self, input_data, dtype):
-        """Checks the analytical gradient for 'left_border' against a numerical approximation."""
+    @given(input_data=st_valid_grad_input_array())
+    def test_dlog_left_border_numerical_for_array_input(self, input_data, dtype):
+        """Checks the analytical gradient for 'left_border' against a numerical approximation for array input."""
+
         borders, x = input_data
         left_border, right_border = borders
 
@@ -242,9 +308,22 @@ class TestUniformGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(input_data=st_valid_grad_input())
-    def test_dlog_right_border_numerical(self, input_data, dtype):
-        """Checks the analytical gradient for 'right_border' against a numerical approximation."""
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_dlog_left_border_for_scalar_input(self, input_data, dtype):
+        """Checks that the gradient for 'left_border' for a scalar input returns a scalar."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_left_border(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(input_data=st_valid_grad_input_array())
+    def test_dlog_right_border_numerical_for_array_input(self, input_data, dtype):
+        """Checks the analytical gradient for 'right_border' against a numerical approximation for array input."""
+
         borders, x = input_data
         left_border, right_border = borders
 
@@ -260,6 +339,18 @@ class TestUniformGradients:
             lpdf_minus_h = Uniform(left_border=left_border, right_border=right_border - self.h).lpdf(x)
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_dlog_right_border_for_scalar_input(self, input_data, dtype):
+        """Checks that the gradient for 'right_border' for a scalar input returns a scalar."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_right_border(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -290,6 +381,18 @@ class TestUniformGradients:
         if "right_border" in expected_params:
             idx = sorted(expected_params).index("right_border")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
+
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_log_gradients_for_scalar_input(self, input_data, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+        dist = Uniform(left_border, right_border, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -384,21 +384,29 @@ class TestWeibullGradients:
 class TestWeibullGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if generating 0 number of samples returns an empty array"""
-
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -86,10 +86,10 @@ class TestWeibullPDF:
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
-        x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
+        x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, shape, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, shape, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -97,6 +97,17 @@ class TestWeibullPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, shape, loc, scale, x):
@@ -135,14 +146,24 @@ class TestWeibullLPDF:
         scale=st_scale,
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_lpdf_return_type_and_shape(self, shape, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, shape, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, shape, loc, scale, x):
@@ -173,14 +194,24 @@ class TestWeibullPPF:
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, shape, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, shape, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, p=st.floats(0.01, 1))
     def test_ppf_against_scipy(self, shape, loc, scale, p):
@@ -211,8 +242,8 @@ class TestWeibullGradients:
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_shape_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'shape' against a numerical approximation."""
+    def test_dlog_shape_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'shape' against a numerical approximation for array input."""
 
         assume(np.all(x > loc))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -227,14 +258,24 @@ class TestWeibullGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_shape_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'shape' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_shape(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_loc_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -249,14 +290,24 @@ class TestWeibullGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_scale_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > loc))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -270,6 +321,16 @@ class TestWeibullGradients:
             lpdf_minus_h = Weibull(shape=shape, loc=loc, scale=scale - self.h).lpdf(x)
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
@@ -305,6 +366,18 @@ class TestWeibullGradients:
             np.testing.assert_allclose(gradients[:, sorted_params.index("scale")], dist._dlog_scale(x))
         if "shape" in expected_params:
             np.testing.assert_allclose(gradients[:, sorted_params.index("shape")], dist._dlog_shape(x))
+
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        assume(x > loc)
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)


### PR DESCRIPTION
This PR standardizes the behavior of distributions to ensure consistent return types (scalars vs arrays) and improves the numerical stability of PDF calculations.

## Changes
- **Numerical Stability:** Refactored `pdf` methods in all distributions to calculate probability density via `np.exp(lpdf(X))`. 
- **Standardized Outputs:** Updated distribution methods (`pdf`, `lpdf`, `ppf`, `log_gradients`) to strictly distinguish between inputs:
  - Scalar input -> Scalar output.
  - Array input -> Array output with correct `dtype`.
- **Generate:** - Update `generate` method signature in `ContinuousDistribution` and implementations to support `size` as `int`, `tuple`, or `None` (SciPy-like behavior).
- **Testing:** Added comprehensive property-based tests (via Hypothesis) for all distributions ensuring that:
  - Scalar inputs return scalars (`np.isscalar` check).
  - Array inputs return arrays with correct shapes and dtypes.
  - Add unit tests covering various `size` shapes (scalar, 1D, ND, empty)