### PR TITLE
feat: likelihood breakpointer

### DIFF
--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -267,8 +267,7 @@ class MixtureModel(Generic[DType]):
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        component_pdfs = np.array([comp.pdf(X) for comp in self.components])
-        return np.dot(self.weights, component_pdfs)
+        return np.exp(self.lpdf(X))
 
     def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Logarithms of the Probability Density Function.
@@ -285,13 +284,17 @@ class MixtureModel(Generic[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         component_lpdfs = np.array([comp.lpdf(X) for comp in self.components])
         broadcast_shape = (self.n_components,) + (1,) * X.ndim
         log_weights = self.log_weights.reshape(broadcast_shape)
         log_terms = log_weights + component_lpdfs
 
-        return logsumexp(log_terms, axis=0)
+        result = logsumexp(log_terms, axis=0)
+        if is_scalar:
+            return result[()]
+        return result
 
     def loglikelihood(self, X: ArrayLike) -> DType:
         """Log-likelihood of the complete data :attr:`X`.
@@ -313,7 +316,7 @@ class MixtureModel(Generic[DType]):
         X = np.asarray(X, dtype=self.dtype)
         return np.sum(self.lpdf(X))
 
-    def generate(self, size: int) -> NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
         """Generates random samples from the mixture model.
 
         First, a component is chosen based on the mixture weights. Then, a
@@ -322,28 +325,43 @@ class MixtureModel(Generic[DType]):
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             A NumPy array containing the generated samples. Returns an
             empty array if :attr:`size` is not positive.
         """
 
-        if size == 0:
-            return np.array([], dtype=self.dtype)
+        if size is None:
+            n_samples = 1
+        elif isinstance(size, int):
+            n_samples = size
+            if n_samples == 0:
+                return np.array([], dtype=self.dtype)
+        else:
+            n_samples = int(np.prod(size))
+            if n_samples == 0:
+                return np.empty(size, dtype=self.dtype)
 
-        component_choices = np.random.choice(self.n_components, size=size, p=self.weights)
-
+        component_choices = np.random.choice(self.n_components, size=n_samples, p=self.weights)
         counts = np.bincount(component_choices, minlength=self.n_components)
 
         samples_list = [self.components[i].generate(size=count) for i, count in enumerate(counts) if count > 0]
 
         samples = np.concatenate(samples_list)
         np.random.shuffle(samples)
-        return samples
+
+        if size is None:
+            return samples[0]
+
+        target_shape = (size,) if isinstance(size, int) else size
+        return samples.reshape(target_shape)
 
     def astype(self, new_dtype: type[DType]) -> "MixtureModel[DType]":
         """Creates a copy of the MixtureModel with a new data type.

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -9,7 +9,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy import float64
@@ -72,7 +72,7 @@ class MixtureModel:
         generate
     """
 
-    def __init__(self, components: Sequence["ContinuousDistribution"], weights: Optional[ArrayLike] = None):
+    def __init__(self, components: Sequence["ContinuousDistribution"], weights: ArrayLike | None = None):
         n_components = len(components)
         if n_components == 0:
             raise ValueError("List of components cannot be an empty")
@@ -85,9 +85,9 @@ class MixtureModel:
 
         self._components = list(components)
         self._log_weights = np.log(weights + 1e-30)
-        self._cached_weights: Optional[NDArray[float64]] = None
+        self._cached_weights: NDArray[float64] | None = None
 
-        self._sorted_pairs_cache: Optional[list[tuple[ContinuousDistribution, float]]] = None
+        self._sorted_pairs_cache: list[tuple[ContinuousDistribution, float]] | None = None
 
     def _validate_weights(self, n_components: int, weights: NDArray[float64]):
         """Validates the component weights.

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -248,7 +248,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def pdf(self, X: ArrayLike) -> NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Probability Density Function of the mixture.
 
         The PDF is computed as the weighted sum of the PDFs of its
@@ -261,15 +261,16 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
         component_pdfs = np.array([comp.pdf(X) for comp in self.components])
-        return np.asarray(np.dot(self.weights, component_pdfs))
+        return np.dot(self.weights, component_pdfs)
 
-    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Logarithms of the Probability Density Function.
 
         Parameters
@@ -279,15 +280,18 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
-        X = np.atleast_1d(X).astype(self.dtype)
+        X = np.asarray(X, dtype=self.dtype)
         component_lpdfs = np.array([comp.lpdf(X) for comp in self.components])
-        log_weights = self.log_weights
-        log_terms = log_weights[:, np.newaxis] + component_lpdfs
-        return logsumexp(log_terms, axis=0)  # type: ignore
+        broadcast_shape = (self.n_components,) + (1,) * X.ndim
+        log_weights = self.log_weights.reshape(broadcast_shape)
+        log_terms = log_weights + component_lpdfs
+
+        return logsumexp(log_terms, axis=0)
 
     def loglikelihood(self, X: ArrayLike) -> DType:
         """Log-likelihood of the complete data :attr:`X`.

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -12,19 +12,22 @@ from copy import copy
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy import float64
 from numpy.typing import ArrayLike, NDArray
 from scipy.special import logsumexp, softmax
+
+from ..typings import DType
 
 if TYPE_CHECKING:
     from ..distributions import ContinuousDistribution
 
 
-class MixtureModel:
+class MixtureModel(Generic[DType]):
     """Represents a finite mixture of continuous probability distributions.
 
     This class encapsulates a collection of distribution components and their
-    corresponding weights.
+    corresponding weights. All components within the mixture are automatically
+    converted to the specified `dtype` of the MixtureModel, ensuring
+    computational consistency.
 
     Instances of this class can be compared for equality (``==``) and
     inequality (``!=``). Two models are considered equal if they have the
@@ -39,17 +42,21 @@ class MixtureModel:
         An array of initial weights for the components. The weights must be
         positive and sum to 1. If None, components are assigned equal
         weights. Defaults to None.
+    dtype : type[DType], optional
+        The numpy data type used for internal calculations and
+        output arrays (e.g., `np.float32` or `np.float64`).
+        Defaults to `np.float64`.
 
     Attributes
     ----------
-    components : tuple[ContinuousDistribution]
+    components : tuple[ContinuousDistribution[DType], ...]
         A tuple of the distribution objects that form the mixture.
     n_components : int
         The number of components in the mixture.
-    weights : NDArray[np.float64]
+    weights : NDArray[DType]
         A NumPy array of the normalized weights for each component. The sum
         of weights is always 1.
-    log_weights : NDArray[np.float64]
+    log_weights : NDArray[DType]
         A NumPy array of the natural logarithm of the component weights.
 
     Raises
@@ -77,10 +84,12 @@ class MixtureModel:
         if n_components == 0:
             raise ValueError("List of components cannot be an empty")
 
+        self._dtype = dtype
+
         if weights is None:
-            weights = np.full(n_components, 1.0 / n_components)
+            weights = np.full(n_components, 1.0 / n_components, dtype=self.dtype)
         else:
-            weights = np.asarray(weights, dtype=float64)
+            weights = np.asarray(weights, dtype=self.dtype)
             self._validate_weights(n_components, weights)
 
         self._components = list(components)
@@ -89,14 +98,14 @@ class MixtureModel:
 
         self._sorted_pairs_cache: list[tuple[ContinuousDistribution, float]] | None = None
 
-    def _validate_weights(self, n_components: int, weights: NDArray[float64]):
+    def _validate_weights(self, n_components: int, weights: NDArray[DType]):
         """Validates the component weights.
 
         Parameters
         ----------
         n_components : int
             The expected number of components.
-        weights : NDArray[np.float64]
+        weights : NDArray[DType]
             The array of weights to validate.
 
         Raises
@@ -112,8 +121,13 @@ class MixtureModel:
         if np.any(weights < 0):
             raise ValueError("Weights must be positive.")
 
-        if not np.isclose(np.sum(weights), 1.0):
+        if not np.isclose(np.sum(weights), self.dtype(1.0)):
             raise ValueError(f"Sum of the weights must be equal 1, but it equal {np.sum(weights)}.")
+
+    @property
+    def dtype(self) -> type[DType]:
+        """type[DType]: The numpy data type of the mixture's outputs."""
+        return self._dtype
 
     @property
     def n_components(self):
@@ -123,13 +137,13 @@ class MixtureModel:
 
     @property
     def components(self):
-        """tuple[ContinuousDistribution, ...]: The components of the mixture."""
+        """tuple[ContinuousDistribution[DType], ...]: The components of the mixture."""
 
         return tuple(self._components)
 
     @property
-    def weights(self) -> NDArray[float64]:
-        """NDArray[np.float64]: The normalized weights of the components.
+    def weights(self) -> NDArray[DType]:
+        """NDArray[DType]: The normalized weights of the components.
 
         The weights are computed from the log-weights using the softmax
         function and cached for efficiency.
@@ -141,8 +155,8 @@ class MixtureModel:
         return self._cached_weights  # type: ignore
 
     @property
-    def log_weights(self) -> NDArray[float64]:
-        """NDArray[np.float64]: The logarithm of the component weights."""
+    def log_weights(self) -> NDArray[DType]:
+        """NDArray[DType]: The logarithm of the component weights."""
 
         return self._log_weights
 
@@ -162,11 +176,11 @@ class MixtureModel:
             number of components.
         """
 
-        new_log_weights = np.asarray(new_log_weights, dtype=float64)
+        new_log_weights = np.asarray(new_log_weights, dtype=self.dtype)
 
         if len(new_log_weights) != self.n_components:
             raise ValueError("The length of the new logit vector does not match the number of components.")
-        self._log_weights = np.asarray(new_log_weights, dtype=float)
+        self._log_weights = new_log_weights
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
@@ -192,11 +206,13 @@ class MixtureModel:
         if not (0 < weight < 1):
             raise ValueError("The weight of the new component must be in the range (0, 1).")
 
-        self._log_weights += np.log(1 - weight)
-        new_log_weight = np.log(weight)
+        d_weight = self.dtype(weight)
+        self._log_weights += np.log(self.dtype(1.0) - d_weight)
+        new_log_weight = np.log(d_weight)
         self._log_weights = np.append(self._log_weights, new_log_weight)
 
-        self._components.append(component)
+        new_component = component.astype(self.dtype)
+        self._components.append(new_component)
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
@@ -231,7 +247,7 @@ class MixtureModel:
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def pdf(self, X: ArrayLike) -> NDArray[float64]:
+    def pdf(self, X: ArrayLike) -> NDArray[DType]:
         """Probability Density Function of the mixture.
 
         The PDF is computed as the weighted sum of the PDFs of its
@@ -244,15 +260,15 @@ class MixtureModel:
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
         component_pdfs = np.array([comp.pdf(X) for comp in self.components])
         return np.asarray(np.dot(self.weights, component_pdfs))
 
-    def lpdf(self, X: ArrayLike) -> NDArray[float64]:
+    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
         """Logarithms of the Probability Density Function.
 
         Parameters
@@ -262,17 +278,17 @@ class MixtureModel:
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.atleast_1d(X)
+        X = np.atleast_1d(X).astype(self.dtype)
         component_lpdfs = np.array([comp.lpdf(X) for comp in self.components])
         log_weights = self.log_weights
         log_terms = log_weights[:, np.newaxis] + component_lpdfs
         return logsumexp(log_terms, axis=0)  # type: ignore
 
-    def loglikelihood(self, X: ArrayLike) -> float:
+    def loglikelihood(self, X: ArrayLike) -> DType:
         """Log-likelihood of the complete data :attr:`X`.
 
         The log-likelihood is the sum of the log-PDF values for all data
@@ -289,10 +305,10 @@ class MixtureModel:
             The total log-likelihood value.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
         return np.sum(self.lpdf(X))
 
-    def generate(self, size: int) -> NDArray[float64]:
+    def generate(self, size: int) -> NDArray[DType]:
         """Generates random samples from the mixture model.
 
         First, a component is chosen based on the mixture weights. Then, a
@@ -306,13 +322,13 @@ class MixtureModel:
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples. Returns an
             empty array if :attr:`size` is not positive.
         """
 
         if size == 0:
-            return np.array([])
+            return np.array([], dtype=self.dtype)
 
         component_choices = np.random.choice(self.n_components, size=size, p=self.weights)
 
@@ -324,7 +340,7 @@ class MixtureModel:
         np.random.shuffle(samples)
         return samples
 
-    def __getitem__(self, key: int) -> "ContinuousDistribution":
+    def __getitem__(self, key: int) -> "ContinuousDistribution[DType]":
         """Retrieves components by index.
 
         Parameters
@@ -334,13 +350,13 @@ class MixtureModel:
 
         Returns
         -------
-        ContinuousDistribution
+        ContinuousDistribution[DType]
             A single component of the mixture
         """
 
         return self.components[key]
 
-    def __iter__(self) -> Iterator["ContinuousDistribution"]:
+    def __iter__(self) -> Iterator["ContinuousDistribution[DType]"]:
         """Returns an iterator over the mixture components.
 
         This allows the `MixtureModel` instance to be used directly in
@@ -348,26 +364,26 @@ class MixtureModel:
 
         Yields
         ------
-        Iterator[ContinuousDistribution]
+        Iterator[ContinuousDistribution[DType]
             An iterator that yields the components of the mixture model.
         """
 
         return iter(self.components)
 
-    def __copy__(self) -> "MixtureModel":
+    def __copy__(self) -> "MixtureModel[DType]":
         """Creates a copy of the mixture model instance.
 
         Returns
         -------
-        MixtureModel
+        MixtureModel[DType]
             A new instance of the distribution, identical to the original.
         """
 
         copied_components = [copy(component) for component in self._components]
-        new_mixture = MixtureModel(components=copied_components, weights=self.weights.copy())
+        new_mixture = MixtureModel(components=copied_components, weights=self.weights.copy(), dtype=self.dtype)
         return new_mixture
 
-    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution", float]]:
+    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution[DType]", DType]]:
         """Internal helper to get component-weight pairs, sorted by component hash."""
 
         if self._sorted_pairs_cache is None or for_hashing:
@@ -401,7 +417,7 @@ class MixtureModel:
         if not isinstance(other, MixtureModel):
             return NotImplemented
 
-        if self.n_components != other.n_components:
+        if self.dtype != other.dtype or self.n_components != other.n_components:
             return False
 
         self_pairs = self._get_sorted_pairs()
@@ -425,4 +441,4 @@ class MixtureModel:
         """
 
         sorted_pairs_for_hash = self._get_sorted_pairs(for_hashing=True)
-        return hash(tuple(sorted_pairs_for_hash))
+        return hash((self.dtype, tuple(sorted_pairs_for_hash)))

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -127,6 +127,7 @@ class MixtureModel(Generic[DType]):
     @property
     def dtype(self) -> type[DType]:
         """type[DType]: The numpy data type of the mixture's outputs."""
+
         return self._dtype
 
     @property
@@ -389,7 +390,8 @@ class MixtureModel(Generic[DType]):
         if self._sorted_pairs_cache is None or for_hashing:
             weights_to_use = self.weights
             if for_hashing:
-                weights_to_use = np.round(weights_to_use, 8)
+                decimals = np.finfo(self.dtype).precision
+                weights_to_use = np.round(weights_to_use, decimals)
 
             pairs = sorted(zip(self.components, weights_to_use), key=lambda p: hash(p[0]))
             if not for_hashing:

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -301,7 +301,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        float
+        DType
             The total log-likelihood value.
         """
 

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -341,6 +341,30 @@ class MixtureModel(Generic[DType]):
         np.random.shuffle(samples)
         return samples
 
+    def astype(self, new_dtype: type[DType]) -> "MixtureModel[DType]":
+        """Creates a copy of the MixtureModel with a new data type.
+
+        If the specified `new_dtype` is the same as the instance's current `dtype`,
+        this method returns the original instance instead.
+
+        Parameters
+        ----------
+        new_dtype : type[DType]
+            The target NumPy data type for the new distribution instance.
+
+        Returns
+        -------
+        MixtureModel[DType]
+            A new MixtureModel instance with all components and weights converted to the
+            specified `new_dtype`, or the original instance if the `dtype` is
+            unchanged.
+        """
+        if self.dtype is new_dtype:
+            return self
+
+        new_mixture = MixtureModel(components=self.components, weights=self.weights.copy(), dtype=new_dtype)
+        return new_mixture
+
     def __getitem__(self, key: int) -> "ContinuousDistribution[DType]":
         """Retrieves components by index.
 

--- a/rework_pysatl_mpest/core/parameter.py
+++ b/rework_pysatl_mpest/core/parameter.py
@@ -10,7 +10,8 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable, Union, overload
+from collections.abc import Callable
+from typing import Union, overload
 
 
 class Parameter:

--- a/rework_pysatl_mpest/core/parameter.py
+++ b/rework_pysatl_mpest/core/parameter.py
@@ -5,7 +5,7 @@ and validate parameters in classes inheriting from `ContinuousDistribution`.
 It allows you to set invariants for parameter values and handle assignment errors,
 as well as to fix parameters from changes."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -65,7 +65,7 @@ class Parameter:
         self.invariant = invariant
         self.error_message = error_message
 
-    def __set_name__(self, owner: type[object], name: str):
+    def __set_name__(self, owner: type["ContinuousDistribution[DType]"], name: str):
         """Sets the name for the public and private attributes.
 
         This method is automatically called when a descriptor instance is created
@@ -74,7 +74,7 @@ class Parameter:
 
         Parameters
         ----------
-        owner : type[object]
+        owner : type[ContinuousDistribution]
             The class that uses the descriptor.
         name : str
             The attribute name assigned to the descriptor instance.
@@ -84,14 +84,16 @@ class Parameter:
         self.private_name = "_" + name
 
     @overload
-    def __get__(self, instance: None, owner: type[object]) -> "Parameter":
+    def __get__(self, instance: None, owner: type["ContinuousDistribution[DType]"]) -> "Parameter":
         """If access is via a class, return the descriptor object itself."""
 
     @overload
-    def __get__(self, instance: object, owner: type[object]) -> float:
+    def __get__(self, instance: "ContinuousDistribution[DType]", owner: type["ContinuousDistribution[DType]"]) -> DType:
         """If access is via an object, return the value."""
 
-    def __get__(self, instance: object | None, owner: type[object]) -> Union[float, "Parameter"]:
+    def __get__(
+        self, instance: Optional["ContinuousDistribution[DType]"], owner: type["ContinuousDistribution[DType]"]
+    ) -> Union[DType, "Parameter"]:
         """Returns the parameter value or the descriptor itself.
 
         If access is through an instance of the class, it returns the
@@ -100,15 +102,15 @@ class Parameter:
 
         Parameters
         ----------
-        instance : object or None
+        instance : ContinuousDistribution, optional
             An instance of the owner class, or `None` if access
             is through the class.
-        owner : type[object]
+        owner : type[ContinuousDistribution]
             The owner class.
 
         Returns
         -------
-        float or Parameter
+        DType or Parameter
             The value of the parameter or the descriptor itself.
         """
 
@@ -117,7 +119,7 @@ class Parameter:
 
         return getattr(instance, self.private_name)
 
-    def __set__(self, instance: object, value: float):
+    def __set__(self, instance: "ContinuousDistribution[DType]", value: float):
         """Sets the parameter value after validation.
 
         Before setting a new value, it checks whether the parameter is
@@ -125,7 +127,7 @@ class Parameter:
 
         Parameters
         ----------
-        instance : object
+        instance : "ContinuousDistribution[DType]"
             An instance of the owner class.
         value : float
             The new value for the parameter.
@@ -144,7 +146,10 @@ class Parameter:
                 "This parameter is fixed."
             )
 
-        if not self.invariant(value):
+        owner_dtype = getattr(instance, "dtype", np.float64)
+        d_value = owner_dtype(value)
+
+        if not self.invariant(d_value):
             raise ValueError(f"Invalid value for '{self.public_name}': {self.error_message}")
 
-        setattr(instance, self.private_name, value)
+        setattr(instance, self.private_name, d_value)

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -191,6 +191,7 @@ class Beta(ContinuousDistribution):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
@@ -199,6 +200,8 @@ class Beta(ContinuousDistribution):
         log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta).astype(dtype)
         result = log_pdf_standard - np.log(self.right_border - self.left_border)
 
+        if is_scalar:
+            return result[()]
         return result
 
     def _dlog_alpha(self, X):
@@ -420,26 +423,30 @@ class Beta(ContinuousDistribution):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(
-            beta_dist.rvs(
-                self.alpha, self.beta, loc=self.left_border, scale=self.right_border - self.left_border, size=size
-            ),
-            dtype=self.dtype,
+        samples = beta_dist.rvs(
+            self.alpha, self.beta, loc=self.left_border, scale=self.right_border - self.left_border, size=size
         )
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -1,4 +1,4 @@
-"""Module providing four parametric beta distribution distribution class"""
+"""Module providing four parametric beta distribution class"""
 
 __author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -408,7 +408,7 @@ class Beta(ContinuousDistribution):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Beta(alpha=1.0, beta=2.0, left_border=0.0, right_border=1.0)".
+            "Beta(alpha=1.0, beta=2.0, left_border=0.0, right_border=1.0, dtype=np.float64)".
         """
 
         return (
@@ -416,5 +416,6 @@ class Beta(ContinuousDistribution):
             f"alpha={self.alpha}, "
             f"beta={self.beta}, "
             f"left_border={self.left_border}, "
-            f"right_border={self.right_border})"
+            f"right_border={self.right_border}, "
+            f"dtype=np.{self.dtype.__name__})"
         )

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -1,15 +1,16 @@
 """Module providing four parametric beta distribution distribution class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+
 import numpy as np
-from numpy import float64
 from scipy.special import digamma
 from scipy.stats import beta as beta_dist
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
@@ -60,8 +61,15 @@ class Beta(ContinuousDistribution):
     left_border = Parameter()
     right_border = Parameter()
 
-    def __init__(self, alpha: float, beta: float, left_border: float, right_border: float):
-        super().__init__()
+    def __init__(
+        self,
+        alpha: float,
+        beta: float,
+        left_border: float,
+        right_border: float,
+        dtype: type[DType] = np.float64,  # type: ignore[assignment]
+    ):
+        super().__init__(dtype=dtype)
         if left_border >= right_border:
             raise ValueError("Left border must be less than right border")
         self.alpha = alpha
@@ -101,10 +109,11 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
 
         """
+        X = np.asarray(X, dtype=self.dtype)
         return np.exp(self.lpdf(X))
 
     def ppf(self, P):
@@ -128,14 +137,19 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
-        P = np.asarray(P, dtype=float64)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
+
         return np.where(
             (P >= 0) & (P <= 1),
-            (self.left_border + (self.right_border - self.left_border) * beta_dist.ppf(P, self.alpha, self.beta)),
-            np.nan,
+            (
+                self.left_border
+                + (self.right_border - self.left_border) * beta_dist.ppf(P, self.alpha, self.beta).astype(dtype)
+            ),
+            dtype(np.nan),
         )
 
     def lpdf(self, X):
@@ -163,17 +177,19 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
 
         Z = (X - self.left_border) / (self.right_border - self.left_border)
 
-        log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta)
+        log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta).astype(dtype)
+        result = log_pdf_standard - np.log(self.right_border - self.left_border)
 
-        return log_pdf_standard - np.log(self.right_border - self.left_border)
+        return np.atleast_1d(result)
 
     def _dlog_alpha(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`alpha` parameter.
@@ -198,18 +214,20 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`alpha` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_bounds = (self.left_border < X) & (self.right_border >= X)
         return np.where(
             in_bounds,
             np.log(X - self.left_border)
             - np.log(self.right_border - self.left_border)
-            - (digamma(self.alpha) - digamma(self.alpha + self.beta)),
-            0.0,
+            - (dtype(digamma(self.alpha)) - dtype(digamma(self.alpha + self.beta))),
+            dtype(0.0),
         )
 
     def _dlog_beta(self, X):
@@ -235,18 +253,20 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`beta` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_bounds = (self.left_border < X) & (self.right_border >= X)
         return np.where(
             in_bounds,
             np.log(self.right_border - X)
             - np.log(self.right_border - self.left_border)
-            - (digamma(self.beta) - digamma(self.alpha + self.beta)),
-            0.0,
+            - (dtype(digamma(self.beta)) - dtype(digamma(self.alpha + self.beta))),
+            dtype(0.0),
         )
 
     def _dlog_left_border(self, X):
@@ -270,19 +290,21 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_bounds = (self.left_border < X) & (self.right_border >= X)
         return np.where(
             in_bounds,
             (
-                ((self.alpha + self.beta - 1) / (self.right_border - self.left_border))
-                - ((self.alpha - 1) / (X - self.left_border))
+                ((self.alpha + self.beta - dtype(1)) / (self.right_border - self.left_border))
+                - ((self.alpha - dtype(1)) / (X - self.left_border))
             ),
-            0.0,
+            dtype(0.0),
         )
 
     def _dlog_right_border(self, X):
@@ -306,18 +328,20 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_bounds = (self.left_border < X) & (self.right_border >= X)
         return np.where(
             in_bounds,
             (
-                ((self.beta - 1) / (self.right_border - X))
-                - ((self.alpha + self.beta - 1) / (self.right_border - self.left_border))
+                ((self.beta - dtype(1)) / (self.right_border - X))
+                - ((self.alpha + self.beta - dtype(1)) / (self.right_border - self.left_border))
             ),
-            0.0,
+            dtype(0.0),
         )
 
     def log_gradients(self, X):
@@ -332,13 +356,13 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_ALPHA: self._dlog_alpha,
@@ -350,7 +374,7 @@ class Beta(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -366,7 +390,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
@@ -374,7 +398,7 @@ class Beta(ContinuousDistribution):
             beta_dist.rvs(
                 self.alpha, self.beta, loc=self.left_border, scale=self.right_border - self.left_border, size=size
             ),
-            dtype=float64,
+            dtype=self.dtype,
         )
 
     def __repr__(self) -> str:

--- a/rework_pysatl_mpest/distributions/beta.py
+++ b/rework_pysatl_mpest/distributions/beta.py
@@ -109,10 +109,12 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
 
         """
+
         X = np.asarray(X, dtype=self.dtype)
         return np.exp(self.lpdf(X))
 
@@ -137,13 +139,16 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1),
             (
                 self.left_border
@@ -151,6 +156,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(np.nan),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -177,8 +186,9 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -189,7 +199,7 @@ class Beta(ContinuousDistribution):
         log_pdf_standard = beta_dist.logpdf(Z, self.alpha, self.beta).astype(dtype)
         result = log_pdf_standard - np.log(self.right_border - self.left_border)
 
-        return np.atleast_1d(result)
+        return result
 
     def _dlog_alpha(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`alpha` parameter.
@@ -214,21 +224,27 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`alpha` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             np.log(X - self.left_border)
             - np.log(self.right_border - self.left_border)
             - (dtype(digamma(self.alpha)) - dtype(digamma(self.alpha + self.beta))),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_beta(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`beta` parameter.
@@ -253,21 +269,27 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`beta` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             np.log(self.right_border - X)
             - np.log(self.right_border - self.left_border)
             - (dtype(digamma(self.beta)) - dtype(digamma(self.alpha + self.beta))),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_left_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`left_border` parameter.
@@ -290,15 +312,17 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             (
                 ((self.alpha + self.beta - dtype(1)) / (self.right_border - self.left_border))
@@ -306,6 +330,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_right_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`right_border` parameter.
@@ -328,14 +356,17 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_bounds = (self.left_border < X) & (self.right_border >= X)
-        return np.where(
+        result = np.where(
             in_bounds,
             (
                 ((self.beta - dtype(1)) / (self.right_border - X))
@@ -343,6 +374,10 @@ class Beta(ContinuousDistribution):
             ),
             dtype(0.0),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -361,7 +396,10 @@ class Beta(ContinuousDistribution):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -378,6 +416,8 @@ class Beta(ContinuousDistribution):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -270,7 +270,7 @@ class Cauchy(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Cauchy(loc=0.0, scale=2.0)".
+            "Cauchy(loc=0.0, scale=2.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(loc={self.loc}, scale={self.scale})"
+        return f"{self.__class__.__name__}(loc={self.loc}, scale={self.scale}, dtype=np.{self.dtype.__name__})"

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -82,14 +82,13 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        return dtype(1.0) / (dtype(np.pi) * self.scale * (dtype(1.0) + ((X - self.loc) / self.scale) ** 2))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -110,13 +109,16 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1),
             np.where(
                 (P == 0) | (P == 1),
@@ -125,6 +127,9 @@ class Cauchy(ContinuousDistribution[DType]):
             ),
             dtype(np.nan),
         )
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -145,8 +150,9 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -179,14 +185,20 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (dtype(2) * X - dtype(2) * self.loc) / (self.scale**2 + X**2 - dtype(2) * self.loc * X + self.loc**2)
+        result = (dtype(2) * X - dtype(2) * self.loc) / (self.scale**2 + X**2 - dtype(2) * self.loc * X + self.loc**2)
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -208,15 +220,22 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (-(self.scale**2) + X**2 - dtype(2) * self.loc * X + self.loc**2) / (
+        result = (-(self.scale**2) + X**2 - dtype(2) * self.loc * X + self.loc**2) / (
             self.scale**3 + self.scale * (X**2) - dtype(2) * self.loc * self.scale * X + self.scale * self.loc**2
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -235,7 +254,10 @@ class Cauchy(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -250,6 +272,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -155,15 +155,20 @@ class Cauchy(ContinuousDistribution[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return (
+        result = (
             np.log(dtype(1.0))
             - np.log(dtype(np.pi))
             - np.log(self.scale)
             - np.log(dtype(1.0) + ((X - self.loc) / self.scale) ** 2)
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -276,21 +281,28 @@ class Cauchy(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(cauchy.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = cauchy.rvs(loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -1,18 +1,19 @@
 """Module providing Cauchy distribution class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+
 import numpy as np
-from numpy import float64
 from scipy.stats import cauchy
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
-class Cauchy(ContinuousDistribution):
+class Cauchy(ContinuousDistribution[DType]):
     """Class for the two-parameter cauchy distribution.
 
     Parameters
@@ -49,8 +50,8 @@ class Cauchy(ContinuousDistribution):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0.0, "Scale parameter should be positive")
 
-    def __init__(self, loc: float, scale: float):
-        super().__init__()
+    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
 
@@ -81,12 +82,14 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return 1.0 / (np.pi * self.scale * (1.0 + ((X - self.loc) / self.scale) ** 2))
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return dtype(1.0) / (dtype(np.pi) * self.scale * (dtype(1.0) + ((X - self.loc) / self.scale) ** 2))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -107,18 +110,20 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
-        P = np.asarray(P, dtype=float64)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
+
         return np.where(
             (P >= 0) & (P <= 1),
             np.where(
                 (P == 0) | (P == 1),
-                np.where(P == 1, np.inf, -np.inf),
-                self.loc + self.scale * np.tan(np.pi * (P - 0.5)),
+                np.where(P == 1, dtype(np.inf), dtype(-np.inf)),
+                self.loc + self.scale * np.tan(dtype(np.pi) * (P - dtype(0.5))),
             ),
-            np.nan,
+            dtype(np.nan),
         )
 
     def lpdf(self, X):
@@ -140,11 +145,14 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
-        X = np.asarray(X, dtype=float64)
-        return np.log(1.0) - np.log(np.pi) - np.log(self.scale) - np.log(1.0 + ((X - self.loc) / self.scale) ** 2)
+
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.log(dtype(1.0)) - np.log(dtype(np.pi)) - np.log(self.scale) - np.log(dtype(1.0) + ((X - self.loc) / self.scale) ** 2)
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -166,12 +174,14 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return (2 * X - 2 * self.loc) / (self.scale**2 + X**2 - 2 * self.loc * X + self.loc**2)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return (dtype(2) * X - dtype(2) * self.loc) / (self.scale**2 + X**2 - dtype(2) * self.loc * X + self.loc**2)
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -193,12 +203,14 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
         """
-        X = np.asarray(X, dtype=float64)
-        return (-(self.scale**2) + X**2 - 2 * self.loc * X + self.loc**2) / (
-            self.scale**3 + self.scale * (X**2) - 2 * self.loc * self.scale * X + self.scale * self.loc**2
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return (-(self.scale**2) + X**2 - dtype(2) * self.loc * X + self.loc**2) / (
+            self.scale**3 + self.scale * (X**2) - dtype(2) * self.loc * self.scale * X + self.scale * self.loc**2
         )
 
     def log_gradients(self, X):
@@ -213,13 +225,13 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_LOC: self._dlog_loc,
@@ -229,7 +241,7 @@ class Cauchy(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -245,11 +257,11 @@ class Cauchy(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-        return np.asarray(cauchy.rvs(loc=self.loc, scale=self.scale, size=size), dtype=float64)
+        return np.asarray(cauchy.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/cauchy.py
+++ b/rework_pysatl_mpest/distributions/cauchy.py
@@ -152,7 +152,12 @@ class Cauchy(ContinuousDistribution[DType]):
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.log(dtype(1.0)) - np.log(dtype(np.pi)) - np.log(self.scale) - np.log(dtype(1.0) + ((X - self.loc) / self.scale) ** 2)
+        return (
+            np.log(dtype(1.0))
+            - np.log(dtype(np.pi))
+            - np.log(self.scale)
+            - np.log(dtype(1.0) + ((X - self.loc) / self.scale) ** 2)
+        )
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -8,7 +8,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic
+from typing import Generic, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -165,7 +165,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         return [getattr(self, name) for name in param_names]
 
-    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float]):
+    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[Union[float, DType]]):
         """Sets parameter values from a sequence of floats.
 
         Updates the distribution's parameters using values from the provided

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -8,12 +8,15 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Generic
 
-from numpy import float64
+import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ..typings import DType
 
-class ContinuousDistribution(ABC):
+
+class ContinuousDistribution(ABC, Generic[DType]):
     """Abstract base class for continuous distributions.
 
     This class defines the basic mathematical functions of distributions
@@ -48,6 +51,7 @@ class ContinuousDistribution(ABC):
         unfix_param
         get_params_vector
         set_params_from_vector
+        astype
 
     **Abstract methods**
 
@@ -84,12 +88,23 @@ class ContinuousDistribution(ABC):
 
     """
 
-    def __init__(self):
-        """The constructor must be called by all descendants for the
-        `fixed_params` attribute to be initialized.
+    _dtype: type[DType]
+
+    def __init__(self, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        """This constructor must be called by all descendants to ensure
+        proper initialization of common attributes like `fixed_params`
+        and `dtype`.
+
+        Parameters
+        ----------
+        dtype : Type[DType], optional
+            The numpy data type used for internal calculations and
+            output arrays (e.g., `np.float32` or `np.float64`).
+            Defaults to `np.float64`.
         """
 
         self._fixed_params: set[str] = set()
+        self._dtype = dtype
 
     def fix_param(self, name: str):
         """Fixes a parameter, excluding it from optimization and further changes.
@@ -123,7 +138,7 @@ class ContinuousDistribution(ABC):
 
         self._fixed_params.discard(name)
 
-    def get_params_vector(self, param_names: Sequence[str]) -> list[float]:
+    def get_params_vector(self, param_names: Sequence[str]) -> list[DType]:
         """Retrieves specified parameter values as a list.
 
         Parameters
@@ -155,7 +170,10 @@ class ContinuousDistribution(ABC):
 
         Updates the distribution's parameters using values from the provided
         sequence. The order of values in the :attr:`vector` must correspond to the order
-        of names in :attr:`param_names`.
+        of names in :attr:`param_names`. This vector can contain
+        standard numerical types like `int` or `float`. Internally, each
+        value is automatically cast to the distribution's specific `dtype`
+        (e.g., `numpy.float32` or `numpy.float64`)
 
         Parameters
         ----------
@@ -179,7 +197,12 @@ class ContinuousDistribution(ABC):
             raise ValueError(f"Invalid parameter names provided: {invalid_params}")
 
         for name, value in zip(param_names, vector):
-            setattr(self, name, value)
+            setattr(self, name, self.dtype(value))
+
+    @property
+    def dtype(self) -> type[DType]:
+        """type[DType]: The numpy data type of the distribution's outputs."""
+        return self._dtype
 
     @property
     @abstractmethod
@@ -198,7 +221,7 @@ class ContinuousDistribution(ABC):
         return self.params - self._fixed_params
 
     @abstractmethod
-    def pdf(self, X: ArrayLike) -> NDArray[float64]:
+    def pdf(self, X: ArrayLike) -> NDArray[DType]:
         """Probability Density Function.
 
         Parameters
@@ -208,12 +231,12 @@ class ContinuousDistribution(ABC):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
     @abstractmethod
-    def ppf(self, P: ArrayLike) -> NDArray[float64]:
+    def ppf(self, P: ArrayLike) -> NDArray[DType]:
         """Percent Point Function (PPF) or quantile function.
 
         This is the inverse of the Cumulative Distribution Function (CDF).
@@ -226,12 +249,12 @@ class ContinuousDistribution(ABC):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
 
     @abstractmethod
-    def lpdf(self, X: ArrayLike) -> NDArray[float64]:
+    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
         """Logarithm of the Probability Density Function.
 
         Evaluating the log-PDF is often more numerically stable than
@@ -245,12 +268,12 @@ class ContinuousDistribution(ABC):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
     @abstractmethod
-    def log_gradients(self, X: ArrayLike) -> NDArray[float64]:
+    def log_gradients(self, X: ArrayLike) -> NDArray[DType]:
         """Calculates the gradients of the log-PDF with respect to its parameters.
 
         The gradients are computed for the parameters that are not fixed.
@@ -262,7 +285,7 @@ class ContinuousDistribution(ABC):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X` and
             each column corresponds to the gradient with respect to a specific
             optimizable parameter. The order of columns corresponds to the
@@ -270,7 +293,7 @@ class ContinuousDistribution(ABC):
         """
 
     @abstractmethod
-    def generate(self, size: int) -> NDArray[float64]:
+    def generate(self, size: int) -> NDArray[DType]:
         """Generates random samples from the distribution.
 
         Parameters
@@ -280,21 +303,49 @@ class ContinuousDistribution(ABC):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-    def __copy__(self) -> "ContinuousDistribution":
+    def astype(self, new_dtype: type[DType]) -> "ContinuousDistribution[DType]":
+        """Creates a copy of the distribution with a new data type.
+
+        If the specified `new_dtype` is the same as the instance's current `dtype`,
+        this method returns the original instance instead.
+
+        Parameters
+        ----------
+        new_dtype : type[DType]
+            The target NumPy data type for the new distribution instance.
+
+        Returns
+        -------
+        ContinuousDistribution[DType]
+            A new distribution instance with all parameters converted to the
+            specified `new_dtype`, or the original instance if the `dtype` is
+            unchanged.
+        """
+        if self._dtype is new_dtype:
+            return self
+
+        params_dict = {p: new_dtype(getattr(self, p)) for p in self.params}
+
+        new_instance = self.__class__(**params_dict, dtype=new_dtype)
+        new_instance._fixed_params = self._fixed_params.copy()
+
+        return new_instance
+
+    def __copy__(self) -> "ContinuousDistribution[DType]":
         """Creates a copy of the distribution instance.
 
         Returns
         -------
-        ContinuousDistribution
+        ContinuousDistribution[DType]
             A new instance of the distribution, identical to the original.
         """
         params_dict = {p: getattr(self, p) for p in self.params}
 
-        new_instance = self.__class__(**params_dict)
+        new_instance = self.__class__(**params_dict, dtype=self.dtype)
         new_instance._fixed_params = self._fixed_params.copy()
 
         return new_instance
@@ -327,6 +378,7 @@ class ContinuousDistribution(ABC):
             self.name == other.name
             and self.params == other.params
             and self.get_params_vector(sorted_params) == other.get_params_vector(sorted_params)
+            and self.dtype == other.dtype
         )
 
     def __hash__(self) -> int:
@@ -343,4 +395,4 @@ class ContinuousDistribution(ABC):
         sorted_params = sorted(list(self.params))
         param_values = tuple(self.get_params_vector(sorted_params))
 
-        return hash(tuple([self.name, tuple(self.params), param_values]))
+        return hash(tuple([self.name, tuple(self.params), self.dtype, param_values]))

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -202,6 +202,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
     @property
     def dtype(self) -> type[DType]:
         """type[DType]: The numpy data type of the distribution's outputs."""
+
         return self._dtype
 
     @property
@@ -221,7 +222,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         return self.params - self._fixed_params
 
     @abstractmethod
-    def pdf(self, X: ArrayLike) -> NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
         """Probability Density Function.
 
         Parameters
@@ -231,8 +232,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -249,8 +251,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -268,8 +271,9 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
@@ -325,6 +329,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
+
         if self._dtype is new_dtype:
             return self
 
@@ -343,6 +348,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         ContinuousDistribution[DType]
             A new instance of the distribution, identical to the original.
         """
+
         params_dict = {p: getattr(self, p) for p in self.params}
 
         new_instance = self.__class__(**params_dict, dtype=self.dtype)
@@ -366,6 +372,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         bool
             True if the distributions are equal, False otherwise.
         """
+
         if not isinstance(other, ContinuousDistribution):
             return NotImplemented
 
@@ -392,6 +399,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         int
             The hash value of the distribution object.
         """
+
         sorted_params = sorted(list(self.params))
         param_values = tuple(self.get_params_vector(sorted_params))
 

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -297,18 +297,21 @@ class ContinuousDistribution(ABC, Generic[DType]):
         """
 
     @abstractmethod
-    def generate(self, size: int) -> NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
     def astype(self, new_dtype: type[DType]) -> "ContinuousDistribution[DType]":

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -87,9 +87,7 @@ class Exponential(ContinuousDistribution[DType]):
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        return np.where(self.loc <= X, self.rate * np.exp(-self.rate * (X - self.loc)), dtype(0.0))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -107,14 +105,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.loc - np.log(dtype(1) - P) / self.rate, dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), self.loc - np.log(dtype(1) - P) / self.rate, dtype(np.nan))
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -132,14 +135,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), dtype(-np.inf))
+        result = np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), dtype(-np.inf))
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -159,14 +167,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.loc <= X, self.rate, dtype(0.0))
+        result = np.where(self.loc <= X, self.rate, dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_rate(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`rate` parameter.
@@ -186,13 +199,19 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
-        return np.where(self.loc <= X, dtype(1.0) / self.rate - (X - self.loc), dtype(0.0))
+
+        result = np.where(self.loc <= X, dtype(1.0) / self.rate - (X - self.loc), dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -211,8 +230,10 @@ class Exponential(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -227,6 +248,8 @@ class Exponential(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -1,19 +1,19 @@
 """Module providing exponential distribution class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 import numpy as np
-from numpy import float64
 from scipy.stats import expon
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
-class Exponential(ContinuousDistribution):
+class Exponential(ContinuousDistribution[DType]):
     """Class for the two-parameter exponential distribution.
 
     Parameters
@@ -50,8 +50,8 @@ class Exponential(ContinuousDistribution):
     loc = Parameter()
     rate = Parameter(lambda x: x > 0, "Rate parameter must be a positive")
 
-    def __init__(self, loc: float, rate: float):
-        super().__init__()
+    def __init__(self, loc: float, rate: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         self.loc = loc
         self.rate = rate
 
@@ -82,13 +82,14 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
 
-        return np.where(self.loc <= X, self.rate * np.exp(-self.rate * (X - self.loc)), 0.0)
+        return np.where(self.loc <= X, self.rate * np.exp(-self.rate * (X - self.loc)), dtype(0.0))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -106,13 +107,14 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
 
-        P = np.asarray(P, dtype=float64)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.loc - np.log(1 - P) / self.rate, np.nan)
+        return np.where((P >= 0) & (P <= 1), self.loc - np.log(dtype(1) - P) / self.rate, dtype(np.nan))
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -130,12 +132,14 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), -np.inf)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.where(self.loc <= X, np.log(self.rate) - self.rate * (X - self.loc), dtype(-np.inf))
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`loc` parameter.
@@ -155,12 +159,14 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return np.where(self.loc <= X, self.rate, 0.0)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.where(self.loc <= X, self.rate, dtype(0.0))
 
     def _dlog_rate(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`rate` parameter.
@@ -180,12 +186,13 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return np.where(self.loc <= X, 1.0 / self.rate - (X - self.loc), 0.0)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+        return np.where(self.loc <= X, dtype(1.0) / self.rate - (X - self.loc), dtype(0.0))
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -199,14 +206,14 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_LOC: self._dlog_loc,
@@ -216,7 +223,7 @@ class Exponential(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -232,11 +239,11 @@ class Exponential(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-        return np.asarray(expon.rvs(loc=self.loc, scale=1 / self.rate, size=size), dtype=float64)
+        return np.asarray(expon.rvs(loc=self.loc, scale=1 / self.rate, size=size), dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -252,21 +252,28 @@ class Exponential(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(expon.rvs(loc=self.loc, scale=1 / self.rate, size=size), dtype=self.dtype)
+        samples = expon.rvs(loc=self.loc, scale=1 / self.rate, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/exponential.py
+++ b/rework_pysatl_mpest/distributions/exponential.py
@@ -252,7 +252,7 @@ class Exponential(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Exponential(loc=0.0, rate=2.0)".
+            "Exponential(loc=0.0, rate=2.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(loc={self.loc}, rate={self.rate})"
+        return f"{self.__class__.__name__}(loc={self.loc}, rate={self.rate}, dtype=np.{self.dtype.__name__})"

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -83,15 +83,13 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-        return np.exp(-(z**2) / dtype(2.0)) / (self.scale * np.sqrt(dtype(2.0) * dtype(np.pi)))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -107,13 +105,17 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         result = norm.ppf(P, loc=self.loc, scale=self.scale)
 
+        if is_scalar:
+            return self.dtype(result)
         return np.asarray(result, dtype=self.dtype)
 
     def lpdf(self, X):
@@ -133,8 +135,9 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
@@ -173,8 +176,10 @@ class Normal(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -188,6 +193,9 @@ class Normal(ContinuousDistribution[DType]):
             return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
+
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -1,18 +1,19 @@
 """Module providing normal (Gaussian) distribution class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+
 import numpy as np
-from numpy import float64
 from scipy.stats import norm
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
-class Normal(ContinuousDistribution):
+class Normal(ContinuousDistribution[DType]):
     """Class for the Normal (Gaussian) distribution.
 
     Parameters
@@ -49,8 +50,8 @@ class Normal(ContinuousDistribution):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, loc: float, scale: float):
-        super().__init__()
+    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
 
@@ -82,13 +83,15 @@ class Normal(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
-        return np.exp(-(z**2) / 2.0) / (self.scale * np.sqrt(2.0 * np.pi))
+        return np.exp(-(z**2) / dtype(2.0)) / (self.scale * np.sqrt(dtype(2.0) * dtype(np.pi)))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -104,12 +107,14 @@ class Normal(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
 
-        P = np.asarray(P, dtype=float64)
-        return norm.ppf(P, loc=self.loc, scale=self.scale)
+        P = np.asarray(P, dtype=self.dtype)
+        result = norm.ppf(P, loc=self.loc, scale=self.scale)
+
+        return np.asarray(result, dtype=self.dtype)
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -128,26 +133,30 @@ class Normal(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
-        return -np.log(self.scale) - 0.5 * np.log(2.0 * np.pi) - 0.5 * z**2
+        return -np.log(self.scale) - dtype(0.5) * np.log(dtype(2.0) * dtype(np.pi)) - dtype(0.5) * z**2
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
         return (X - self.loc) / (self.scale**2)
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z_sq = ((X - self.loc) / self.scale) ** 2
-        return (z_sq - 1.0) / self.scale
+        return (z_sq - dtype(1.0)) / self.scale
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -159,14 +168,14 @@ class Normal(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_LOC: self._dlog_loc,
@@ -176,7 +185,7 @@ class Normal(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
         return np.stack(gradients, axis=1)
@@ -193,11 +202,11 @@ class Normal(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-        return np.asarray(norm.rvs(loc=self.loc, scale=self.scale, size=size), dtype=float64)
+        return np.asarray(norm.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -140,26 +140,41 @@ class Normal(ContinuousDistribution[DType]):
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
-        return -np.log(self.scale) - dtype(0.5) * np.log(dtype(2.0) * dtype(np.pi)) - dtype(0.5) * z**2
+        result = -np.log(self.scale) - dtype(0.5) * np.log(dtype(2.0) * dtype(np.pi)) - dtype(0.5) * z**2
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
-        return (X - self.loc) / (self.scale**2)
+        result = (X - self.loc) / (self.scale**2)
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z_sq = ((X - self.loc) / self.scale) ** 2
-        return (z_sq - dtype(1.0)) / self.scale
+        result = (z_sq - dtype(1.0)) / self.scale
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -198,23 +213,30 @@ class Normal(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         This implementation relies on `scipy.stats.norm.rvs`.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(norm.rvs(loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = norm.rvs(loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/normal.py
+++ b/rework_pysatl_mpest/distributions/normal.py
@@ -215,7 +215,7 @@ class Normal(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Normal(loc=0.0, scale=1.0)".
+            "Normal(loc=0.0, scale=1.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(loc={self.loc}, scale={self.scale})"
+        return f"{self.__class__.__name__}(loc={self.loc}, scale={self.scale}, dtype=np.{self.dtype.__name__})"

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -1,19 +1,19 @@
 """Module providing pareto type 1 distribution class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 import numpy as np
-from numpy import float64
 from scipy.stats import pareto
 
-from rework_pysatl_mpest.core.parameter import Parameter
-from rework_pysatl_mpest.distributions.continuous_dist import ContinuousDistribution
+from ..core.parameter import Parameter
+from ..distributions.continuous_dist import ContinuousDistribution
+from ..typings import DType
 
 
-class Pareto(ContinuousDistribution):
+class Pareto(ContinuousDistribution[DType]):
     """Class for the two-parameter Pareto distribution.
 
     The Pareto distribution is a power-law probability distribution commonly used
@@ -53,8 +53,8 @@ class Pareto(ContinuousDistribution):
     shape = Parameter(lambda x: x > 0, "Shape parameter must be a positive")
     scale = Parameter(lambda x: x > 0, "Scale parameter must be a positive")
 
-    def __init__(self, shape: float, scale: float):
-        super().__init__()
+    def __init__(self, shape: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         self.shape = shape
         self.scale = scale
 
@@ -78,9 +78,12 @@ class Pareto(ContinuousDistribution):
         where :math:`\\alpha` is the :attr:`shape` parameter and :math:`\\beta` is the
         :attr:`scale` parameter. The function is zero for :math:`x < \\beta`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
 
-        return np.where(self.scale <= X, (self.shape * (self.scale**self.shape)) / X ** (self.shape + 1), 0.0)
+        return np.where(
+            self.scale <= X, (self.shape * (self.scale**self.shape)) / X ** (self.shape + dtype(1)), dtype(0.0)
+        )
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -98,13 +101,14 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
 
-        P = np.asarray(P, dtype=float64)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.scale * (1 - P) ** (-1.0 / self.shape), np.nan)
+        return np.where((P >= 0) & (P <= 1), self.scale * (dtype(1) - P) ** (dtype(-1.0) / self.shape), dtype(np.nan))
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -125,15 +129,17 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         return np.where(
             self.scale <= X,
-            np.log(self.shape) + self.shape * np.log(self.scale) - (1 + self.shape) * np.log(X),
-            -np.inf,
+            np.log(self.shape) + self.shape * np.log(self.scale) - (dtype(1) + self.shape) * np.log(X),
+            dtype(-np.inf),
         )
 
     def _dlog_shape(self, X):
@@ -144,7 +150,7 @@ class Pareto(ContinuousDistribution):
         .. math::
 
             \\frac{\\partial \\ln f(x | \\alpha, \\beta)}{\\partial \\alpha} =
-            \\ln \\beta - \\ln x
+            \\frac{1}{\\alpha} + \\ln \\beta - \\ln x
 
         where :math:`\\alpha` is the :attr:`shape` parameter and :math:`\\beta` is the
         :attr:`scale` parameter.
@@ -156,12 +162,14 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`shape` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return np.where(self.scale <= X, 1.0 / self.shape + np.log(self.scale) - np.log(X), 0.0)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.where(self.scale <= X, dtype(1.0) / self.shape + np.log(self.scale) - np.log(X), dtype(0.0))
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -182,12 +190,14 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
-        return np.where(self.scale <= X, self.shape / self.scale, 0.0)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.where(self.scale <= X, self.shape / self.scale, dtype(0.0))
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -201,14 +211,14 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_SHAPE: self._dlog_shape,
@@ -218,7 +228,7 @@ class Pareto(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -234,11 +244,11 @@ class Pareto(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-        return np.asarray(pareto.rvs(scale=self.scale, b=self.shape, size=size), dtype=float64)
+        return np.asarray(pareto.rvs(scale=self.scale, b=self.shape, size=size), dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -77,13 +77,21 @@ class Pareto(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the :attr:`shape` parameter and :math:`\\beta` is the
         :attr:`scale` parameter. The function is zero for :math:`x < \\beta`.
-        """
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
 
-        return np.where(
-            self.scale <= X, (self.shape * (self.scale**self.shape)) / X ** (self.shape + dtype(1)), dtype(0.0)
-        )
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points at which to evaluate the PDF.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
+        """
+
+        X = np.asarray(X, dtype=self.dtype)
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -101,14 +109,20 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where((P >= 0) & (P <= 1), self.scale * (dtype(1) - P) ** (dtype(-1.0) / self.shape), dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), self.scale * (dtype(1) - P) ** (dtype(-1.0) / self.shape), dtype(np.nan))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -129,18 +143,24 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             self.scale <= X,
             np.log(self.shape) + self.shape * np.log(self.scale) - (dtype(1) + self.shape) * np.log(X),
             dtype(-np.inf),
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_shape(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`shape` parameter.
@@ -162,14 +182,20 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`shape` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.scale <= X, dtype(1.0) / self.shape + np.log(self.scale) - np.log(X), dtype(0.0))
+        result = np.where(self.scale <= X, dtype(1.0) / self.shape + np.log(self.scale) - np.log(X), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`scale` parameter.
@@ -190,14 +216,19 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(self.scale <= X, self.shape / self.scale, dtype(0.0))
+        result = np.where(self.scale <= X, self.shape / self.scale, dtype(0.0))
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -216,8 +247,10 @@ class Pareto(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -232,6 +265,8 @@ class Pareto(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -269,21 +269,28 @@ class Pareto(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(pareto.rvs(scale=self.scale, b=self.shape, size=size), dtype=self.dtype)
+        samples = pareto.rvs(scale=self.scale, b=self.shape, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/pareto.py
+++ b/rework_pysatl_mpest/distributions/pareto.py
@@ -257,7 +257,7 @@ class Pareto(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Pareto(shape=0.0, scale=2.0)".
+            "Pareto(shape=0.0, scale=2.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(shape={self.shape}, scale={self.scale})"
+        return f"{self.__class__.__name__}(shape={self.shape}, scale={self.scale}, dtype=np.{self.dtype.__name__})"

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -97,17 +97,13 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
 
-        return np.where(
-            (self.left_border <= X) & (self.right_border >= X),
-            dtype(1.0) / (self.right_border - self.left_border),
-            dtype(0.0),
-        )
+        X = np.asarray(X, dtype=self.dtype)
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -128,15 +124,22 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
-        return np.where(
+        result = np.where(
             (P >= 0) & (P <= 1), self.left_border + P * (self.right_border - self.left_border), dtype(np.nan)
         )
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -158,15 +161,22 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
         valid_dist = self.right_border > self.left_border
-        return np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), dtype(-np.inf))
+        result = np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), dtype(-np.inf))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_left_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`left_border` parameter.
@@ -177,13 +187,29 @@ class Uniform(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the left_border parameter and :math:`\\beta` is the
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
+
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, dtype(1.0) / (self.right_border - self.left_border), dtype(0.0))
+        result = np.where(in_range, dtype(1.0) / (self.right_border - self.left_border), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_right_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`right_border` parameter.
@@ -194,13 +220,29 @@ class Uniform(ContinuousDistribution[DType]):
 
         where :math:`\\alpha` is the left_border parameter and :math:`\\beta` is the
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
+
+        Parameters
+        ----------
+        X : ArrayLike
+            The input data points.
+
+        Returns
+        -------
+        DType | NDArray[DType]
+            The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, dtype(-1.0) / (self.right_border - self.left_border), dtype(0.0))
+        result = np.where(in_range, dtype(-1.0) / (self.right_border - self.left_border), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -219,8 +261,10 @@ class Uniform(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -235,6 +279,8 @@ class Uniform(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.asarray(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -1,18 +1,19 @@
 """Module providing uniform distribution class"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+
 import numpy as np
-from numpy import float64
 from scipy.stats import uniform
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
-class Uniform(ContinuousDistribution):
+class Uniform(ContinuousDistribution[DType]):
     """
     The Uniform continuous probability distribution.
 
@@ -59,8 +60,8 @@ class Uniform(ContinuousDistribution):
     left_border = Parameter()
     right_border = Parameter()
 
-    def __init__(self, left_border: float, right_border: float):
-        super().__init__()
+    def __init__(self, left_border: float, right_border: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         if left_border >= right_border:
             raise ValueError("right_border parameter must be strictly greater than left_border")
         if not (np.isfinite(left_border) and np.isfinite(right_border)):
@@ -99,9 +100,13 @@ class Uniform(ContinuousDistribution):
         NDArray[np.float64]
             The PDF values corresponding to each point in :attr:`X`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         return np.where(
-            (self.left_border <= X) & (self.right_border >= X), 1.0 / (self.right_border - self.left_border), 0.0
+            (self.left_border <= X) & (self.right_border >= X),
+            dtype(1.0) / (self.right_border - self.left_border),
+            dtype(0.0),
         )
 
     def ppf(self, P):
@@ -126,8 +131,12 @@ class Uniform(ContinuousDistribution):
         NDArray[np.float64]
             The PPF values corresponding to each probability in :attr:`P`.
         """
-        P = np.asarray(P, dtype=float64)
-        return np.where((P >= 0) & (P <= 1), self.left_border + P * (self.right_border - self.left_border), np.nan)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
+
+        return np.where(
+            (P >= 0) & (P <= 1), self.left_border + P * (self.right_border - self.left_border), dtype(np.nan)
+        )
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -152,10 +161,12 @@ class Uniform(ContinuousDistribution):
         NDArray[np.float64]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_range = (self.left_border <= X) & (self.right_border >= X)
         valid_dist = self.right_border > self.left_border
-        return np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), -np.inf)
+        return np.where(in_range & valid_dist, -np.log(self.right_border - self.left_border), dtype(-np.inf))
 
     def _dlog_left_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`left_border` parameter.
@@ -168,9 +179,11 @@ class Uniform(ContinuousDistribution):
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, 1.0 / (self.right_border - self.left_border), 0.0)
+        return np.where(in_range, dtype(1.0) / (self.right_border - self.left_border), dtype(0.0))
 
     def _dlog_right_border(self, X):
         """Partial derivative of the lpdf w.r.t. the :attr:`right_border` parameter.
@@ -183,9 +196,11 @@ class Uniform(ContinuousDistribution):
         right_border parameter. The derivative is non-zero only for `left_border <= X <= right_border`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         in_range = (self.left_border <= X) & (self.right_border >= X)
-        return np.where(in_range, -1.0 / (self.right_border - self.left_border), 0.0)
+        return np.where(in_range, dtype(-1.0) / (self.right_border - self.left_border), dtype(0.0))
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -206,7 +221,7 @@ class Uniform(ContinuousDistribution):
             to the sorted order of :attr:`self.params_to_optimize`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.LEFT_BORDER: self._dlog_left_border,
@@ -216,7 +231,7 @@ class Uniform(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -237,7 +252,7 @@ class Uniform(ContinuousDistribution):
         """
 
         return np.asarray(
-            uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size), dtype=float64
+            uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size), dtype=self.dtype
         )
 
     def __repr__(self) -> str:

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -262,7 +262,10 @@ class Uniform(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Uniform(left_border=0.0, right_border=2.0)".
+            "Uniform(left_border=0.0, right_border=2.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(left_border={self.left_border}, right_border={self.right_border})"
+        return (
+            f"{self.__class__.__name__}(left_border={self.left_border}, "
+            f"right_border={self.right_border}, dtype=np.{self.dtype.__name__})"
+        )

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -283,23 +283,28 @@ class Uniform(ContinuousDistribution[DType]):
             return np.asarray(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(
-            uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size), dtype=self.dtype
-        )
+        samples = uniform.rvs(loc=self.left_border, scale=self.right_border - self.left_border, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/uniform.py
+++ b/rework_pysatl_mpest/distributions/uniform.py
@@ -97,7 +97,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
         X = np.asarray(X, dtype=self.dtype)
@@ -128,7 +128,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
         P = np.asarray(P, dtype=self.dtype)
@@ -158,7 +158,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
         X = np.asarray(X, dtype=self.dtype)
@@ -214,7 +214,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -247,7 +247,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -91,21 +91,13 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
         X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-
-        # PDF is 0 for x < loc, and handle cases where z=0 and shape<1
-        # which would lead to division by zero.
-        with np.errstate(divide="ignore", invalid="ignore"):
-            pdf_vals = (self.shape / self.scale) * np.power(z, self.shape - dtype(1)) * np.exp(-np.power(z, self.shape))
-
-        return np.where(self.loc <= X, np.nan_to_num(pdf_vals, nan=dtype(0.0), posinf=dtype(np.inf)), dtype(0.0))
+        return np.exp(self.lpdf(X))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -124,15 +116,21 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
+        is_scalar = np.isscalar(P)
         P = np.asarray(P, dtype=self.dtype)
         dtype = self.dtype
 
         ppf_vals = self.loc + self.scale * np.power(-np.log(dtype(1) - P), dtype(1.0) / self.shape)
-        return np.where((P >= 0) & (P <= 1), ppf_vals, dtype(np.nan))
+        result = np.where((P >= 0) & (P <= 1), ppf_vals, dtype(np.nan))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -152,34 +150,55 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        DType | NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
+            Return a scalar when given a scalar, and to return an array when given an array.
         """
 
-        X = np.asarray(X, dtype=self.dtype)
-        dtype = self.dtype
-
-        z = (X - self.loc) / self.scale
-        with np.errstate(divide="ignore"):
-            lpdf_vals = (
-                np.log(self.shape) - np.log(self.scale) + (self.shape - dtype(1)) * np.log(z) - np.power(z, self.shape)
-            )
-        return np.where(self.loc < X, lpdf_vals, dtype(-np.inf))
-
-    def _dlog_shape(self, X):
-        """Partial derivative of the lpdf w.r.t. the shape parameter."""
-
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
         with np.errstate(divide="ignore", invalid="ignore"):
-            grad = dtype(1.0) / self.shape + np.log(z) - np.power(z, self.shape) * np.log(z)
-        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+            # Handle potential NaN from 0 * -inf when shape=1 and z=0
+            # This term's limit is 0, so we replace NaN with 0.
+            lpdf_vals = (
+                np.log(self.shape)
+                - np.log(self.scale)
+                + np.nan_to_num((self.shape - dtype(1)) * np.log(z), nan=dtype(0.0))
+                - np.power(z, self.shape)
+            )
+        result = np.where(self.loc < X, lpdf_vals, dtype(-np.inf))
+
+        if is_scalar:
+            return result[()]
+        return result
+
+    def _dlog_shape(self, X):
+        """Partial derivative of the lpdf w.r.t. the shape parameter."""
+
+        is_scalar = np.isscalar(X)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
+        z = (X - self.loc) / self.scale
+        with np.errstate(divide="ignore", invalid="ignore"):
+            # Handle z^k * ln(z), which -> 0 as z -> 0.
+            # This prevents NaN from 0 * -inf.
+            grad = (
+                dtype(1.0) / self.shape + np.log(z) - np.nan_to_num(np.power(z, self.shape) * np.log(z), nan=dtype(0.0))
+            )
+        result = np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
@@ -188,17 +207,26 @@ class Weibull(ContinuousDistribution[DType]):
             grad = -(self.shape - dtype(1)) / (X - self.loc) + (self.shape / self.scale) * np.power(
                 z, self.shape - dtype(1)
             )
-        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+        result = np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
         dtype = self.dtype
 
         z = (X - self.loc) / self.scale
         grad = -self.shape / self.scale + (self.shape / self.scale) * np.power(z, self.shape)
-        return np.where(self.loc < X, grad, dtype(0.0))
+        result = np.where(self.loc < X, grad, dtype(0.0))
+
+        if is_scalar:
+            return result[()]
+        return result
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -215,7 +243,10 @@ class Weibull(ContinuousDistribution[DType]):
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
+            Returns a 1D array if X is a scalar.
         """
+
+        is_scalar = np.isscalar(X)
         X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
@@ -231,6 +262,8 @@ class Weibull(ContinuousDistribution[DType]):
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
+        if is_scalar:
+            return np.array(gradients)
         return np.stack(gradients, axis=1)
 
     def generate(self, size: int):

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -256,7 +256,10 @@ class Weibull(ContinuousDistribution[DType]):
         -------
         str
             A string that can be used to recreate the object, e.g.,
-            "Weibull(shape=2.0, loc=0.0, scale=1.0)".
+            "Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=np.float64)".
         """
 
-        return f"{self.__class__.__name__}(shape={self.shape}, loc={self.loc}, scale={self.scale})"
+        return (
+            f"{self.__class__.__name__}(shape={self.shape}, "
+            f"loc={self.loc}, scale={self.scale}, dtype=np.{self.dtype.__name__})"
+        )

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -1,19 +1,19 @@
 """Module providing three-parametric weibull distribution class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 import numpy as np
-from numpy import float64
 from scipy.stats import weibull_min
 
 from ..core import Parameter
+from ..typings import DType
 from .continuous_dist import ContinuousDistribution
 
 
-class Weibull(ContinuousDistribution):
+class Weibull(ContinuousDistribution[DType]):
     """Class for the three-parameter Weibull distribution.
 
     Parameters
@@ -55,8 +55,8 @@ class Weibull(ContinuousDistribution):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, shape: float, loc: float, scale: float):
-        super().__init__()
+    def __init__(self, shape: float, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+        super().__init__(dtype=dtype)
         self.shape = shape
         self.loc = loc
         self.scale = scale
@@ -91,19 +91,21 @@ class Weibull(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
 
         # PDF is 0 for x < loc, and handle cases where z=0 and shape<1
         # which would lead to division by zero.
         with np.errstate(divide="ignore", invalid="ignore"):
-            pdf_vals = (self.shape / self.scale) * np.power(z, self.shape - 1) * np.exp(-np.power(z, self.shape))
+            pdf_vals = (self.shape / self.scale) * np.power(z, self.shape - dtype(1)) * np.exp(-np.power(z, self.shape))
 
-        return np.where(self.loc <= X, np.nan_to_num(pdf_vals, nan=0.0, posinf=np.inf), 0.0)
+        return np.where(self.loc <= X, np.nan_to_num(pdf_vals, nan=dtype(0.0), posinf=dtype(np.inf)), dtype(0.0))
 
     def ppf(self, P):
         """Percent Point Function (PPF) or quantile function.
@@ -122,13 +124,15 @@ class Weibull(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The PPF values corresponding to each probability in :attr:`P`.
         """
 
-        P = np.asarray(P, dtype=float64)
-        ppf_vals = self.loc + self.scale * np.power(-np.log(1 - P), 1.0 / self.shape)
-        return np.where((P >= 0) & (P <= 1), ppf_vals, np.nan)
+        P = np.asarray(P, dtype=self.dtype)
+        dtype = self.dtype
+
+        ppf_vals = self.loc + self.scale * np.power(-np.log(dtype(1) - P), dtype(1.0) / self.shape)
+        return np.where((P >= 0) & (P <= 1), ppf_vals, dtype(np.nan))
 
     def lpdf(self, X):
         """Log of the Probability Density Function (LPDF).
@@ -148,41 +152,53 @@ class Weibull(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             The log-PDF values corresponding to each point in :attr:`X`.
         """
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
         with np.errstate(divide="ignore"):
-            lpdf_vals = np.log(self.shape) - np.log(self.scale) + (self.shape - 1) * np.log(z) - np.power(z, self.shape)
-        return np.where(self.loc < X, lpdf_vals, -np.inf)
+            lpdf_vals = (
+                np.log(self.shape) - np.log(self.scale) + (self.shape - dtype(1)) * np.log(z) - np.power(z, self.shape)
+            )
+        return np.where(self.loc < X, lpdf_vals, dtype(-np.inf))
 
     def _dlog_shape(self, X):
         """Partial derivative of the lpdf w.r.t. the shape parameter."""
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
         with np.errstate(divide="ignore", invalid="ignore"):
-            grad = 1.0 / self.shape + np.log(z) - np.power(z, self.shape) * np.log(z)
-        return np.where(self.loc < X, np.nan_to_num(grad), 0.0)
+            grad = dtype(1.0) / self.shape + np.log(z) - np.power(z, self.shape) * np.log(z)
+        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
 
     def _dlog_loc(self, X):
         """Partial derivative of the lpdf w.r.t. the loc parameter."""
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
         with np.errstate(divide="ignore", invalid="ignore"):
-            grad = -(self.shape - 1) / (X - self.loc) + (self.shape / self.scale) * np.power(z, self.shape - 1)
-        return np.where(self.loc < X, np.nan_to_num(grad), 0.0)
+            grad = -(self.shape - dtype(1)) / (X - self.loc) + (self.shape / self.scale) * np.power(
+                z, self.shape - dtype(1)
+            )
+        return np.where(self.loc < X, np.nan_to_num(grad), dtype(0.0))
 
     def _dlog_scale(self, X):
         """Partial derivative of the lpdf w.r.t. the scale parameter."""
 
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
+        dtype = self.dtype
+
         z = (X - self.loc) / self.scale
         grad = -self.shape / self.scale + (self.shape / self.scale) * np.power(z, self.shape)
-        return np.where(self.loc < X, grad, 0.0)
+        return np.where(self.loc < X, grad, dtype(0.0))
 
     def log_gradients(self, X):
         """Calculates the gradients of the log-PDF w.r.t. its parameters.
@@ -194,13 +210,13 @@ class Weibull(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
             to the sorted order of :attr:`self.params_to_optimize`.
         """
-        X = np.asarray(X, dtype=float64)
+        X = np.asarray(X, dtype=self.dtype)
 
         gradient_calculators = {
             self.PARAM_SHAPE: self._dlog_shape,
@@ -211,7 +227,7 @@ class Weibull(ContinuousDistribution):
         optimizable_params = sorted(list(self.params_to_optimize))
 
         if not optimizable_params:
-            return np.empty((len(X), 0))
+            return np.empty((len(X), 0), dtype=self.dtype)
 
         gradients = [gradient_calculators[param](X) for param in optimizable_params]
 
@@ -227,11 +243,11 @@ class Weibull(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[np.float64]
+        NDArray[DType]
             A NumPy array containing the generated samples.
         """
 
-        return np.asarray(weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size), dtype=float64)
+        return np.asarray(weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/distributions/weibull.py
+++ b/rework_pysatl_mpest/distributions/weibull.py
@@ -266,21 +266,28 @@ class Weibull(ContinuousDistribution[DType]):
             return np.array(gradients)
         return np.stack(gradients, axis=1)
 
-    def generate(self, size: int):
+    def generate(self, size: int | tuple[int, ...] | None = None):
         """Generates random samples from the distribution.
 
         Parameters
         ----------
-        size : int
-            The number of random samples to generate.
+        size : int | tuple[int, ...] | None, optional
+            Defining number of random variates.
+            - If None (default), returns a single scalar.
+            - If int, returns a 1D array of that length.
+            - If tuple, returns an array of that shape.
 
         Returns
         -------
-        NDArray[DType]
-            A NumPy array containing the generated samples.
+        DType | NDArray[DType]
+            A scalar or NumPy array containing the generated samples.
         """
 
-        return np.asarray(weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size), dtype=self.dtype)
+        samples = weibull_min.rvs(c=self.shape, loc=self.loc, scale=self.scale, size=size)
+
+        if size is None:
+            return self.dtype(samples)
+        return np.asarray(samples, dtype=self.dtype)
 
     def __repr__(self) -> str:
         """Returns a string representation of the object.

--- a/rework_pysatl_mpest/estimators/base_estimator.py
+++ b/rework_pysatl_mpest/estimators/base_estimator.py
@@ -1,17 +1,19 @@
 """A module that provides an abstract class for implementing custom estimators."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
+from typing import Generic
 
 from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
+from ..typings import DType
 
 
-class BaseEstimator(ABC):
+class BaseEstimator(ABC, Generic[DType]):
     """Abstract class for a mixture model parameter estimator.
 
     This class defines the interface for all estimator algorithms. Estimators are responsible for
@@ -35,7 +37,7 @@ class BaseEstimator(ABC):
     """
 
     @abstractmethod
-    def fit(self, X: ArrayLike, mixture: MixtureModel) -> MixtureModel:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[DType]) -> MixtureModel[DType]:
         """Fits the mixture model to the provided data.
 
         This method estimates the parameters of the model's components and their
@@ -45,11 +47,11 @@ class BaseEstimator(ABC):
         ----------
         X : ArrayLike
             The input data sample for fitting the model.
-        mixture : MixtureModel
+        mixture : MixtureModel[DType]
             The initial mixture model to be fitted.
 
         Returns
         -------
-        MixtureModel
+        MixtureModel[DType]
             The mixture model with estimated parameters.
         """

--- a/rework_pysatl_mpest/estimators/ecm.py
+++ b/rework_pysatl_mpest/estimators/ecm.py
@@ -57,7 +57,7 @@ class ECM(BaseEstimator[DType]):
     pruners : Sequence[Pruner]
         A sequence of strategies for removing (pruning) components from the
         mixture model during fitting.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         A numerical optimizer instance used in the maximization step to find
         the optimal parameters.
 
@@ -69,7 +69,7 @@ class ECM(BaseEstimator[DType]):
     pruners : list[Pruner]
         The list of objects that may remove components from the mixture during
         the fitting process.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         The numerical optimizer used for parameter estimation.
     logger : IterationsHistory | None
         An object that collects information about each iteration.
@@ -84,7 +84,9 @@ class ECM(BaseEstimator[DType]):
         fit
     """
 
-    def __init__(self, breakpointers: Sequence[Breakpointer], pruners: Sequence[Pruner], optimizer: Optimizer) -> None:
+    def __init__(
+        self, breakpointers: Sequence[Breakpointer], pruners: Sequence[Pruner], optimizer: Optimizer[DType]
+    ) -> None:
         self.breakpointers = list(breakpointers)
         self.pruners = list(pruners)
         self.optimizer = optimizer

--- a/rework_pysatl_mpest/estimators/ecm.py
+++ b/rework_pysatl_mpest/estimators/ecm.py
@@ -6,7 +6,7 @@ It uses a pipeline architecture (:class:`~rework_pysatl_mpest.estimators.iterati
 to fit the parameters of a mixture model to data.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -17,6 +17,7 @@ from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
 from ..optimizers import Optimizer
+from ..typings import DType
 from .base_estimator import BaseEstimator
 from .iterative import (
     Breakpointer,
@@ -30,7 +31,7 @@ from .iterative import (
 from .iterative._logger import IterationsHistory
 
 
-class ECM(BaseEstimator):
+class ECM(BaseEstimator[DType]):
     """An estimator that implements the Expectation-Conditional Maximization (ECM) algorithm.
 
     This class encapsulates the logic for the ECM algorithm, a variant of the
@@ -87,10 +88,10 @@ class ECM(BaseEstimator):
         self.breakpointers = list(breakpointers)
         self.pruners = list(pruners)
         self.optimizer = optimizer
-        self._logger: IterationsHistory | None = None
+        self._logger: IterationsHistory[DType] | None = None
 
     @property
-    def logger(self) -> IterationsHistory:
+    def logger(self) -> IterationsHistory[DType]:
         """An object that collects information about each iteration.
 
         Raises
@@ -103,7 +104,7 @@ class ECM(BaseEstimator):
             raise AttributeError("Logger is not available. Call the 'fit' method first.")
         return self._logger
 
-    def fit(self, X: ArrayLike, mixture: MixtureModel, once_in_iterations: int = 1) -> MixtureModel:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[DType], once_in_iterations: int = 1) -> MixtureModel[DType]:
         """Fits the mixture model to the data using the ECM algorithm.
 
         This method sets up and runs an iterative pipeline to estimate the
@@ -115,7 +116,7 @@ class ECM(BaseEstimator):
         ----------
         X : ArrayLike
             The input dataset for fitting the model.
-        mixture : MixtureModel
+        mixture : MixtureModel[DType]
             The initial mixture model to be fitted.
         once_in_iterations : int, optional
             The logging frequency. A value of `n` means logging occurs every
@@ -123,7 +124,7 @@ class ECM(BaseEstimator):
 
         Returns
         -------
-        MixtureModel
+        MixtureModel[DType]
             The mixture model with the estimated parameters.
         """
 
@@ -132,7 +133,7 @@ class ECM(BaseEstimator):
             block = OptimizationBlock(i, comp.params_to_optimize, MaximizationStrategy.QFUNCTION)
             blocks.append(block)
 
-        pipeline = Pipeline(
+        pipeline: Pipeline[DType] = Pipeline(
             [ExpectationStep(), MaximizationStep(blocks, self.optimizer)],
             self.breakpointers,
             self.pruners,

--- a/rework_pysatl_mpest/estimators/iterative/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/__init__.py
@@ -18,7 +18,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from .breakpointer import Breakpointer
-from .breakpointers import StepBreakpointer
+from .breakpointers import StepBreakpointer, LikelihoodBreakpointer
 from .pipeline import Pipeline
 from .pipeline_state import PipelineState
 from .pipeline_step import PipelineStep
@@ -38,4 +38,5 @@ __all__ = [
     "PriorThresholdPruner",
     "Pruner",
     "StepBreakpointer",
+    "LikelihoodBreakpointer"
 ]

--- a/rework_pysatl_mpest/estimators/iterative/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/__init__.py
@@ -18,7 +18,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from .breakpointer import Breakpointer
-from .breakpointers import StepBreakpointer, LikelihoodBreakpointer
+from .breakpointers import LikelihoodBreakpointer, StepBreakpointer
 from .pipeline import Pipeline
 from .pipeline_state import PipelineState
 from .pipeline_step import PipelineStep
@@ -29,6 +29,7 @@ from .steps import ExpectationStep, MaximizationStep, MaximizationStrategy, Opti
 __all__ = [
     "Breakpointer",
     "ExpectationStep",
+    "LikelihoodBreakpointer",
     "MaximizationStep",
     "MaximizationStrategy",
     "OptimizationBlock",
@@ -38,5 +39,4 @@ __all__ = [
     "PriorThresholdPruner",
     "Pruner",
     "StepBreakpointer",
-    "LikelihoodBreakpointer"
 ]

--- a/rework_pysatl_mpest/estimators/iterative/_logger.py
+++ b/rework_pysatl_mpest/estimators/iterative/_logger.py
@@ -6,21 +6,21 @@ including mixture models, input data, responsibilities, pruning actions,
 and errors across iterations.
 """
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
 
-from numpy import float64
 from numpy.typing import NDArray
 
 from ...core import MixtureModel
+from ...typings import DType
 from .pruner import Pruner
 
 
 @dataclass
-class IterationRecord:
+class IterationRecord(Generic[DType]):
     """Data class representing a single pipeline iteration snapshot.
 
     This class captures the complete state of a pipeline iteration after
@@ -31,15 +31,15 @@ class IterationRecord:
     ----------
     iteration : int
         The iteration number (0-based index).
-    mixture : MixtureModel
+    mixture : MixtureModel[DType]
         The state of the mixture model after pruning in this iteration.
-    X : NDArray[float64]
+    X : NDArray[DType]
         The input data sample being processed (conventionally named `X`).
-    H : Optional[NDArray[float64]]
+    H : Optional[NDArray[DType]]
         The responsibility matrix (posterior probabilities) if available,
         where `H[i, j]` represents the probability that data point `i`
         belongs to component `j`. May be `None` if not computed.
-    pruners_used : Optional[list[Pruner]]
+    pruners_used : Optional[list[Pruner[DType]]]
         List of pruner instances that were applied during this iteration.
         `None` or empty if no pruning occurred.
     error : Optional[Exception]
@@ -55,7 +55,7 @@ class IterationRecord:
     error: Exception | None
 
 
-class IterationsHistory:
+class IterationsHistory(Generic[DType]):
     """A container for storing and accessing pipeline iteration history.
 
     `IterationsHistory` collects and stores snapshots of each pipeline iteration
@@ -97,7 +97,7 @@ class IterationsHistory:
     _counter : int
         Internal counter tracking the total number of `log()` calls
         (i.e., total iterations processed, not just recorded ones).
-    _logs : list[IterationRecord]
+    _logs : list[IterationRecord[DType]]
         List of stored iteration records. Only iterations matching the
         recording frequency are appended.
 
@@ -122,11 +122,11 @@ class IterationsHistory:
         if once_in_iterations < 1:
             raise ValueError("once_in_iterations must be a positive integer")
 
-        self._logs: list[IterationRecord] = []
+        self._logs: list[IterationRecord[DType]] = []
         self._counter: int = 0
         self.once_in_iterations = once_in_iterations
 
-    def log(self, record: IterationRecord) -> None:
+    def log(self, record: IterationRecord[DType]) -> None:
         """Store an iteration record based on the configured frequency.
 
         The record is stored only if the current internal counter is divisible
@@ -135,7 +135,7 @@ class IterationsHistory:
 
         Parameters
         ----------
-        record : IterationRecord
+        record : IterationRecord[DType]
             The iteration snapshot to potentially store. The `record.iteration`
             should ideally match the logger's internal state, though this is
             not enforced.
@@ -167,7 +167,7 @@ class IterationsHistory:
         """
         return len(self._logs)
 
-    def __getitem__(self, index: int) -> IterationRecord:
+    def __getitem__(self, index: int) -> IterationRecord[DType]:
         """Access a stored iteration record by index.
 
         Supports both positive (0-based) and negative indexing (e.g., `-1` for last).
@@ -180,7 +180,7 @@ class IterationsHistory:
 
         Returns
         -------
-        IterationRecord
+        IterationRecord[DType]
             The recorded state of the specified iteration.
 
         Raises

--- a/rework_pysatl_mpest/estimators/iterative/_logger.py
+++ b/rework_pysatl_mpest/estimators/iterative/_logger.py
@@ -11,7 +11,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Optional
 
 from numpy import float64
 from numpy.typing import NDArray
@@ -51,9 +50,9 @@ class IterationRecord:
     iteration: int
     mixture: MixtureModel
     X: NDArray[float64]
-    H: Optional[NDArray[float64]]
-    pruners_used: Optional[list[Pruner]]
-    error: Optional[Exception]
+    H: NDArray[float64] | None
+    pruners_used: list[Pruner] | None
+    error: Exception | None
 
 
 class IterationsHistory:

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -12,11 +12,15 @@ from ....optimizers import Optimizer
 from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
+from .moments import moments_strategy as _moments_strategy
 from .q_function import q_function_strategy as _q_function_strategy
 
 q_function_strategy: Callable[
     [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
 ] = _q_function_strategy
+moments_strategy: Callable[
+    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
+] = _moments_strategy
 
 
-__all__ = ["q_function_strategy"]
+__all__ = ["moments_strategy", "q_function_strategy"]

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -9,12 +9,13 @@ from collections.abc import Callable
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
+from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
 from .q_function import q_function_strategy as _q_function_strategy
 
 q_function_strategy: Callable[
-    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, float]]
+    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
 ] = _q_function_strategy
 
 

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/moments.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/moments.py
@@ -1,0 +1,156 @@
+"""Provides strategies for the Maximization-step based on the Method of Moments.
+
+This module implements the logic for updating component parameters by
+equating theoretical moments of the distribution to the empirical weighted
+moments of the data. It uses `functools.singledispatch` to provide a generic
+interface that can be specialized for specific distribution types.
+"""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from functools import singledispatch
+
+import numpy as np
+
+from ....distributions import ContinuousDistribution, Exponential
+from ....optimizers import Optimizer
+from ....typings import DType
+from ..pipeline_state import PipelineState
+from ..steps import OptimizationBlock
+from .utils import handle_numerical_overflow
+
+NUMERICAL_TOLERANCE = 1e-9
+
+
+# ------------------------
+# Base Moments strategy
+# ------------------------
+
+
+@singledispatch
+def moments_strategy(
+    component: ContinuousDistribution[DType],
+    state: PipelineState[DType],
+    block: OptimizationBlock,
+    optimizer: Optimizer,
+) -> tuple[int, dict[str, DType]]:
+    """Generic M-step strategy that uses the Method of Moments.
+
+    This function serves as the base dispatcher. Since the Method of Moments
+    typically requires analytical expressions for theoretical moments specific
+    to each distribution, a generic implementation is not provided and raises
+    NotImplementedError.
+
+    Parameters
+    ----------
+    component : ContinuousDistribution[DType]
+        The distribution component whose parameters are to be optimized.
+    state : PipelineState
+        The current state of the pipeline.
+    block : OptimizationBlock
+        The configuration block defining which component to optimize.
+    optimizer : Optimizer
+        The numerical optimizer (unused in this strategy).
+
+    Raises
+    ------
+    NotImplementedError
+        If a specialized moments strategy is not registered for the given
+        distribution type.
+    """
+    raise NotImplementedError(f"Moments strategy is not implemented for distribution '{type(component).__name__}'.")
+
+
+# ---------------------------------
+# Exponential distribution strategy
+# ---------------------------------
+
+
+@moments_strategy.register(Exponential)
+def _(
+    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+) -> tuple[int, dict[str, DType]]:
+    """Specialized Moments parameter estimation strategy for the Exponential distribution
+    using an analytical solution.
+
+    This function provides a closed-form update for the parameters of an
+    `Exponential` distribution using the Method of Moments. It equates the
+    theoretical moments to the empirical weighted moments calculated from
+    the data and responsibilities.
+
+    Notes
+    -----
+    The analytical updates depend on the set of parameters to optimize:
+
+    - **Both `loc` and `rate`**: Derived from the first weighted moment ($m_1$)
+      and the second weighted moment ($m_2$). The variance is estimated as
+      $Var = m_2 - m_1^2$.
+      Then, ``rate`` = $1 / \\sqrt{Var}$ and ``loc`` = $m_1 - \\sqrt{Var}$.
+
+    - **Only `rate`** (fixed `loc`): Derived from the first moment.
+      ``rate`` = $1 / (m_1 - \\text{loc})$.
+
+    - **Only `loc`** (fixed `rate`): Derived from the first moment.
+      ``loc`` = $m_1 - (1 / \\text{rate})$.
+
+    This implementation ignores the `optimizer` parameter as it does not
+    require numerical optimization.
+    """
+
+    if state.H is None:
+        raise ValueError("Responsibility matrix H is not computed.")
+
+    dtype = component.dtype
+    X = state.X
+    H_j = state.H[:, block.component_id]
+
+    params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
+    new_params = {}
+
+    N_j = np.sum(H_j)
+
+    # If the component has negligible responsibility, do not update its parameters.
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+        return block.component_id, {}
+
+    weighted_sum_X = np.dot(H_j, X)
+    if np.isinf(weighted_sum_X):
+        handle_numerical_overflow(state, context="Moments optimization")
+        return block.component_id, {}
+
+    m1 = weighted_sum_X / N_j
+
+    # Update both location (loc) and lambda (rate) if they are in the optimization block
+    if Exponential.PARAM_LOC in params_to_optimize and Exponential.PARAM_RATE in params_to_optimize:
+        weighted_sum_X2 = np.dot(H_j, X**2)
+        if np.isinf(weighted_sum_X2):
+            handle_numerical_overflow(state, context="Moments optimization")
+            return block.component_id, {}
+
+        m2 = weighted_sum_X2 / N_j
+
+        variance = np.maximum(m2 - m1**2, dtype(NUMERICAL_TOLERANCE))
+
+        std_dev = np.sqrt(variance)
+
+        new_params[Exponential.PARAM_RATE] = dtype(1.0 / std_dev)
+        new_params[Exponential.PARAM_LOC] = dtype(m1 - std_dev)
+
+    # Update lambda (rate) if it's in the optimization block
+    elif Exponential.PARAM_RATE in params_to_optimize:
+        denominator = m1 - component.loc
+
+        if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
+            new_params[Exponential.PARAM_RATE] = component.rate
+        else:
+            new_params[Exponential.PARAM_RATE] = dtype(1.0 / denominator)
+
+    # Update location (loc) if it's in the optimization block
+    elif Exponential.PARAM_LOC in params_to_optimize:
+        new_loc = m1 - (dtype(1.0) / component.rate)
+        new_params[Exponential.PARAM_LOC] = dtype(new_loc)
+
+    return block.component_id, new_params

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/moments.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/moments.py
@@ -35,7 +35,7 @@ def moments_strategy(
     component: ContinuousDistribution[DType],
     state: PipelineState[DType],
     block: OptimizationBlock,
-    optimizer: Optimizer,
+    optimizer: Optimizer[DType],
 ) -> tuple[int, dict[str, DType]]:
     """Generic M-step strategy that uses the Method of Moments.
 
@@ -52,7 +52,7 @@ def moments_strategy(
         The current state of the pipeline.
     block : OptimizationBlock
         The configuration block defining which component to optimize.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         The numerical optimizer (unused in this strategy).
 
     Raises
@@ -61,7 +61,7 @@ def moments_strategy(
         If a specialized moments strategy is not registered for the given
         distribution type.
     """
-    raise NotImplementedError(f"Moments strategy is not implemented for distribution '{type(component).__name__}'.")
+    raise NotImplementedError(f"Moments strategy is not implemented for distribution '{component.name}'.")
 
 
 # ---------------------------------
@@ -71,7 +71,7 @@ def moments_strategy(
 
 @moments_strategy.register(Exponential)
 def _(
-    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
     """Specialized Moments parameter estimation strategy for the Exponential distribution
     using an analytical solution.

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -166,7 +166,7 @@ def _(
         denominator = weighted_sum_X / N_j - loc
 
         if denominator > NUMERICAL_TOLERANCE:
-            new_params[Exponential.PARAM_RATE] = dtype(1.0 / denominator)
+            new_params[Exponential.PARAM_RATE] = dtype(1.0) / denominator
         else:
             # If the weighted average is too close to loc,
             # leave rate unchanged to avoid infinity.

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -351,8 +351,8 @@ def _(
 
 @q_function_strategy.register(Pareto)
 def _(
-    component: Pareto, state: PipelineState, block: OptimizationBlock, optimizer: Optimizer
-) -> tuple[int, dict[str, float]]:
+    component: Pareto, state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Pareto type 1 distribution using an analytical solution.
 
@@ -379,13 +379,15 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
+    dtype = component.dtype
+
     X = state.X
     H_j = state.H[:, block.component_id]
 
     params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
     new_params = {}
 
-    N_j = np.sum(H_j).item()
+    N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
     if N_j < NUMERICAL_TOLERANCE:
@@ -395,19 +397,17 @@ def _(
     if Pareto.PARAM_SCALE in params_to_optimize:
         mask = (H_j > NUMERICAL_TOLERANCE) & (X > 0)
         if np.any(mask):
-            new_scale = np.min(X[mask]).item()
+            new_params[Pareto.PARAM_SCALE] = dtype(np.min(X[mask]))
         else:
             new_params[Pareto.PARAM_SCALE] = component.scale
-
-        new_params[Pareto.PARAM_SCALE] = new_scale
 
     # Update shape if it's in the optimization block
     if Pareto.PARAM_SHAPE in params_to_optimize:
         scale = new_params.get(Pareto.PARAM_SCALE, component.scale)
 
-        denominator = np.dot(H_j, np.log(X / scale)).item()
+        denominator = np.dot(H_j, np.log(X / scale))
         if denominator > NUMERICAL_TOLERANCE:
-            new_params[Pareto.PARAM_SHAPE] = N_j / denominator
+            new_params[Pareto.PARAM_SHAPE] = dtype(N_j / denominator)
         else:
             new_params[Pareto.PARAM_SHAPE] = component.shape
 

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -19,11 +19,11 @@ from functools import singledispatch
 import numpy as np
 
 from ....distributions import ContinuousDistribution, Exponential, Normal, Pareto, Weibull
-from ....exceptions import NumericalStabilityError
 from ....optimizers import Optimizer
 from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
+from .utils import handle_numerical_overflow
 
 NUMERICAL_TOLERANCE = 1e-9
 
@@ -31,28 +31,6 @@ NUMERICAL_TOLERANCE = 1e-9
 # ------------------------
 # Base Q-function strategy
 # ------------------------
-
-
-def _handle_numerical_overflow(state: PipelineState[DType]) -> None:
-    """Creates and registers a numerical stability error in the pipeline state.
-
-    This helper function is called when a numerical instability (e.g., infinity)
-    is detected during the M-step. It creates a `NumericalStabilityError`,
-    places it in `state.error`.
-
-    The presence of this error in the state signals the `Pipeline` class to
-    take corrective action, such as restarting the fitting process with a
-    higher floating-point precision (e.g., `np.float64`).
-
-    Parameters
-    ----------
-    state : PipelineState[DType]
-        The current pipeline state where the error will be recorded.
-    """
-    error = NumericalStabilityError(
-        "Overflow detected during Q-function optimization. The pipeline will attempt to restart with higher precision."
-    )
-    state.error = error
 
 
 @singledispatch
@@ -115,7 +93,7 @@ def q_function_strategy(
         safe_lpdf = np.where(H_j == 0, dtype(0.0), lpdf_values)
         res = -np.dot(H_j, safe_lpdf)
         if np.isinf(res):
-            _handle_numerical_overflow(state)
+            handle_numerical_overflow(state, "Q-function optimization")
         return -np.dot(H_j, safe_lpdf)
 
     new_params = optimizer.minimize(target, temp_comp.get_params_vector(params_to_optimize))
@@ -182,7 +160,8 @@ def _(
 
         weighted_sum_X = np.dot(H_j, X)
         if np.isinf(weighted_sum_X):
-            _handle_numerical_overflow(state)
+            handle_numerical_overflow(state, "Q-function optimization")
+            return block.component_id, {}
 
         denominator = weighted_sum_X / N_j - loc
         if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
@@ -242,7 +221,8 @@ def _(
     if Normal.PARAM_LOC in params_to_optimize:
         weighted_sum_X = np.dot(H_j, X)
         if np.isinf(weighted_sum_X):
-            _handle_numerical_overflow(state)
+            handle_numerical_overflow(state, "Q-function optimization")
+            return block.component_id, {}
 
         new_mu = weighted_sum_X / N_j
         new_params[Normal.PARAM_LOC] = dtype(new_mu)
@@ -255,7 +235,8 @@ def _(
         # Calculate the weighted variance
         weighted_sum_sq_diff = np.dot(H_j, (X - mu) ** 2)
         if np.isinf(weighted_sum_sq_diff):
-            _handle_numerical_overflow(state)
+            handle_numerical_overflow(state, "Q-function optimization")
+            return block.component_id, {}
 
         new_variance = weighted_sum_sq_diff / N_j
 
@@ -333,9 +314,10 @@ def _(
 
             weighted_sum = np.dot(H_j, safe_X_minus_loc**final_shape)
             if np.isinf(weighted_sum):
-                _handle_numerical_overflow(state)
+                handle_numerical_overflow(state, "Q-function optimization")
+                return block.component_id, {}
 
-            if np.isclose(weighted_sum, 0.0, NUMERICAL_TOLERANCE):
+            if np.isclose(weighted_sum, 0.0, atol=NUMERICAL_TOLERANCE):
                 new_params[Weibull.PARAM_SCALE] = component.scale
             else:
                 new_scale = (weighted_sum / N_j) ** (dtype(1.0) / final_shape)
@@ -390,7 +372,7 @@ def _(
     N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if N_j < NUMERICAL_TOLERANCE:
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
         return block.component_id, {}
 
     # Update scale if it's in the optimization block
@@ -406,9 +388,9 @@ def _(
         scale = new_params.get(Pareto.PARAM_SCALE, component.scale)
 
         denominator = np.dot(H_j, np.log(X / scale))
-        if denominator > NUMERICAL_TOLERANCE:
-            new_params[Pareto.PARAM_SHAPE] = dtype(N_j / denominator)
-        else:
+        if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
             new_params[Pareto.PARAM_SHAPE] = component.shape
+        else:
+            new_params[Pareto.PARAM_SHAPE] = dtype(N_j / denominator)
 
     return block.component_id, new_params

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -8,7 +8,7 @@ efficient analytical solutions for specific distribution types like the
 `Exponential` distribution.
 """
 
-__author__ = "Danil Totmyanin, Maksim Pastukhov"
+__author__ = "Danil Totmyanin, Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -19,7 +19,9 @@ from functools import singledispatch
 import numpy as np
 
 from ....distributions import ContinuousDistribution, Exponential, Normal, Pareto, Weibull
+from ....exceptions import NumericalStabilityError
 from ....optimizers import Optimizer
+from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
 
@@ -31,10 +33,35 @@ NUMERICAL_TOLERANCE = 1e-9
 # ------------------------
 
 
+def _handle_numerical_overflow(state: PipelineState[DType]) -> None:
+    """Creates and registers a numerical stability error in the pipeline state.
+
+    This helper function is called when a numerical instability (e.g., infinity)
+    is detected during the M-step. It creates a `NumericalStabilityError`,
+    places it in `state.error`.
+
+    The presence of this error in the state signals the `Pipeline` class to
+    take corrective action, such as restarting the fitting process with a
+    higher floating-point precision (e.g., `np.float64`).
+
+    Parameters
+    ----------
+    state : PipelineState[DType]
+        The current pipeline state where the error will be recorded.
+    """
+    error = NumericalStabilityError(
+        "Overflow detected during Q-function optimization. The pipeline will attempt to restart with higher precision."
+    )
+    state.error = error
+
+
 @singledispatch
 def q_function_strategy(
-    component: ContinuousDistribution, state: PipelineState, block: OptimizationBlock, optimizer: Optimizer
-) -> tuple[int, dict[str, float]]:
+    component: ContinuousDistribution[DType],
+    state: PipelineState[DType],
+    block: OptimizationBlock,
+    optimizer: Optimizer,
+) -> tuple[int, dict[str, DType]]:
     """Generic M-step strategy that maximizes the Q-function numerically.
 
     This function serves as the default implementation for updating a
@@ -47,7 +74,7 @@ def q_function_strategy(
 
     Parameters
     ----------
-    component : ContinuousDistribution
+    component : ContinuousDistribution[DType]
         The distribution component whose parameters are to be optimized.
     state : PipelineState
         The current state of the pipeline, containing the data :attr:`X` and the
@@ -60,7 +87,7 @@ def q_function_strategy(
 
     Returns
     -------
-    tuple[int, dict[str, float]]
+    tuple[int, dict[str, DType]]
         A tuple containing the component's ID and a dictionary of the
         optimized parameter names and their new values.
 
@@ -74,6 +101,8 @@ def q_function_strategy(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
+    dtype = component.dtype
+
     X, H_j = state.X, state.H[:, block.component_id]
     component_id = block.component_id
 
@@ -83,8 +112,11 @@ def q_function_strategy(
     def target(vector_params):
         temp_comp.set_params_from_vector(params_to_optimize, vector_params)
         lpdf_values = temp_comp.lpdf(X)
-        safe_lpdf = np.where(H_j == 0, 0.0, lpdf_values)
-        return -np.dot(H_j, safe_lpdf).item()
+        safe_lpdf = np.where(H_j == 0, dtype(0.0), lpdf_values)
+        res = -np.dot(H_j, safe_lpdf)
+        if np.isinf(res):
+            _handle_numerical_overflow(state)
+        return -np.dot(H_j, safe_lpdf)
 
     new_params = optimizer.minimize(target, temp_comp.get_params_vector(params_to_optimize))
     return component_id, dict(zip(params_to_optimize, new_params))
@@ -97,8 +129,8 @@ def q_function_strategy(
 
 @q_function_strategy.register(Exponential)
 def _(
-    component: Exponential, state: PipelineState, block: OptimizationBlock, optimizer: Optimizer
-) -> tuple[int, dict[str, float]]:
+    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Exponential distribution using an analytical solution.
 
@@ -122,23 +154,25 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
+    dtype = component.dtype
+
     X = state.X
     H_j = state.H[:, block.component_id]
 
     params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
     new_params = {}
 
-    N_j = np.sum(H_j).item()
+    N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if N_j < NUMERICAL_TOLERANCE:
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
         return block.component_id, {}
 
     # Update location (loc) if it's in the optimization block
     if Exponential.PARAM_LOC in params_to_optimize:
         relevant_X = X[H_j > NUMERICAL_TOLERANCE]
         if relevant_X.size > 0:
-            new_params[Exponential.PARAM_LOC] = np.min(relevant_X).item()
+            new_params[Exponential.PARAM_LOC] = np.min(relevant_X)
         else:
             new_params[Exponential.PARAM_LOC] = component.loc
 
@@ -146,15 +180,17 @@ def _(
     if Exponential.PARAM_RATE in params_to_optimize:
         loc = new_params.get(Exponential.PARAM_LOC, component.loc)
 
-        weighted_sum_X = np.dot(H_j, X).item()
+        weighted_sum_X = np.dot(H_j, X)
+        if np.isinf(weighted_sum_X):
+            _handle_numerical_overflow(state)
 
         denominator = weighted_sum_X / N_j - loc
-        if denominator > NUMERICAL_TOLERANCE:
-            new_params[Exponential.PARAM_RATE] = 1.0 / denominator
-        else:
+        if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
             # If the weighted average is too close to loc,
             # leave rate unchanged to avoid infinity.
             new_params[Exponential.PARAM_RATE] = component.rate
+        else:
+            new_params[Exponential.PARAM_RATE] = dtype(1.0 / denominator)
 
     return block.component_id, new_params
 
@@ -166,8 +202,8 @@ def _(
 
 @q_function_strategy.register(Normal)
 def _(
-    component: Normal, state: PipelineState, block: OptimizationBlock, optimizer: Optimizer
-) -> tuple[int, dict[str, float]]:
+    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the normal distribution using an analytical solution.
 
@@ -188,23 +224,28 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
+    dtype = component.dtype
+
     X = state.X
     H_j = state.H[:, block.component_id]
 
     params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
     new_params = {}
 
-    N_j = np.sum(H_j).item()
+    N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if N_j < NUMERICAL_TOLERANCE:
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
         return block.component_id, {}
 
     # Update mean (loc) if it's in the optimization block
     if Normal.PARAM_LOC in params_to_optimize:
-        weighted_sum_X = np.dot(H_j, X).item()
+        weighted_sum_X = np.dot(H_j, X)
+        if np.isinf(weighted_sum_X):
+            _handle_numerical_overflow(state)
+
         new_mu = weighted_sum_X / N_j
-        new_params[Normal.PARAM_LOC] = new_mu
+        new_params[Normal.PARAM_LOC] = dtype(new_mu)
 
     # Update std (scale) if it's in the optimization block
     if Normal.PARAM_SCALE in params_to_optimize:
@@ -212,15 +253,18 @@ def _(
         mu = new_params.get(Normal.PARAM_LOC, component.loc)
 
         # Calculate the weighted variance
-        weighted_sum_sq_diff = np.dot(H_j, (X - mu) ** 2).item()
+        weighted_sum_sq_diff = np.dot(H_j, (X - mu) ** 2)
+        if np.isinf(weighted_sum_sq_diff):
+            _handle_numerical_overflow(state)
+
         new_variance = weighted_sum_sq_diff / N_j
 
-        if new_variance > NUMERICAL_TOLERANCE:
-            new_params[Normal.PARAM_SCALE] = np.sqrt(new_variance)
-        else:
+        if np.isclose(new_variance, 0.0, NUMERICAL_TOLERANCE):
             # If variance is too small, it can lead to instability.
             # Keep the old scale to prevent it from collapsing to zero.
             new_params[Normal.PARAM_SCALE] = component.scale
+        else:
+            new_params[Normal.PARAM_SCALE] = dtype(np.sqrt(new_variance))
 
     return block.component_id, new_params
 
@@ -232,8 +276,8 @@ def _(
 
 @q_function_strategy.register(Weibull)
 def _(
-    component: Weibull, state: PipelineState, block: OptimizationBlock, optimizer: Optimizer
-) -> tuple[int, dict[str, float]]:
+    component: Weibull[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Weibull distribution using an analytical solution.
     """
@@ -241,16 +285,18 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
+    dtype = component.dtype
+
     X = state.X
     H_j = state.H[:, block.component_id]
 
     params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
     new_params = {}
 
-    N_j = np.sum(H_j).item()
+    N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if N_j < NUMERICAL_TOLERANCE:
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
         return block.component_id, {}
 
     # ------------------------
@@ -283,15 +329,17 @@ def _(
             X_minus_loc = X - final_loc
 
             # Use np.maximum to avoid taking powers of negative numbers if final_loc is slightly off
-            safe_X_minus_loc = np.maximum(X_minus_loc, NUMERICAL_TOLERANCE)
+            safe_X_minus_loc = np.maximum(X_minus_loc, dtype(NUMERICAL_TOLERANCE))
 
             weighted_sum = np.dot(H_j, safe_X_minus_loc**final_shape)
+            if np.isinf(weighted_sum):
+                _handle_numerical_overflow(state)
 
-            if weighted_sum > 0:
-                new_scale = (weighted_sum / N_j) ** (1.0 / final_shape)
-                new_params[Weibull.PARAM_SCALE] = new_scale
-            else:
+            if np.isclose(weighted_sum, 0.0, NUMERICAL_TOLERANCE):
                 new_params[Weibull.PARAM_SCALE] = component.scale
+            else:
+                new_scale = (weighted_sum / N_j) ** (dtype(1.0) / final_shape)
+                new_params[Weibull.PARAM_SCALE] = new_scale
 
     return block.component_id, new_params
 

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -38,7 +38,7 @@ def q_function_strategy(
     component: ContinuousDistribution[DType],
     state: PipelineState[DType],
     block: OptimizationBlock,
-    optimizer: Optimizer,
+    optimizer: Optimizer[DType],
 ) -> tuple[int, dict[str, DType]]:
     """Generic M-step strategy that maximizes the Q-function numerically.
 
@@ -60,7 +60,7 @@ def q_function_strategy(
     block : OptimizationBlock
         The configuration block defining which component and which of its
         parameters to optimize.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         The numerical optimizer instance used to perform the maximization.
 
     Returns
@@ -107,7 +107,7 @@ def q_function_strategy(
 
 @q_function_strategy.register(Exponential)
 def _(
-    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Exponential distribution using an analytical solution.
@@ -143,7 +143,7 @@ def _(
     N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+    if N_j <= NUMERICAL_TOLERANCE:
         return block.component_id, {}
 
     # Update location (loc) if it's in the optimization block
@@ -164,12 +164,13 @@ def _(
             return block.component_id, {}
 
         denominator = weighted_sum_X / N_j - loc
-        if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
+
+        if denominator > NUMERICAL_TOLERANCE:
+            new_params[Exponential.PARAM_RATE] = dtype(1.0 / denominator)
+        else:
             # If the weighted average is too close to loc,
             # leave rate unchanged to avoid infinity.
             new_params[Exponential.PARAM_RATE] = component.rate
-        else:
-            new_params[Exponential.PARAM_RATE] = dtype(1.0 / denominator)
 
     return block.component_id, new_params
 
@@ -181,7 +182,7 @@ def _(
 
 @q_function_strategy.register(Normal)
 def _(
-    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the normal distribution using an analytical solution.
@@ -203,8 +204,6 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
-    dtype = component.dtype
-
     X = state.X
     H_j = state.H[:, block.component_id]
 
@@ -214,7 +213,7 @@ def _(
     N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+    if N_j <= NUMERICAL_TOLERANCE:
         return block.component_id, {}
 
     # Update mean (loc) if it's in the optimization block
@@ -224,8 +223,7 @@ def _(
             handle_numerical_overflow(state, "Q-function optimization")
             return block.component_id, {}
 
-        new_mu = weighted_sum_X / N_j
-        new_params[Normal.PARAM_LOC] = dtype(new_mu)
+        new_params[Normal.PARAM_LOC] = weighted_sum_X / N_j
 
     # Update std (scale) if it's in the optimization block
     if Normal.PARAM_SCALE in params_to_optimize:
@@ -240,12 +238,12 @@ def _(
 
         new_variance = weighted_sum_sq_diff / N_j
 
-        if np.isclose(new_variance, 0.0, NUMERICAL_TOLERANCE):
+        if new_variance > NUMERICAL_TOLERANCE:
+            new_params[Normal.PARAM_SCALE] = np.sqrt(new_variance)
+        else:
             # If variance is too small, it can lead to instability.
             # Keep the old scale to prevent it from collapsing to zero.
             new_params[Normal.PARAM_SCALE] = component.scale
-        else:
-            new_params[Normal.PARAM_SCALE] = dtype(np.sqrt(new_variance))
 
     return block.component_id, new_params
 
@@ -257,7 +255,7 @@ def _(
 
 @q_function_strategy.register(Weibull)
 def _(
-    component: Weibull[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+    component: Weibull[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Weibull distribution using an analytical solution.
@@ -277,7 +275,7 @@ def _(
     N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+    if N_j <= NUMERICAL_TOLERANCE:
         return block.component_id, {}
 
     # ------------------------
@@ -317,11 +315,11 @@ def _(
                 handle_numerical_overflow(state, "Q-function optimization")
                 return block.component_id, {}
 
-            if np.isclose(weighted_sum, 0.0, atol=NUMERICAL_TOLERANCE):
-                new_params[Weibull.PARAM_SCALE] = component.scale
-            else:
+            if weighted_sum > NUMERICAL_TOLERANCE:
                 new_scale = (weighted_sum / N_j) ** (dtype(1.0) / final_shape)
                 new_params[Weibull.PARAM_SCALE] = new_scale
+            else:
+                new_params[Weibull.PARAM_SCALE] = component.scale
 
     return block.component_id, new_params
 
@@ -333,7 +331,7 @@ def _(
 
 @q_function_strategy.register(Pareto)
 def _(
-    component: Pareto, state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer
+    component: Pareto, state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
     """Specialized Q-function parameter estimation strategy for
     the Pareto type 1 distribution using an analytical solution.
@@ -361,8 +359,6 @@ def _(
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
-    dtype = component.dtype
-
     X = state.X
     H_j = state.H[:, block.component_id]
 
@@ -372,14 +368,14 @@ def _(
     N_j = np.sum(H_j)
 
     # If the component has negligible responsibility, do not update its parameters.
-    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+    if N_j <= NUMERICAL_TOLERANCE:
         return block.component_id, {}
 
     # Update scale if it's in the optimization block
     if Pareto.PARAM_SCALE in params_to_optimize:
         mask = (H_j > NUMERICAL_TOLERANCE) & (X > 0)
         if np.any(mask):
-            new_params[Pareto.PARAM_SCALE] = dtype(np.min(X[mask]))
+            new_params[Pareto.PARAM_SCALE] = np.min(X[mask])
         else:
             new_params[Pareto.PARAM_SCALE] = component.scale
 
@@ -388,9 +384,9 @@ def _(
         scale = new_params.get(Pareto.PARAM_SCALE, component.scale)
 
         denominator = np.dot(H_j, np.log(X / scale))
-        if np.isclose(denominator, 0.0, NUMERICAL_TOLERANCE):
-            new_params[Pareto.PARAM_SHAPE] = component.shape
+        if denominator > NUMERICAL_TOLERANCE:
+            new_params[Pareto.PARAM_SHAPE] = N_j / denominator
         else:
-            new_params[Pareto.PARAM_SHAPE] = dtype(N_j / denominator)
+            new_params[Pareto.PARAM_SHAPE] = component.shape
 
     return block.component_id, new_params

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/utils.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/utils.py
@@ -1,0 +1,33 @@
+"""Common utilities for maximization strategies."""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from ....exceptions import NumericalStabilityError
+from ....typings import DType
+from ..pipeline_state import PipelineState
+
+
+def handle_numerical_overflow(state: PipelineState[DType], context: str = "optimization") -> None:
+    """Creates and registers a numerical stability error in the pipeline state.
+
+    This helper function is called when a numerical instability (e.g., infinity)
+    is detected during the M-step. It creates a `NumericalStabilityError`,
+    places it in `state.error`.
+
+    The presence of this error in the state signals the `Pipeline` class to
+    take corrective action, such as restarting the fitting process with a
+    higher floating-point precision (e.g., `np.float64`).
+
+    Parameters
+    ----------
+    state : PipelineState[DType]
+        The current pipeline state where the error will be recorded.
+    context : str
+        The context name to include in the error message (e.g. 'Moments optimization', 'Q-function optimization').
+    """
+    error = NumericalStabilityError(
+        f"Overflow detected during {context}. The pipeline will attempt to restart with higher precision."
+    )
+    state.error = error

--- a/rework_pysatl_mpest/estimators/iterative/breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointer.py
@@ -5,16 +5,18 @@ contract for implementing custom stopping conditions (or convergence criteria)
 within an iterative estimation `Pipeline`.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
+from typing import Generic
 
+from ...typings import DType
 from .pipeline_state import PipelineState
 
 
-class Breakpointer(ABC):
+class Breakpointer(ABC, Generic[DType]):
     """Abstract base class for a pipeline stopping condition.
 
     A Breakpointer is responsible for inspecting the :class:`PipelineState` after each
@@ -40,12 +42,12 @@ class Breakpointer(ABC):
     """
 
     @abstractmethod
-    def check(self, state: PipelineState) -> bool:
+    def check(self, state: PipelineState[DType]) -> bool:
         """Evaluates the pipeline state to determine if it should stop.
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline after a full iteration,
             containing the current and previous mixture models.
 

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
@@ -6,7 +6,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from .step_breakpointer import StepBreakpointer 
 from .likelihood_breakpointer import LikelihoodBreakpointer
+from .step_breakpointer import StepBreakpointer
 
-__all__ = ["StepBreakpointer", "LikelihoodBreakpointer"]
+__all__ = ["LikelihoodBreakpointer", "StepBreakpointer"]

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from .step_breakpointer import StepBreakpointer
+from .step_breakpointer import StepBreakpointer 
+from .likelihood_breakpointer import LikelihoodBreakpointer
 
-__all__ = ["StepBreakpointer"]
+__all__ = ["StepBreakpointer", "LikelihoodBreakpointer"]

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -1,0 +1,89 @@
+"""Module that provides a :class:`rework_pysatl_mpest.estimators.iterative.Pipeline`
+stopping strategy based on when log-likelihood of the mixture converges"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from ..breakpointer import Breakpointer
+from ..pipeline_state import PipelineState
+
+
+class LikelihoodBreakpointer(Breakpointer):
+    """Stops the pipeline when the log-likelihood of the mixture converges.
+
+    This breakpointer terminates the iterative estimation process when the
+    absolute difference between the current and previous log-likelihood values
+    falls below a specified threshold:
+
+        |L_{t+1} - L_t| < threshold
+
+    It tracks the log-likelihood of the current mixture model on the observed
+    data at each iteration and compares it to the previous value.
+
+    Parameters
+    ----------
+    threshold : float
+        The convergence threshold for the log-likelihood difference.
+        Must be a positive number.
+
+    Attributes
+    ----------
+    threshold : float
+        The convergence threshold.
+
+    Raises
+    ------
+    ValueError
+        If `threshold` is not greater than 0.
+
+    Methods
+    -------
+    check(state: PipelineState) -> bool
+        Returns True if convergence is detected, False otherwise.
+    """
+
+    def __init__(self, threshold: float):
+        self._validate(threshold)
+        self.threshold = threshold
+        self._L_old = None  # Start with None to handle first iteration
+        self._L_new = None
+
+    def _validate(self, threshold: float):
+        """Validates the threshold parameter."""
+        if threshold <= 0:
+            raise ValueError("The threshold must be greater than 0")
+
+    def check(self, state: PipelineState) -> bool:
+        """Checks if the log-likelihood has converged.
+
+        Computes the current log-likelihood of the mixture on the data in
+        the pipeline state and compares it with the previous value.
+
+        Parameters
+        ----------
+        state : PipelineState
+            The current state of the pipeline, which must contain a valid
+            `curr_mixture` and data `X`.
+
+        Returns
+        -------
+        bool
+            True if |L_new - L_old| < threshold (converged), False otherwise.
+            On the first call (no previous likelihood), returns False and
+            initializes internal state.
+        """
+        self._L_new = state.curr_mixture.loglikelihood(state.X)
+
+        # First iteration: cannot compare, so just store and continue
+        if self._L_old is None:
+            self._L_old = self._L_new
+            return False
+
+        if abs(self._L_new - self._L_old) < self.threshold:
+            self._L_old = None
+            self._L_new = None
+            return True
+        else:
+            self._L_old = self._L_new
+            return False

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -5,6 +5,8 @@ __author__ = "Maksim Pastukhov"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from typing import Optional
+
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
 
@@ -46,8 +48,8 @@ class LikelihoodBreakpointer(Breakpointer):
     def __init__(self, threshold: float):
         self._validate(threshold)
         self.threshold = threshold
-        self._L_old = None  # Start with None to handle first iteration
-        self._L_new = None
+        self._L_old: Optional[float] = None
+        self._L_new: Optional[float] = None
 
     def _validate(self, threshold: float):
         """Validates the threshold parameter."""

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -5,7 +5,6 @@ __author__ = "Maksim Pastukhov"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-from typing import Optional
 
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
@@ -18,6 +17,7 @@ class LikelihoodBreakpointer(Breakpointer):
     absolute difference between the current and previous log-likelihood values
     falls below a specified threshold:
 
+    .. math::
         |L_{t+1} - L_t| < threshold
 
     It tracks the log-likelihood of the current mixture model on the observed
@@ -41,15 +41,16 @@ class LikelihoodBreakpointer(Breakpointer):
 
     Methods
     -------
-    check(state: PipelineState) -> bool
-        Returns True if convergence is detected, False otherwise.
+    .. autosummary::
+        :toctree: generated/
+
+        check
     """
 
     def __init__(self, threshold: float):
         self._validate(threshold)
         self.threshold = threshold
-        self._L_old: Optional[float] = None
-        self._L_new: Optional[float] = None
+        self._likelihood_old: float | None = None
 
     def _validate(self, threshold: float):
         """Validates the threshold parameter."""
@@ -71,21 +72,23 @@ class LikelihoodBreakpointer(Breakpointer):
         Returns
         -------
         bool
-            True if |L_new - L_old| < threshold (converged), False otherwise.
+            .. math::
+                \text{True if } |L_{\text{new}} - L_{\text{old}}| < \text{threshold, False otherwise}
+
             On the first call (no previous likelihood), returns False and
             initializes internal state.
         """
-        self._L_new = state.curr_mixture.loglikelihood(state.X)
+        self._likelihood_new: float | None = state.curr_mixture.loglikelihood(state.X)
 
         # First iteration: cannot compare, so just store and continue
-        if self._L_old is None:
-            self._L_old = self._L_new
+        if self._likelihood_old is None:
+            self._likelihood_old = self._likelihood_new
             return False
 
-        if abs(self._L_new - self._L_old) < self.threshold:
-            self._L_old = None
-            self._L_new = None
+        if abs(self._likelihood_new - self._likelihood_old) < self.threshold:
+            self._likelihood_old = None
+            self._likelihood_new = None
             return True
         else:
-            self._L_old = self._L_new
+            self._likelihood_old = self._likelihood_new
             return False

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/step_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/step_breakpointer.py
@@ -1,16 +1,17 @@
 """Module that provides a :class:`rework_pysatl_mpest.estimators.iterative.Pipeline`
 stopping strategy based on the number of iterations"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
+from ....typings import DType
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
 
 
-class StepBreakpointer(Breakpointer):
+class StepBreakpointer(Breakpointer[DType]):
     """Stops the pipeline after a fixed number of iterations.
 
     This breakpointer terminates the iterative process once a specified
@@ -57,7 +58,7 @@ class StepBreakpointer(Breakpointer):
         if max_steps <= 0:
             raise ValueError("The maximum number of steps must be greater than or equal to 1")
 
-    def check(self, state: PipelineState) -> bool:
+    def check(self, state: PipelineState[DType]) -> bool:
         """Checks if the maximum number of iterations has been reached.
 
         This method increments the internal step counter and compares it with
@@ -66,7 +67,7 @@ class StepBreakpointer(Breakpointer):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline. This parameter is unused in
             this specific breakpointer but required by the base class interface.
 

--- a/rework_pysatl_mpest/estimators/iterative/pipeline.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline.py
@@ -7,7 +7,7 @@ combining different steps (:class:`PipelineStep`), stopping criteria (:class:`Br
 and component pruning strategies (:class:`Pruner`).
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -19,6 +19,8 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 from ...core import MixtureModel
+from ...exceptions import NumericalStabilityError
+from ...typings import DType
 from ..base_estimator import BaseEstimator
 from ._logger import IterationRecord, IterationsHistory
 from .breakpointer import Breakpointer
@@ -27,7 +29,7 @@ from .pipeline_step import PipelineStep
 from .pruner import Pruner
 
 
-class Pipeline(BaseEstimator):
+class Pipeline(BaseEstimator[DType]):
     """An estimator that fits a mixture model via a configurable iterative process.
 
     The pipeline executes a sequence of defined steps in a loop. After each full
@@ -67,7 +69,7 @@ class Pipeline(BaseEstimator):
     pruners : list[Pruner]
         The list of objects that may remove components from the mixture during
         the fitting process.
-    logger : IterationsHistory
+    logger : IterationsHistory[DType]
         object that collects comprehensive information about each
         iteration of a :class:`Pipeline` estimator.
     Raises
@@ -105,7 +107,7 @@ class Pipeline(BaseEstimator):
         self.breakpointers = list(breakpointers)
         self.pruners = list(pruners) if pruners else []  # self.pruners will always be list
         self.steps = list(steps)
-        self.logger = IterationsHistory(once_in_iterations)
+        self.logger = IterationsHistory[DType](once_in_iterations)
 
     def _validate_steps(self, steps: list[PipelineStep]):
         """Validates the sequence of pipeline steps.
@@ -140,7 +142,7 @@ class Pipeline(BaseEstimator):
                     f"available next steps:'{curr_step.available_next_steps}', but got '{next_step}'"
                 )
 
-    def fit(self, X: ArrayLike, mixture: MixtureModel) -> MixtureModel:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[DType]) -> MixtureModel[DType]:
         """Fits the mixture model to the data using the configured pipeline.
 
         This method initializes the pipeline's state and runs the main loop.
@@ -152,18 +154,18 @@ class Pipeline(BaseEstimator):
         ----------
         X : ArrayLike
             The input data sample.
-        mixture : MixtureModel
+        mixture : MixtureModel[DType]
             The initial mixture model to be fitted. An internal copy of this
             model will be modified throughout the process.
 
         Returns
         -------
-        MixtureModel
+        MixtureModel[DType]
             The fitted mixture model after the pipeline has converged or been
             stopped.
         """
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=mixture.dtype)
         copied_mixture = copy(mixture)  # Copy to avoid modifying the original object
         removed_indices: list[int] = []
         state = PipelineState(X, None, None, copied_mixture, None)
@@ -193,6 +195,21 @@ class Pipeline(BaseEstimator):
                                 result_state.error,
                             )
                         )
+
+                    # Handle numerical stability errors by attempting a restart with higher precision
+                    if isinstance(result_state.error, NumericalStabilityError):
+                        new_dtype = np.promote_types(copied_mixture.dtype, np.float64).type
+                        if new_dtype is not copied_mixture.dtype:
+                            new_mixture = copied_mixture.astype(new_dtype)
+
+                            msg = (
+                                "Numerical stability issue detected. "
+                                f"Restarting pipeline with higher precision ({new_dtype.__name__})."
+                            )
+                            warnings.warn(msg, UserWarning)
+                            # Recursively call fit with the new, higher-precision model
+                            return self.fit(X, new_mixture)
+
                     warnings.warn(
                         f"Pipeline fitting stopped prematurely due to an error in step "
                         f"'{step.__class__.__name__}': {state.error}",

--- a/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
@@ -6,20 +6,20 @@ for all data passed between different steps of a :class:`Pipeline`, such as
 optimized, and other metadata required for the estimation process.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
 
-from numpy import float64
 from numpy.typing import NDArray
 
 from ...core import MixtureModel
+from ...typings import DType
 
 
 @dataclass
-class PipelineState:
+class PipelineState(Generic[DType]):
     """Represents the state of a pipeline at a specific point in its execution.
 
     This dataclass is a mutable container that centralizes all information
@@ -29,18 +29,18 @@ class PipelineState:
 
     Args
     ----------
-    X : NDArray[float64]
+    X : NDArray[DType]
         The input data sample. This data is typically treated as read-only
         throughout the pipeline's execution.
-    H : NDArray[float64] | None
+    H : NDArray[DType] | None
         The responsibility matrix (posterior probabilities). `H[i, j]`
         represents the probability that data point `i` belongs to component
         `j`. It may not be computed at every step.
-    prev_mixture : MixtureModel | None
+    prev_mixture : MixtureModel[DType] | None
         A snapshot of the mixture model from the previous iteration. This is
         useful for convergence checks, such as comparing log-likelihood values.
         It is `None` at the start of the pipeline.
-    curr_mixture : MixtureModel
+    curr_mixture : MixtureModel[DType]
         The current state of the mixture model that is being actively
         optimized by the pipeline steps.
     error : Exception | None

--- a/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
@@ -11,7 +11,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Optional
 
 from numpy import float64
 from numpy.typing import NDArray
@@ -51,7 +50,7 @@ class PipelineState:
     """
 
     X: NDArray[float64]
-    H: Optional[NDArray[float64]]
-    prev_mixture: Optional[MixtureModel]
+    H: NDArray[float64] | None
+    prev_mixture: MixtureModel | None
     curr_mixture: MixtureModel
-    error: Optional[Exception]
+    error: Exception | None

--- a/rework_pysatl_mpest/estimators/iterative/pipeline_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline_step.py
@@ -6,16 +6,18 @@ Each step takes the current state of the pipeline, performs an operation,
 and returns the updated state.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
+from typing import Generic
 
+from ...typings import DType
 from .pipeline_state import PipelineState
 
 
-class PipelineStep(ABC):
+class PipelineStep(ABC, Generic[DType]):
     """Abstract base class for a single step in a processing pipeline.
 
     This class defines the interface for an operation that can be executed as
@@ -52,7 +54,7 @@ class PipelineStep(ABC):
         """
 
     @abstractmethod
-    def run(self, state: PipelineState) -> PipelineState:
+    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
         """Executes the logic of the pipeline step.
 
         This method processes the given pipeline state. Implementations can
@@ -65,13 +67,13 @@ class PipelineStep(ABC):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline to be processed. Note that this
             object can be mutated by the method.
 
         Returns
         -------
-        PipelineState
+        PipelineState[DType]
             The updated state of the pipeline. This can be the mutated input
             `state` object or a completely new instance.
         """

--- a/rework_pysatl_mpest/estimators/iterative/pruner.py
+++ b/rework_pysatl_mpest/estimators/iterative/pruner.py
@@ -5,16 +5,18 @@ interface for implementing various strategies to remove components from a
 mixture model during an iterative estimation process.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
+from typing import Generic
 
+from ...typings import DType
 from .pipeline_state import PipelineState
 
 
-class Pruner(ABC):
+class Pruner(ABC, Generic[DType]):
     """Abstract base class for component pruning strategies.
 
     Pruner subclasses implement the logic for identifying and removing
@@ -39,7 +41,7 @@ class Pruner(ABC):
     """
 
     @abstractmethod
-    def prune(self, state: PipelineState) -> tuple[PipelineState, list[int]]:
+    def prune(self, state: PipelineState[DType]) -> tuple[PipelineState[DType], list[int]]:
         """Analyzes the pipeline state and prunes components from the mixture.
 
         This method is called by the :class:`Pipeline` to inspect the current mixture
@@ -49,13 +51,13 @@ class Pruner(ABC):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline, containing the data, mixture
             model, and other relevant information.
 
         Returns
         -------
-        PipelineState
+        PipelineState[DType]
             The new pipeline state. If components were removed, this state
             contains the updated mixture model. Otherwise, it returns the
             original state.

--- a/rework_pysatl_mpest/estimators/iterative/pruners/prior_threshold_pruner.py
+++ b/rework_pysatl_mpest/estimators/iterative/pruners/prior_threshold_pruner.py
@@ -7,18 +7,19 @@ components whose prior probabilities (weights) fall below a specified
 threshold.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 from copy import copy
 
+from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..pruner import Pruner
 
 
-class PriorThresholdPruner(Pruner):
+class PriorThresholdPruner(Pruner[DType]):
     """A pruner that removes mixture components based on a weight threshold.
 
     This pruner iterates through the components of a :class:`rework_pysatl_mpest.core.MixtureModel`
@@ -57,7 +58,7 @@ class PriorThresholdPruner(Pruner):
             raise ValueError("Threshold must be between 0 and 1.")
         self.threshold = threshold
 
-    def prune(self, state: PipelineState) -> tuple[PipelineState, list[int]]:
+    def prune(self, state: PipelineState[DType]) -> tuple[PipelineState[DType], list[int]]:
         """Removes components from the mixture whose weights are below the threshold.
 
         This method inspects :attr:`state.curr_mixture` and removes any component
@@ -68,13 +69,13 @@ class PriorThresholdPruner(Pruner):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline, containing the mixture model
             to be pruned.
 
         Returns
         -------
-        tuple[PipelineState, list[int]]
+        tuple[PipelineState[DType], list[int]]
         A tuple containing:
         - The updated pipeline state. If components were removed,
           :attr:`state.curr_mixture` will be a new,

--- a/rework_pysatl_mpest/estimators/iterative/steps/block.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/block.py
@@ -27,9 +27,13 @@ class MaximizationStrategy(Enum):
     QFUNCTION
         Indicates that the optimization should maximize the Q-function,
         which is the expected value of the complete-data log-likelihood.
+    MOMENTS
+    Indicates that the optimization should use the Method of Moments,
+    matching theoretical moments to empirical weighted moments.
     """
 
     QFUNCTION = auto()
+    MOMENTS = auto()
 
 
 @dataclass

--- a/rework_pysatl_mpest/estimators/iterative/steps/expectation_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/expectation_step.py
@@ -1,6 +1,6 @@
 """Provides the Expectation-step for an iterative estimation pipeline."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -8,11 +8,12 @@ __license__ = "SPDX-License-Identifier: MIT"
 import numpy as np
 from scipy.special import logsumexp
 
+from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 
 
-class ExpectationStep(PipelineStep):
+class ExpectationStep(PipelineStep[DType]):
     """A pipeline step that performs the Expectation (E-step).
 
     This step calculates the responsibility matrix H, where H[i, j] is
@@ -57,7 +58,7 @@ class ExpectationStep(PipelineStep):
 
         return [MaximizationStep]
 
-    def run(self, state: PipelineState) -> PipelineState:
+    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
         """Executes the E-step by calculating the responsibility matrix H.
 
         This method computes the log-likelihood of each data point under each
@@ -67,17 +68,19 @@ class ExpectationStep(PipelineStep):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline, which must contain the input
             data X and the current mixture model curr_mixture.
 
         Returns
         -------
-        PipelineState
+        PipelineState[DType]
             The updated pipeline state with the H attribute computed and set.
         """
 
         X, mixture = state.X, state.curr_mixture
+
+        dtype = mixture.dtype
 
         log_p_xij_matrix = np.array([comp.lpdf(X) for comp in mixture.components])
         log_p_xij_matrix = log_p_xij_matrix.T
@@ -87,14 +90,14 @@ class ExpectationStep(PipelineStep):
         log_H = log_weighted_likelihoods - log_denominator
 
         H_soft = np.exp(log_H)
-        H_soft[np.isnan(H_soft)] = 0.0
+        H_soft[np.isnan(H_soft)] = dtype(0.0)
 
         if not self.is_soft:
             n_samples = X.shape[0]
-            H_hard = np.zeros_like(H_soft)
+            H_hard = np.zeros_like(H_soft, dtype=dtype)
 
             max_indices = np.argmax(H_soft, axis=1)
-            H_hard[np.arange(n_samples), max_indices] = 1.0
+            H_hard[np.arange(n_samples), max_indices] = dtype(1.0)
 
             state.H = H_hard
         else:

--- a/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -23,7 +23,7 @@ import numpy as np
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
 from ....typings import DType
-from .._strategies import q_function_strategy
+from .._strategies import moments_strategy, q_function_strategy
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 from .block import MaximizationStrategy, OptimizationBlock
@@ -64,7 +64,10 @@ class MaximizationStep(PipelineStep[DType]):
     """
 
     _strategies: ClassVar[Mapping[MaximizationStrategy, Callable]] = MappingProxyType(
-        {MaximizationStrategy.QFUNCTION: q_function_strategy}
+        {
+            MaximizationStrategy.QFUNCTION: q_function_strategy,
+            MaximizationStrategy.MOMENTS: moments_strategy,
+        }
     )
 
     def __init__(self, blocks: Sequence[OptimizationBlock], optimizer: Optimizer[DType]):

--- a/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -9,7 +9,7 @@ log-likelihood, using the responsibilities computed in a preceding
 Expectation-step.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -22,13 +22,14 @@ import numpy as np
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
+from ....typings import DType
 from .._strategies import q_function_strategy
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 from .block import MaximizationStrategy, OptimizationBlock
 
 
-class MaximizationStep(PipelineStep):
+class MaximizationStep(PipelineStep[DType]):
     """A pipeline step that performs the Maximization (M-step).
 
     This step updates the parameters of each component in the mixture model,
@@ -83,14 +84,14 @@ class MaximizationStep(PipelineStep):
 
         return [ExpectationStep]
 
-    def _update_components_params(self, component: ContinuousDistribution, params: dict[str, float]):
+    def _update_components_params(self, component: ContinuousDistribution, params: dict[str, DType]):
         """Helper method to update parameters for a single component.
 
         Parameters
         ----------
         component : ContinuousDistribution
             The component whose parameters are to be updated.
-        params : dict[str, float]
+        params : dict[str, DType]
             A dictionary mapping parameter names to their new optimized values.
         """
 
@@ -98,7 +99,7 @@ class MaximizationStep(PipelineStep):
         param_values = list(params.values())
         component.set_params_from_vector(param_names, param_values)
 
-    def run(self, state: PipelineState) -> PipelineState:
+    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
         """Executes the M-step.
 
         This method iterates through the configured optimization blocks,
@@ -108,13 +109,13 @@ class MaximizationStep(PipelineStep):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline. Must contain the responsibility
             matrix :attr:`H` and the mixture model :attr:`curr_mixture`.
 
         Returns
         -------
-        PipelineState
+        PipelineState[DType]
             The updated pipeline state with the modified :attr:`curr_mixture`. If the
             :attr:`H` matrix is not available in the input state, the state is
             returned with an error set, and no modifications are made.
@@ -128,9 +129,13 @@ class MaximizationStep(PipelineStep):
         results = []
         curr_mixture = state.curr_mixture
 
+        dtype = curr_mixture.dtype
+
         for block in self.blocks:
             strategy = self._strategies[block.maximization_strategy]
             component_id, new_params = strategy(curr_mixture[block.component_id], state, block, self.optimizer)
+            if state.error:
+                return state
             results.append((component_id, new_params))
 
         for result in results:
@@ -139,7 +144,7 @@ class MaximizationStep(PipelineStep):
 
         responsibilities_sum = np.sum(state.H, axis=0)
         new_weights = responsibilities_sum / state.X.shape[0]
-        curr_mixture.log_weights = np.log(new_weights + 1e-30)
+        curr_mixture.log_weights = np.log(new_weights + dtype(1e-30))
 
         return state
 

--- a/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -44,7 +44,7 @@ class MaximizationStep(PipelineStep[DType]):
         A sequence of configuration blocks that define the optimization tasks.
         Each block specifies a component, its parameters to optimize, and the
         maximization strategy to use.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         A numerical optimizer instance used to find the optimal parameters
         when an analytical solution is not available for a given strategy.
 
@@ -52,7 +52,7 @@ class MaximizationStep(PipelineStep[DType]):
     ----------
     blocks : list[OptimizationBlock]
         The list of optimization tasks to be performed.
-    optimizer : Optimizer
+    optimizer : Optimizer[DType]
         The numerical optimizer used for parameter estimation.
 
     Methods
@@ -67,7 +67,7 @@ class MaximizationStep(PipelineStep[DType]):
         {MaximizationStrategy.QFUNCTION: q_function_strategy}
     )
 
-    def __init__(self, blocks: Sequence[OptimizationBlock], optimizer: Optimizer):
+    def __init__(self, blocks: Sequence[OptimizationBlock], optimizer: Optimizer[DType]):
         self.blocks = list(blocks)
         self.optimizer = optimizer
 

--- a/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -14,9 +14,9 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from types import MappingProxyType
-from typing import Callable, ClassVar
+from typing import ClassVar
 
 import numpy as np
 

--- a/rework_pysatl_mpest/exceptions.py
+++ b/rework_pysatl_mpest/exceptions.py
@@ -1,0 +1,15 @@
+"""A module that provides custom exceptions for the project."""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+class NumericalStabilityError(Exception):
+    """
+    Exception raised for issues related to numerical stability, such as
+    overflow or underflow, during calculations.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/rework_pysatl_mpest/initializers/cluster_match_strategy.py
+++ b/rework_pysatl_mpest/initializers/cluster_match_strategy.py
@@ -6,9 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from collections.abc import Callable
 from copy import copy
 from itertools import permutations
-from typing import Callable
 
 import numpy as np
 

--- a/rework_pysatl_mpest/initializers/clusterize_initializer.py
+++ b/rework_pysatl_mpest/initializers/clusterize_initializer.py
@@ -333,5 +333,5 @@ class ClusterizeInitializer(Initializer):
 
         total_weight = sum(weights)
         normalized_weights: list[float] = [w / total_weight for w in weights]
-        current_mixture = MixtureModel(distributions, normalized_weights)
+        current_mixture = MixtureModel(distributions, normalized_weights)  # type: ignore[var-annotated]
         return current_mixture

--- a/rework_pysatl_mpest/initializers/clusterize_initializer.py
+++ b/rework_pysatl_mpest/initializers/clusterize_initializer.py
@@ -6,9 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -118,7 +118,7 @@ class ClusterizeInitializer(Initializer):
         self.is_soft = is_soft
         self.is_accurate = is_accurate
         self.clusterizer = clusterizer
-        self.n_components: Optional[int] = None
+        self.n_components: int | None = None
         self.cluster_match_strategy: ClusterMatchStrategy = ClusterMatchStrategy.LIKELIHOOD
         self.estimation_strategies: list[EstimationStrategy] = []
         self.models: list[ContinuousDistribution] = []

--- a/rework_pysatl_mpest/optimizers/optimizer.py
+++ b/rework_pysatl_mpest/optimizers/optimizer.py
@@ -5,13 +5,15 @@ for implementing various optimization algorithms. Any concrete optimizer should
 inherit from this class and implement the :meth:`minimize` method.
 """
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+
+from ..typings import DType
 
 
 class Optimizer(ABC):
@@ -33,7 +35,7 @@ class Optimizer(ABC):
     """
 
     @abstractmethod
-    def minimize(self, target: Callable, params: list[float]) -> list[float]:
+    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
         """Finds the parameters that minimize a target function.
 
         This abstract method must be implemented by subclasses to perform the
@@ -45,13 +47,13 @@ class Optimizer(ABC):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[float]
+        params : list[DType]
             A list of initial values for the parameters to be optimized. This
             serves as the starting point for the optimization algorithm.
 
         Returns
         -------
-        list[float]
+        list[Dtype]
             A list containing the set of parameters that minimizes the
             target function.
         """

--- a/rework_pysatl_mpest/optimizers/optimizer.py
+++ b/rework_pysatl_mpest/optimizers/optimizer.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from ..typings import DType
 
 
-class Optimizer(ABC):
+class Optimizer(ABC, Generic[DType]):
     """Abstract base class for numerical optimizers.
 
     This class defines the standard interface for all optimizer implementations.

--- a/rework_pysatl_mpest/optimizers/optimizer.py
+++ b/rework_pysatl_mpest/optimizers/optimizer.py
@@ -11,7 +11,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from abc import ABC, abstractmethod
-from typing import Callable
+from collections.abc import Callable
 
 
 class Optimizer(ABC):

--- a/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
+++ b/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from scipy.optimize import minimize
 

--- a/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
+++ b/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
@@ -1,14 +1,16 @@
 """A module that provides a Nelder-Mead optimizer using the SciPy library."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 from collections.abc import Callable
 
+import numpy as np
 from scipy.optimize import minimize
 
+from ..typings import DType
 from .optimizer import Optimizer
 
 
@@ -29,7 +31,7 @@ class ScipyNelderMead(Optimizer):
         minimize
     """
 
-    def minimize(self, target: Callable, params: list[float]) -> list[float]:
+    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
         """Minimizes a target function using the Nelder-Mead algorithm.
 
         This method leverages the `scipy.optimize.minimize` function to find
@@ -41,15 +43,17 @@ class ScipyNelderMead(Optimizer):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[float]
+        params : list[DType]
             A list of initial values for the parameters that serves as the
             starting point for the optimization.
 
         Returns
         -------
-        list[float]
+        list[DType]
             A list containing the set of parameters that minimizes the target
             function, as found by the Nelder-Mead algorithm.
         """
 
-        return list(minimize(target, params, method="Nelder-Mead").x)
+        dtype = params[0].dtype
+
+        return list(np.asarray(minimize(target, params, method="Nelder-Mead").x, dtype=dtype))

--- a/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
+++ b/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
@@ -14,7 +14,7 @@ from ..typings import DType
 from .optimizer import Optimizer
 
 
-class ScipyNelderMead(Optimizer):
+class ScipyNelderMead(Optimizer[DType]):
     """An optimizer that uses the Nelder-Mead simplex algorithm from SciPy.
 
     This class serves as a wrapper for the `scipy.optimize.minimize` function,

--- a/rework_pysatl_mpest/optimizers/scipy_powell.py
+++ b/rework_pysatl_mpest/optimizers/scipy_powell.py
@@ -14,7 +14,7 @@ from ..typings import DType
 from .optimizer import Optimizer
 
 
-class ScipyPowell(Optimizer):
+class ScipyPowell(Optimizer[DType]):
     """An optimizer that uses Powell's conjugate direction method from SciPy.
 
     This class serves as a wrapper for the `scipy.optimize.minimize` function,

--- a/rework_pysatl_mpest/optimizers/scipy_powell.py
+++ b/rework_pysatl_mpest/optimizers/scipy_powell.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from scipy.optimize import minimize
 

--- a/rework_pysatl_mpest/optimizers/scipy_powell.py
+++ b/rework_pysatl_mpest/optimizers/scipy_powell.py
@@ -1,14 +1,16 @@
 """A module that provides a Powell optimizer using the SciPy library."""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
 from collections.abc import Callable
 
+import numpy as np
 from scipy.optimize import minimize
 
+from ..typings import DType
 from .optimizer import Optimizer
 
 
@@ -29,7 +31,7 @@ class ScipyPowell(Optimizer):
         minimize
     """
 
-    def minimize(self, target: Callable, params: list[float]) -> list[float]:
+    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
         """Minimizes a target function using Powell's method.
 
         This method leverages the `scipy.optimize.minimize` function to find
@@ -41,15 +43,17 @@ class ScipyPowell(Optimizer):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[float]
+        params : list[DType]
             A list of initial values for the parameters that serves as the
             starting point for the optimization.
 
         Returns
         -------
-        list[float]
+        list[DType]
             A list containing the set of parameters that minimizes the target
             function, as found by Powell's method.
         """
 
-        return list(minimize(target, params, method="Powell").x)
+        dtype = params[0].dtype
+
+        return list(np.asarray(minimize(target, params, method="Powell").x, dtype=dtype))

--- a/rework_pysatl_mpest/typings.py
+++ b/rework_pysatl_mpest/typings.py
@@ -1,0 +1,11 @@
+"""A module that provides custom types for the project."""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from typing import TypeVar
+
+import numpy as np
+
+DType = TypeVar("DType", bound=np.floating)

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -387,9 +387,9 @@ class TestMixtureModelGenerate:
         target_dtype = np.float32
         mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
 
-        empty_array = mixture.generate(size=size)
-        assert empty_array.shape == (size,)
-        assert empty_array.dtype == target_dtype
+        samples = mixture.generate(size=size)
+        assert samples.shape == (size,)
+        assert samples.dtype == target_dtype
 
 
 class TestMixtureModelDunderMethods:

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -89,6 +89,40 @@ class TestMixtureModelInitialization:
         with pytest.raises(ValueError, match="List of components cannot be an empty"):
             MixtureModel(components=[])
 
+    def test_init_casts_component_dtypes(self):
+        """Tests that the MixtureModel casts all components to its own dtype during initialization."""
+        comp1_f64 = Exponential(loc=0.0, rate=1.0)
+        comp2_f64 = Exponential(loc=5.0, rate=2.0)
+        assert comp1_f64.dtype == np.float64
+
+        target_dtype = np.float32
+        mixture = MixtureModel(components=[comp1_f64, comp2_f64], dtype=target_dtype)
+
+        assert mixture.dtype == target_dtype
+        assert mixture.weights.dtype == target_dtype
+
+        for component in mixture.components:
+            assert component.dtype == target_dtype
+            for param in component.params:
+                assert isinstance(getattr(component, param), target_dtype)
+
+        # Original components have not changed
+        for component in [comp1_f64, comp2_f64]:
+            assert component.dtype == np.float64
+            for param in component.params:
+                assert isinstance(getattr(component, param), np.float64)
+
+    def test_init_does_not_recreate_components_with_correct_dtype(self):
+        """Tests that components with the correct dtype are not recreated."""
+        target_dtype = np.float32
+        comp_f32 = Exponential(loc=0.0, rate=1.0, dtype=target_dtype)
+
+        original_id = id(comp_f32)
+
+        mixture = MixtureModel(components=[comp_f32], dtype=target_dtype)
+
+        assert id(mixture.components[0]) == original_id
+
 
 class TestMixtureModelProperties:
     """Tests for the properties of the MixtureModel class."""
@@ -143,6 +177,14 @@ class TestMixtureModelProperties:
         with pytest.raises(ValueError, match="The length of the new logit vector does not match"):
             mixture_model.log_weights = np.log([0.1, 0.2, 0.7])
 
+    def test_properties_have_correct_dtype(self):
+        """Tests that checks the dtype of the weights and log_weights properties."""
+        target_dtype = np.float32
+        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
+
+        assert mixture.weights.dtype == target_dtype
+        assert mixture.log_weights.dtype == target_dtype
+
 
 class TestMixtureModelModification:
     """Tests for methods that modify the MixtureModel instance."""
@@ -174,6 +216,26 @@ class TestMixtureModelModification:
 
         with pytest.raises(ValueError, match="The weight of the new component must be in the range"):
             mixture_model.add_component(Exponential(10, 3), weight=invalid_weight)
+
+    def test_add_component_casts_dtype(self):
+        """Tests that the add_component method casts the type of the new component to the dtype of the mixture."""
+        comp = Exponential(loc=0.0, rate=1.0)
+        target_dtype = np.float32
+        mixture = MixtureModel(components=[comp], dtype=target_dtype)
+
+        new_comp_f64 = Exponential(loc=10.0, rate=2.0)
+        assert new_comp_f64.dtype == np.float64
+
+        mixture.add_component(new_comp_f64, weight=0.3)
+
+        added_component_in_mixture = mixture.components[-1]
+        assert added_component_in_mixture.dtype == target_dtype
+        assert isinstance(added_component_in_mixture.loc, target_dtype)
+
+        # Original component have not changed
+        assert comp.dtype == np.float64
+        for param in comp.params:
+            assert isinstance(getattr(comp, param), np.float64)
 
     def test_remove_component(self):
         """Tests removing a component and verifies weight renormalization."""
@@ -233,6 +295,18 @@ class TestMixtureModelCalculations:
         assert isinstance(calculated_lpdf, np.ndarray)
         np.testing.assert_allclose(calculated_lpdf, expected_lpdf)
 
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf"])
+    def test_pdf_lpdf_methods_return_correct_dtype(self, method_name: str):
+        """Tests that pdf and lpdf methods return arrays of the correct dtype."""
+        target_dtype = np.float32
+        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
+        method_to_test = getattr(mixture, method_name)
+
+        input_x = np.array([1.0, 2.0, 3.0])
+        result = method_to_test(input_x)
+
+        assert result.dtype == target_dtype
+
     def test_loglikelihood_calculation(self, mixture_model: MixtureModel):
         """Tests that loglikelihood is the sum of LPDF values."""
 
@@ -240,8 +314,17 @@ class TestMixtureModelCalculations:
         expected_loglikelihood = np.sum(mixture_model.lpdf(X))
         calculated_loglikelihood = mixture_model.loglikelihood(X)
 
-        assert isinstance(calculated_loglikelihood, float)
+        assert isinstance(calculated_loglikelihood, np.float64)
         assert np.isclose(calculated_loglikelihood, expected_loglikelihood)
+
+    def test_loglikelihood_returns_numpy_scalar_with_correct_dtype(self):
+        """Tests that checks that loglikelihood returns a NumPy scalar of the correct type."""
+        target_dtype = np.float32
+        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
+
+        loglik = mixture.loglikelihood(np.array([1, 2, 3]))
+
+        assert isinstance(loglik, target_dtype)
 
 
 class TestMixtureModelGenerate:
@@ -297,6 +380,16 @@ class TestMixtureModelGenerate:
         samples_from_c1 = samples[samples < midpoint_between_means]
         proportion_c1 = len(samples_from_c1) / n_samples
         assert proportion_c1 == pytest.approx(weights[0], abs=0.05)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_array_with_correct_dtype(self, size):
+        """Tests that generate returns an array with the correct dtype."""
+        target_dtype = np.float32
+        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
+
+        empty_array = mixture.generate(size=size)
+        assert empty_array.shape == (size,)
+        assert empty_array.dtype == target_dtype
 
 
 class TestMixtureModelDunderMethods:
@@ -442,6 +535,13 @@ class TestMixtureModelComparison:
         m1 = MixtureModel(components=c1, weights=[0.4, 0.6])
         m2 = MixtureModel(components=c2, weights=[1.0])
         assert m1 != m2
+
+    def test_neq_other_object(self, mixture_model, exp_components):
+        """Tests that a model instance is not equal to an object of a different class."""
+        model = mixture_model
+
+        other = "not_a_mixture_model"
+        assert model != other
 
     def test_hash_consistency(self):
         """Tests that equal models produce the same hash."""

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -381,26 +381,31 @@ class TestMixtureModelCalculations:
 class TestMixtureModelGenerate:
     """Statistical tests for the `generate` method."""
 
-    def test_generate_returns_correct_size(self, mixture_model: MixtureModel):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+            ((2, 0), (2, 0), False),
+        ],
+    )
+    def test_generate_returns_correct_size(self, mixture_model: MixtureModel, size, expected_shape, is_scalar):
         """Tests that generate returns an array of the requested size."""
-
-        size = 100
-        dtype = mixture_model.dtype
 
         samples = mixture_model.generate(size=size)
 
-        assert len(samples) == size
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-
-    def test_generate_with_size_zero(self, mixture_model):
-        """Tests that generating with size = 0 returns an empty array."""
-
-        dtype = mixture_model.dtype
-
-        samples = mixture_model.generate(0)
-        assert len(samples) == 0
-        assert samples.dtype == dtype
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, mixture_model.dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == mixture_model.dtype
+            if 0 in expected_shape:
+                assert samples.size == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_with_negative_size(self, mixture_model: MixtureModel, size: int):

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -68,9 +68,10 @@ class TestMixtureModelInitialization:
         model = MixtureModel(components=exp_components, weights=weights, dtype=dtype)
         expected_n_components = 2
         assert model.n_components == expected_n_components
-        if dtype == np.float64:
-            np.testing.assert_allclose(model.weights, weights)
-            np.testing.assert_allclose(np.exp(model.log_weights), weights, atol=1e-9)
+
+        atol = np.finfo(dtype).eps
+        np.testing.assert_allclose(model.weights, weights, rtol=atol)
+        np.testing.assert_allclose(np.exp(model.log_weights), weights, rtol=atol)
 
     @pytest.mark.parametrize(
         "invalid_weights, error_msg",
@@ -134,11 +135,11 @@ class TestMixtureModelInitialization:
     def test_init_does_not_recreate_components_with_correct_dtype(self, dtype):
         """Tests that components with the correct dtype are not recreated."""
 
-        comp_f32 = Exponential(loc=0.0, rate=1.0, dtype=dtype)
+        comp = Exponential(loc=0.0, rate=1.0, dtype=dtype)
 
-        original_id = id(comp_f32)
+        original_id = id(comp)
 
-        mixture = MixtureModel(components=[comp_f32], dtype=dtype)
+        mixture = MixtureModel(components=[comp], dtype=dtype)
 
         assert id(mixture.components[0]) == original_id
 
@@ -304,24 +305,26 @@ class TestMixtureModelCalculations:
         expected_pdf = w1 * c1.pdf(X) + w2 * c2.pdf(X)
         calculated_pdf = mixture_model.pdf(X)
 
-        assert isinstance(calculated_pdf, np.ndarray)
         assert calculated_pdf.dtype == dtype
-        if dtype == np.float64:
-            np.testing.assert_allclose(calculated_pdf, expected_pdf)
+        if not np.isscalar(X):
+            assert isinstance(calculated_pdf, np.ndarray)
+
+        np.testing.assert_allclose(calculated_pdf, expected_pdf, rtol=np.finfo(dtype).eps)
 
     @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
     def test_lpdf_calculation(self, mixture_model: MixtureModel, X):
         """Tests the LPDF calculation against the definition."""
 
         dtype = mixture_model.dtype
+        c1, c2 = mixture_model.components
+        w1, w2 = mixture_model.weights
 
-        expected_lpdf = np.log(mixture_model.pdf(X))
+        expected_lpdf = np.log(w1 * c1.pdf(X) + w2 * c2.pdf(X))
         calculated_lpdf = mixture_model.lpdf(X)
 
         assert isinstance(calculated_lpdf, np.ndarray)
         assert calculated_lpdf.dtype == dtype
-        if dtype == np.float64:
-            np.testing.assert_allclose(calculated_lpdf, expected_lpdf)
+        np.testing.assert_allclose(calculated_lpdf, expected_lpdf, rtol=np.finfo(dtype).eps)
 
     def test_loglikelihood_calculation(self, mixture_model: MixtureModel):
         """Tests that loglikelihood is the sum of LPDF values."""
@@ -353,7 +356,11 @@ class TestMixtureModelGenerate:
     def test_generate_with_size_zero(self, mixture_model):
         """Tests that generating with size = 0 returns an empty array."""
 
-        assert len(mixture_model.generate(0)) == 0
+        dtype = mixture_model.dtype
+
+        samples = mixture_model.generate(0)
+        assert len(samples) == 0
+        assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_with_negative_size(self, mixture_model: MixtureModel, size: int):

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -401,6 +401,52 @@ class TestMixtureModelGenerate:
         assert proportion_c1 == pytest.approx(weights[0], abs=0.05)
 
 
+class TestMixtureModelAstype:
+    """Tests for astype method of MixtureModel"""
+
+    def test_astype_successful_conversion(self, exp_components: tuple[Exponential, Exponential]):
+        """
+        Tests that astype creates a new instance with the correct new dtype
+        and that the original instance remains unchanged.
+        """
+        mixture_model = MixtureModel(components=exp_components, weights=[0.5, 0.5], dtype=np.float64)
+
+        assert mixture_model.dtype == np.float64
+        assert mixture_model.log_weights.dtype == np.float64
+        for component in mixture_model.components:
+            assert component.dtype == np.float64
+
+        target_dtype = np.float32
+        new_mixture = mixture_model.astype(target_dtype)
+
+        assert new_mixture is not mixture_model
+        assert new_mixture != mixture_model
+
+        assert new_mixture.dtype == np.float32
+        assert new_mixture.log_weights.dtype == np.float32
+        for component in new_mixture.components:
+            assert component.dtype == np.float32
+
+        # original instance remains unchanged
+        assert mixture_model.dtype == np.float64
+        assert mixture_model.log_weights.dtype == np.float64
+        for component in mixture_model.components:
+            assert component.dtype == np.float64
+
+    def test_astype_returns_self_if_same_dtype(self, exp_components: tuple[Exponential, Exponential]):
+        """
+        Tests that astype returns the same instance if the target dtype
+        is identical to the current one, avoiding unnecessary copying.
+        """
+        mixture_model = MixtureModel(components=exp_components, weights=[0.5, 0.5], dtype=np.float64)
+
+        assert mixture_model.dtype == np.float64
+
+        same_dtype_dist = mixture_model.astype(np.float64)
+
+        assert same_dtype_dist is mixture_model
+
+
 class TestMixtureModelDunderMethods:
     """Tests for special (dunder) methods of MixtureModel."""
 

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -16,6 +16,8 @@ from hypothesis import strategies as st
 from rework_pysatl_mpest.core import MixtureModel
 from rework_pysatl_mpest.distributions import ContinuousDistribution, Exponential
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
 
 @pytest.fixture
 def exp_components() -> tuple[Exponential, Exponential]:
@@ -24,13 +26,15 @@ def exp_components() -> tuple[Exponential, Exponential]:
     return Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)
 
 
-@pytest.fixture
-def mixture_model(exp_components: tuple[Exponential, Exponential]) -> MixtureModel:
+@pytest.fixture(params=DTYPES_TO_TEST)
+def mixture_model(exp_components: tuple[Exponential, Exponential], request) -> MixtureModel:
     """Provides a standard MixtureModel instance with two components and equal weights."""
 
-    return MixtureModel(components=exp_components, weights=[0.5, 0.5])
+    dtype = request.param
+    return MixtureModel(components=exp_components, weights=[0.5, 0.5], dtype=dtype)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestMixtureModelInitialization:
     """Tests for the __init__ method of MixtureModel."""
 
@@ -41,70 +45,85 @@ class TestMixtureModelInitialization:
             [Exponential(loc=0, rate=1), Exponential(loc=1, rate=2)],
         ],
     )
-    def test_init_with_valid_component_sequences(self, components_seq: Sequence[ContinuousDistribution]):
+    def test_init_with_valid_component_sequences(self, components_seq: Sequence[ContinuousDistribution], dtype):
         """Tests that MixtureModel can be initialized with different sequence types."""
 
-        model = MixtureModel(components=components_seq)
+        model = MixtureModel(components=components_seq, dtype=dtype)
         expected_n_components = 2
         assert model.n_components == expected_n_components
         assert isinstance(model.components, tuple)
 
-    def test_init_with_equal_weights_by_default(self, exp_components: tuple[Exponential, Exponential]):
+    def test_init_with_equal_weights_by_default(self, exp_components: tuple[Exponential, Exponential], dtype):
         """Tests that weights are distributed equally when not provided."""
 
-        model = MixtureModel(components=exp_components)
+        model = MixtureModel(components=exp_components, dtype=dtype)
         expected_n_components = 2
         assert model.n_components == expected_n_components
         np.testing.assert_allclose(model.weights, [0.5, 0.5])
 
-    def test_init_with_specified_weights(self, exp_components: tuple[Exponential, Exponential]):
+    def test_init_with_specified_weights(self, exp_components: tuple[Exponential, Exponential], dtype):
         """Tests initialization with correctly specified weights."""
 
         weights = [0.3, 0.7]
-        model = MixtureModel(components=exp_components, weights=weights)
+        model = MixtureModel(components=exp_components, weights=weights, dtype=dtype)
         expected_n_components = 2
         assert model.n_components == expected_n_components
-        np.testing.assert_allclose(model.weights, weights)
-        np.testing.assert_allclose(np.exp(model.log_weights), weights, atol=1e-9)
+        if dtype == np.float64:
+            np.testing.assert_allclose(model.weights, weights)
+            np.testing.assert_allclose(np.exp(model.log_weights), weights, atol=1e-9)
 
     @pytest.mark.parametrize(
         "invalid_weights, error_msg",
         [
             ([0.5, 0.5, 0.5], "Components number \\(2\\) must be equal to weights number \\(3\\)."),
             ([-0.2, 1.2], "Weights must be positive."),
-            ([0.4, 0.4], "Sum of the weights must be equal 1, but it equal 0.8."),
         ],
     )
     def test_init_with_invalid_weights_raises_value_error(
-        self, exp_components: tuple[Exponential, Exponential], invalid_weights: list[float], error_msg: str
+        self, exp_components: tuple[Exponential, Exponential], invalid_weights: list[float], error_msg: str, dtype
     ):
         """Tests that initialization with invalid weights raises a ValueError."""
 
         with pytest.raises(ValueError, match=error_msg):
-            MixtureModel(components=exp_components, weights=invalid_weights)
+            MixtureModel(components=exp_components, weights=invalid_weights, dtype=dtype)
 
-    def test_init_with_empty_components_raises_value_error(self):
+    @pytest.mark.parametrize(
+        "invalid_weights, error_msg",
+        [
+            ([0.4, 0.4], "Sum of the weights must be equal 1, but it equal "),
+        ],
+    )
+    def test_init_with_invalid_sum_of_weights_raises_value_error(
+        self, exp_components: tuple[Exponential, Exponential], invalid_weights: list[float], error_msg: str, dtype
+    ):
+        """Tests that initialization with invalid sum of weights raises a ValueError."""
+        with pytest.raises(ValueError) as excinfo:
+            MixtureModel(components=exp_components, weights=invalid_weights, dtype=dtype)
+
+        actual_error_msg = str(excinfo.value)
+        assert actual_error_msg.startswith(error_msg)
+
+    def test_init_with_empty_components_raises_value_error(self, dtype):
         """Tests that initialization with an empty component list raises a ValueError."""
 
         with pytest.raises(ValueError, match="List of components cannot be an empty"):
-            MixtureModel(components=[])
+            MixtureModel(components=[], dtype=dtype)
 
-    def test_init_casts_component_dtypes(self):
+    def test_init_casts_component_dtypes(self, dtype):
         """Tests that the MixtureModel casts all components to its own dtype during initialization."""
+
         comp1_f64 = Exponential(loc=0.0, rate=1.0)
         comp2_f64 = Exponential(loc=5.0, rate=2.0)
         assert comp1_f64.dtype == np.float64
 
-        target_dtype = np.float32
-        mixture = MixtureModel(components=[comp1_f64, comp2_f64], dtype=target_dtype)
+        mixture = MixtureModel(components=[comp1_f64, comp2_f64], dtype=dtype)
 
-        assert mixture.dtype == target_dtype
-        assert mixture.weights.dtype == target_dtype
-
+        assert mixture.dtype == dtype
+        assert mixture.weights.dtype == dtype
         for component in mixture.components:
-            assert component.dtype == target_dtype
+            assert component.dtype == dtype
             for param in component.params:
-                assert isinstance(getattr(component, param), target_dtype)
+                assert isinstance(getattr(component, param), dtype)
 
         # Original components have not changed
         for component in [comp1_f64, comp2_f64]:
@@ -112,14 +131,14 @@ class TestMixtureModelInitialization:
             for param in component.params:
                 assert isinstance(getattr(component, param), np.float64)
 
-    def test_init_does_not_recreate_components_with_correct_dtype(self):
+    def test_init_does_not_recreate_components_with_correct_dtype(self, dtype):
         """Tests that components with the correct dtype are not recreated."""
-        target_dtype = np.float32
-        comp_f32 = Exponential(loc=0.0, rate=1.0, dtype=target_dtype)
+
+        comp_f32 = Exponential(loc=0.0, rate=1.0, dtype=dtype)
 
         original_id = id(comp_f32)
 
-        mixture = MixtureModel(components=[comp_f32], dtype=target_dtype)
+        mixture = MixtureModel(components=[comp_f32], dtype=dtype)
 
         assert id(mixture.components[0]) == original_id
 
@@ -141,10 +160,11 @@ class TestMixtureModelProperties:
         with pytest.raises(TypeError):
             components[0] = Exponential(0, 1)  # type: ignore
 
-    def test_weights_caching(self, exp_components: tuple[Exponential, Exponential]):
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    def test_weights_caching(self, exp_components: tuple[Exponential, Exponential], dtype):
         """Tests the caching mechanism of the 'weights' property."""
 
-        model = MixtureModel(components=exp_components)
+        model = MixtureModel(components=exp_components, dtype=dtype)
         assert model._cached_weights is None
 
         first_access_weights = model.weights
@@ -164,12 +184,12 @@ class TestMixtureModelProperties:
         mixture_model.log_weights = new_log_weights
 
         assert mixture_model._cached_weights is None
-        np.testing.assert_allclose(mixture_model.log_weights, new_log_weights)
+        np.testing.assert_allclose(mixture_model.log_weights, new_log_weights, atol=1e-3)
 
         new_weights = mixture_model.weights
-        np.testing.assert_allclose(new_weights, [0.3, 0.7])
+        np.testing.assert_allclose(new_weights, [0.3, 0.7], atol=1e-3)
         assert id(old_weights) != id(new_weights)
-        assert np.isclose(np.sum(new_weights), 1.0)
+        assert np.isclose(np.sum(new_weights), 1.0, atol=1e-3)
 
     def test_log_weights_setter_with_invalid_shape_raises_error(self, mixture_model: MixtureModel):
         """Tests that setting log_weights with an incorrect shape raises a ValueError."""
@@ -177,13 +197,11 @@ class TestMixtureModelProperties:
         with pytest.raises(ValueError, match="The length of the new logit vector does not match"):
             mixture_model.log_weights = np.log([0.1, 0.2, 0.7])
 
-    def test_properties_have_correct_dtype(self):
+    def test_properties_have_correct_dtype(self, mixture_model: MixtureModel):
         """Tests that checks the dtype of the weights and log_weights properties."""
-        target_dtype = np.float32
-        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
 
-        assert mixture.weights.dtype == target_dtype
-        assert mixture.log_weights.dtype == target_dtype
+        assert mixture_model.weights.dtype == mixture_model.dtype
+        assert mixture_model.log_weights.dtype == mixture_model.dtype
 
 
 class TestMixtureModelModification:
@@ -192,8 +210,10 @@ class TestMixtureModelModification:
     def test_add_component(self, mixture_model: MixtureModel):
         """Tests adding a new component and verifies weight preservation and renormalization."""
 
+        dtype = mixture_model.dtype
+
         old_weights = mixture_model.weights.copy()
-        new_component = Exponential(loc=10, rate=3)
+        new_component = Exponential(loc=10, rate=3, dtype=dtype)
         new_weight = 0.4
 
         mixture_model.add_component(new_component, weight=new_weight)
@@ -217,11 +237,12 @@ class TestMixtureModelModification:
         with pytest.raises(ValueError, match="The weight of the new component must be in the range"):
             mixture_model.add_component(Exponential(10, 3), weight=invalid_weight)
 
-    def test_add_component_casts_dtype(self):
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    def test_add_component_casts_dtype(self, dtype):
         """Tests that the add_component method casts the type of the new component to the dtype of the mixture."""
+
         comp = Exponential(loc=0.0, rate=1.0)
-        target_dtype = np.float32
-        mixture = MixtureModel(components=[comp], dtype=target_dtype)
+        mixture = MixtureModel(components=[comp], dtype=dtype)
 
         new_comp_f64 = Exponential(loc=10.0, rate=2.0)
         assert new_comp_f64.dtype == np.float64
@@ -229,8 +250,8 @@ class TestMixtureModelModification:
         mixture.add_component(new_comp_f64, weight=0.3)
 
         added_component_in_mixture = mixture.components[-1]
-        assert added_component_in_mixture.dtype == target_dtype
-        assert isinstance(added_component_in_mixture.loc, target_dtype)
+        assert added_component_in_mixture.dtype == dtype
+        assert isinstance(added_component_in_mixture.loc, dtype)
 
         # Original component have not changed
         assert comp.dtype == np.float64
@@ -276,6 +297,7 @@ class TestMixtureModelCalculations:
     def test_pdf_calculation(self, mixture_model: MixtureModel, X):
         """Tests the PDF calculation against the definition."""
 
+        dtype = mixture_model.dtype
         c1, c2 = mixture_model.components
         w1, w2 = mixture_model.weights
 
@@ -283,48 +305,34 @@ class TestMixtureModelCalculations:
         calculated_pdf = mixture_model.pdf(X)
 
         assert isinstance(calculated_pdf, np.ndarray)
-        np.testing.assert_allclose(calculated_pdf, expected_pdf)
+        assert calculated_pdf.dtype == dtype
+        if dtype == np.float64:
+            np.testing.assert_allclose(calculated_pdf, expected_pdf)
 
     @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
     def test_lpdf_calculation(self, mixture_model: MixtureModel, X):
         """Tests the LPDF calculation against the definition."""
 
+        dtype = mixture_model.dtype
+
         expected_lpdf = np.log(mixture_model.pdf(X))
         calculated_lpdf = mixture_model.lpdf(X)
 
         assert isinstance(calculated_lpdf, np.ndarray)
-        np.testing.assert_allclose(calculated_lpdf, expected_lpdf)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf"])
-    def test_pdf_lpdf_methods_return_correct_dtype(self, method_name: str):
-        """Tests that pdf and lpdf methods return arrays of the correct dtype."""
-        target_dtype = np.float32
-        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
-        method_to_test = getattr(mixture, method_name)
-
-        input_x = np.array([1.0, 2.0, 3.0])
-        result = method_to_test(input_x)
-
-        assert result.dtype == target_dtype
+        assert calculated_lpdf.dtype == dtype
+        if dtype == np.float64:
+            np.testing.assert_allclose(calculated_lpdf, expected_lpdf)
 
     def test_loglikelihood_calculation(self, mixture_model: MixtureModel):
         """Tests that loglikelihood is the sum of LPDF values."""
 
+        dtype = mixture_model.dtype
         X = np.array([1.0, 1.5, 6.0])
         expected_loglikelihood = np.sum(mixture_model.lpdf(X))
         calculated_loglikelihood = mixture_model.loglikelihood(X)
 
-        assert isinstance(calculated_loglikelihood, np.float64)
+        assert isinstance(calculated_loglikelihood, dtype)
         assert np.isclose(calculated_loglikelihood, expected_loglikelihood)
-
-    def test_loglikelihood_returns_numpy_scalar_with_correct_dtype(self):
-        """Tests that checks that loglikelihood returns a NumPy scalar of the correct type."""
-        target_dtype = np.float32
-        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
-
-        loglik = mixture.loglikelihood(np.array([1, 2, 3]))
-
-        assert isinstance(loglik, target_dtype)
 
 
 class TestMixtureModelGenerate:
@@ -334,9 +342,13 @@ class TestMixtureModelGenerate:
         """Tests that generate returns an array of the requested size."""
 
         size = 100
+        dtype = mixture_model.dtype
 
-        assert len(mixture_model.generate(size=size)) == size
-        assert isinstance(mixture_model.generate(size=size), np.ndarray)
+        samples = mixture_model.generate(size=size)
+
+        assert len(samples) == size
+        assert isinstance(samples, np.ndarray)
+        assert samples.dtype == dtype
 
     def test_generate_with_size_zero(self, mixture_model):
         """Tests that generating with size = 0 returns an empty array."""
@@ -381,16 +393,6 @@ class TestMixtureModelGenerate:
         proportion_c1 = len(samples_from_c1) / n_samples
         assert proportion_c1 == pytest.approx(weights[0], abs=0.05)
 
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_array_with_correct_dtype(self, size):
-        """Tests that generate returns an array with the correct dtype."""
-        target_dtype = np.float32
-        mixture = MixtureModel([Exponential(0, 1)], dtype=target_dtype)
-
-        samples = mixture.generate(size=size)
-        assert samples.shape == (size,)
-        assert samples.dtype == target_dtype
-
 
 class TestMixtureModelDunderMethods:
     """Tests for special (dunder) methods of MixtureModel."""
@@ -413,7 +415,8 @@ class TestMixtureModelDunderMethods:
     ):
         """Tests that __getitem__ retrieves the correct component by index."""
 
-        assert mixture_model[index] == exp_components[expected_component_index]
+        dtype = mixture_model.dtype
+        assert mixture_model[index] == exp_components[expected_component_index].astype(dtype)
 
     def test_getitem_out_of_bounds_raises_index_error(self, mixture_model: MixtureModel):
         """Tests that accessing an out-of-bounds index raises an IndexError."""
@@ -434,6 +437,9 @@ class TestMixtureModelDunderMethods:
         self, mixture_model: MixtureModel, exp_components: tuple[Exponential, ...]
     ):
         """Tests that iterating over the model yields all components in the correct order."""
+
+        dtype = mixture_model.dtype
+        exp_components = [component.astype(dtype) for component in exp_components]
 
         iterated_components = list(mixture_model)
         assert iterated_components == list(exp_components)
@@ -467,8 +473,8 @@ class TestMixtureModelCopying:
         copied_model = copy(mixture_model)
         copied_model.log_weights = np.log([0.1, 0.9])
 
-        np.testing.assert_allclose(mixture_model.weights, [0.5, 0.5])
-        np.testing.assert_allclose(copied_model.weights, [0.1, 0.9])
+        np.testing.assert_allclose(mixture_model.weights, [0.5, 0.5], atol=1e-4)
+        np.testing.assert_allclose(copied_model.weights, [0.1, 0.9], atol=1e-4)
 
     def test_copy_is_independent_components(self, mixture_model: MixtureModel):
         """Tests that the components in the copied model are also independent copies."""
@@ -486,97 +492,92 @@ class TestMixtureModelCopying:
         assert mixture_model.components[0].rate != copied_model.components[0].rate
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestMixtureModelComparison:
     """Tests the __eq__ and __hash__ methods for MixtureModel."""
 
-    def test_eq_identical_models(self):
+    def test_eq_identical_models(self, dtype):
         """Tests that two identical models are equal."""
 
         c = [Exponential(0, 1), Exponential(10, 2)]
-        m1 = MixtureModel(components=c, weights=[0.4, 0.6])
-        m2 = MixtureModel(components=c, weights=[0.4, 0.6])
+        m1 = MixtureModel(components=c, weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=c, weights=[0.4, 0.6], dtype=dtype)
         assert m1 == m2
 
-    def test_eq_order_insensitivity(self):
+    def test_eq_order_insensitivity(self, dtype):
         """Tests that models with the same components/weights in a different order are equal."""
 
         c1 = [Exponential(0, 1), Exponential(10, 2)]
         w1 = [0.4, 0.6]
-        m1 = MixtureModel(components=c1, weights=w1)
+        m1 = MixtureModel(components=c1, weights=w1, dtype=dtype)
 
         c2 = [Exponential(10, 2), Exponential(0, 1)]
         w2 = [0.6, 0.4]
-        m2 = MixtureModel(components=c2, weights=w2)
+        m2 = MixtureModel(components=c2, weights=w2, dtype=dtype)
 
         assert m1 == m2
 
-    def test_neq_different_weights(self):
+    def test_neq_different_weights(self, dtype):
         """Tests that models with different weights are not equal."""
 
         c = [Exponential(0, 1), Exponential(10, 2)]
-        m1 = MixtureModel(components=c, weights=[0.4, 0.6])
-        m2 = MixtureModel(components=c, weights=[0.41, 0.59])
+        m1 = MixtureModel(components=c, weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=c, weights=[0.41, 0.59], dtype=dtype)
         assert m1 != m2
 
-    def test_neq_different_components(self):
+    def test_neq_different_components(self, dtype):
         """Tests that models with different components are not equal."""
 
         c1 = [Exponential(0, 1), Exponential(10, 2)]
         c2 = [Exponential(0, 1), Exponential(99, 2)]
-        m1 = MixtureModel(components=c1, weights=[0.4, 0.6])
-        m2 = MixtureModel(components=c2, weights=[0.4, 0.6])
+        m1 = MixtureModel(components=c1, weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=c2, weights=[0.4, 0.6], dtype=dtype)
         assert m1 != m2
 
-    def test_neq_different_n_components(self):
+    def test_neq_different_n_components(self, dtype):
         """Tests that models with a different number of components are not equal."""
 
         c1 = [Exponential(0, 1), Exponential(10, 2)]
         c2 = [Exponential(0, 1)]
-        m1 = MixtureModel(components=c1, weights=[0.4, 0.6])
-        m2 = MixtureModel(components=c2, weights=[1.0])
+        m1 = MixtureModel(components=c1, weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=c2, weights=[1.0], dtype=dtype)
         assert m1 != m2
 
-    def test_neq_other_object(self, mixture_model, exp_components):
+    def test_neq_different_dtype(self, dtype):
+        """Tests that models with different dtype are not equal."""
+
+        c1 = [Exponential(0, 1), Exponential(10, 2)]
+        c2 = [Exponential(0, 1), Exponential(99, 2)]
+        m1 = MixtureModel(components=c1, weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=c2, weights=[0.4, 0.6], dtype=np.float128)
+        assert m1 != m2
+
+    def test_neq_other_object(self, mixture_model, exp_components, dtype):
         """Tests that a model instance is not equal to an object of a different class."""
         model = mixture_model
 
         other = "not_a_mixture_model"
         assert model != other
 
-    def test_hash_consistency(self):
+    def test_hash_consistency(self, dtype):
         """Tests that equal models produce the same hash."""
 
-        m1 = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2)],
-            weights=[0.4, 0.6],
-        )
-        m2 = MixtureModel(
-            components=[Exponential(10, 2), Exponential(0, 1)],
-            weights=[0.6, 0.4],
-        )
+        m1 = MixtureModel(components=[Exponential(0, 1), Exponential(10, 2)], weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=[Exponential(10, 2), Exponential(0, 1)], weights=[0.6, 0.4], dtype=dtype)
         assert m1 == m2
         assert hash(m1) == hash(m2)
 
-    def test_hash_difference(self):
+    def test_hash_difference(self, dtype):
         """Tests that non-equal models are likely to have different hashes."""
 
-        m1 = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2)],
-            weights=[0.4, 0.6],
-        )
-        m2 = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2)],
-            weights=[0.5, 0.5],
-        )
+        m1 = MixtureModel(components=[Exponential(0, 1), Exponential(10, 2)], weights=[0.4, 0.6], dtype=dtype)
+        m2 = MixtureModel(components=[Exponential(0, 1), Exponential(10, 2)], weights=[0.5, 0.5], dtype=dtype)
         assert m1 != m2
         assert hash(m1) != hash(m2)
 
-    def test_hash_changes_after_modifying_weights(self):
+    def test_hash_changes_after_modifying_weights(self, dtype):
         """Tests that the hash of the model updates after its weights are changed."""
-        model = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2)],
-            weights=[0.4, 0.6],
-        )
+        model = MixtureModel(components=[Exponential(0, 1), Exponential(10, 2)], weights=[0.4, 0.6], dtype=dtype)
         old_hash = hash(model)
 
         model.log_weights = np.log([0.5, 0.5])
@@ -584,12 +585,9 @@ class TestMixtureModelComparison:
 
         assert old_hash != new_hash
 
-    def test_hash_changes_after_adding_component(self):
+    def test_hash_changes_after_adding_component(self, dtype):
         """Tests that the hash of the model updates after a new component is added."""
-        model = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2)],
-            weights=[0.4, 0.6],
-        )
+        model = MixtureModel(components=[Exponential(0, 1), Exponential(10, 2)], weights=[0.4, 0.6], dtype=dtype)
         old_hash = hash(model)
 
         model.add_component(Exponential(99, 3), weight=0.1)
@@ -599,11 +597,10 @@ class TestMixtureModelComparison:
         assert model.n_components == expected_n_components
         assert old_hash != new_hash
 
-    def test_hash_changes_after_removing_component(self):
+    def test_hash_changes_after_removing_component(self, dtype):
         """Tests that the hash of the model updates after a component is removed."""
         model = MixtureModel(
-            components=[Exponential(0, 1), Exponential(10, 2), Exponential(99, 3)],
-            weights=[0.4, 0.5, 0.1],
+            components=[Exponential(0, 1), Exponential(10, 2), Exponential(99, 3)], weights=[0.4, 0.5, 0.1], dtype=dtype
         )
         old_hash = hash(model)
 

--- a/rework_tests/unit/core/test_mixture.py
+++ b/rework_tests/unit/core/test_mixture.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.core import MixtureModel
 from rework_pysatl_mpest.distributions import ContinuousDistribution, Exponential
 
@@ -291,45 +292,84 @@ class TestMixtureModelModification:
             mixture_model.remove_component(2)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestMixtureModelCalculations:
     """Tests for calculation methods like pdf, lpdf, etc."""
 
-    @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
-    def test_pdf_calculation(self, mixture_model: MixtureModel, X):
+    @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_pdf_calculation_for_array(self, x, dtype):
         """Tests the PDF calculation against the definition."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         c1, c2 = mixture_model.components
         w1, w2 = mixture_model.weights
 
-        expected_pdf = w1 * c1.pdf(X) + w2 * c2.pdf(X)
-        calculated_pdf = mixture_model.pdf(X)
+        expected_pdf = w1 * c1.pdf(x) + w2 * c2.pdf(x)
+        calculated_pdf = mixture_model.pdf(x)
 
         assert calculated_pdf.dtype == dtype
-        if not np.isscalar(X):
+        if not np.isscalar(x):
             assert isinstance(calculated_pdf, np.ndarray)
 
-        np.testing.assert_allclose(calculated_pdf, expected_pdf, rtol=np.finfo(dtype).eps)
+        np.testing.assert_allclose(calculated_pdf, expected_pdf, atol=np.finfo(dtype).eps)
 
-    @pytest.mark.parametrize("X", [1.5, [1.5], np.array([1.0, 1.5, 6.0])])
-    def test_lpdf_calculation(self, mixture_model: MixtureModel, X):
-        """Tests the LPDF calculation against the definition."""
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_calculation_for_scalar(self, x, dtype):
+        """Tests the PDF calculation against the definition."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         c1, c2 = mixture_model.components
         w1, w2 = mixture_model.weights
 
-        expected_lpdf = np.log(w1 * c1.pdf(X) + w2 * c2.pdf(X))
-        calculated_lpdf = mixture_model.lpdf(X)
+        expected_pdf = w1 * c1.pdf(x) + w2 * c2.pdf(x)
+        calculated_pdf = mixture_model.pdf(x)
 
-        assert isinstance(calculated_lpdf, np.ndarray)
+        assert np.isscalar(calculated_pdf)
+        assert isinstance(calculated_pdf, dtype)
+        np.testing.assert_allclose(calculated_pdf, expected_pdf, atol=np.finfo(dtype).eps)
+
+    @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_lpdf_calculation_for_array(self, x, dtype):
+        """Tests the LPDF calculation against the definition."""
+
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
+
+        expected_pdf = mixture_model.pdf(x)
+        calculated_lpdf = mixture_model.lpdf(x)
+
+        if not np.isscalar(x):
+            assert isinstance(calculated_lpdf, np.ndarray)
+
         assert calculated_lpdf.dtype == dtype
-        np.testing.assert_allclose(calculated_lpdf, expected_lpdf, rtol=np.finfo(dtype).eps)
+        np.testing.assert_allclose(np.exp(calculated_lpdf), expected_pdf, atol=np.finfo(dtype).eps)
 
-    def test_loglikelihood_calculation(self, mixture_model: MixtureModel):
+    @given(x=st.floats(-1e6, 1e6))
+    def test_lpdf_calculation_for_scalar(self, x, dtype):
+        """Tests the LPDF calculation against the definition."""
+
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
+
+        expected_pdf = mixture_model.pdf(x)
+        calculated_lpdf = mixture_model.lpdf(x)
+
+        assert np.isscalar(calculated_lpdf)
+        assert calculated_lpdf.dtype == dtype
+        np.testing.assert_allclose(np.exp(calculated_lpdf), expected_pdf, atol=np.finfo(dtype).eps)
+
+    def test_loglikelihood_calculation(self, dtype):
         """Tests that loglikelihood is the sum of LPDF values."""
 
-        dtype = mixture_model.dtype
+        mixture_model = MixtureModel(
+            components=[Exponential(loc=0.0, rate=1.0), Exponential(loc=5.0, rate=2.0)], weights=[0.5, 0.5], dtype=dtype
+        )
         X = np.array([1.0, 1.5, 6.0])
         expected_loglikelihood = np.sum(mixture_model.lpdf(X))
         calculated_loglikelihood = mixture_model.loglikelihood(X)

--- a/rework_tests/unit/core/test_parameter.py
+++ b/rework_tests/unit/core/test_parameter.py
@@ -1,10 +1,10 @@
 """Tests for Parameter class"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-
+import numpy as np
 import pytest
 from rework_pysatl_mpest.core import Parameter
 
@@ -29,6 +29,23 @@ class _OwnerClass:
         self.any_param = any_val
 
 
+class _OwnerClassWithDType:
+    """A helper class that has a dtype attribute."""
+
+    positive_param = Parameter(invariant=lambda x: x > 0, error_message="Value must be positive.")
+    any_param = Parameter()
+
+    def __init__(self, positive_val: float, any_val: float, dtype=np.float64):
+        """
+        Initializes the owner class and its parameters.
+        Also initializes a set to keep track of fixed parameters.
+        """
+        self.dtype = dtype
+        self._fixed_params: set[str] = set()
+        self.positive_param = positive_val
+        self.any_param = any_val
+
+
 @pytest.fixture
 def owner_instance() -> _OwnerClass:
     """
@@ -36,6 +53,15 @@ def owner_instance() -> _OwnerClass:
     """
 
     return _OwnerClass(positive_val=10.0, any_val=-5.0)
+
+
+@pytest.fixture
+def owner_instance_float32() -> _OwnerClassWithDType:
+    """
+    Pytest fixture to provide a clean instance of _OwnerClassWithDType for each test.
+    """
+
+    return _OwnerClassWithDType(positive_val=10.0, any_val=-5.0, dtype=np.float32)
 
 
 def test_parameter_initialization():
@@ -179,3 +205,33 @@ def test_can_set_unfixed_parameter_after_fixing_another(owner_instance: _OwnerCl
 
     assert owner_instance.any_param == expected_any_value
     assert owner_instance.positive_param == expected_positive_value
+
+
+def test_get_from_instance_with_dtype_returns_correct_type(owner_instance_float32: _OwnerClassWithDType):
+    """
+    Tests that __get__ returns a value of the correct DType when the owner
+    instance has a `dtype` attribute.
+    """
+
+    positive_value = owner_instance_float32.positive_param
+    any_value = owner_instance_float32.any_param
+
+    assert isinstance(positive_value, np.float32)
+    assert isinstance(any_value, np.float32)
+
+    assert positive_value == np.float32(10.0)
+    assert any_value == np.float32(-5.0)
+
+
+def test_set_and_get_with_dtype_casting(owner_instance_float32: _OwnerClassWithDType):
+    """
+    Tests the full set -> get cycle with dtype casting.
+    """
+
+    new_positive_value = 123.45
+    owner_instance_float32.positive_param = new_positive_value
+
+    retrieved_value = owner_instance_float32.positive_param
+
+    assert isinstance(retrieved_value, np.float32)
+    assert retrieved_value == np.float32(new_positive_value)

--- a/rework_tests/unit/core/test_parameter.py
+++ b/rework_tests/unit/core/test_parameter.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 from rework_pysatl_mpest.core import Parameter
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
 
 class _OwnerClass:
     """
@@ -19,49 +21,26 @@ class _OwnerClass:
     positive_param = Parameter(invariant=lambda x: x > 0, error_message="Value must be positive.")
     any_param = Parameter()
 
-    def __init__(self, positive_val: float, any_val: float):
+    def __init__(self, positive_val: float, any_val: float, dtype: np.floating):
         """
         Initializes the owner class and its parameters.
         Also initializes a set to keep track of fixed parameters.
         """
         self._fixed_params: set[str] = set()
-        self.positive_param = positive_val
-        self.any_param = any_val
-
-
-class _OwnerClassWithDType:
-    """A helper class that has a dtype attribute."""
-
-    positive_param = Parameter(invariant=lambda x: x > 0, error_message="Value must be positive.")
-    any_param = Parameter()
-
-    def __init__(self, positive_val: float, any_val: float, dtype=np.float64):
-        """
-        Initializes the owner class and its parameters.
-        Also initializes a set to keep track of fixed parameters.
-        """
         self.dtype = dtype
-        self._fixed_params: set[str] = set()
+
         self.positive_param = positive_val
         self.any_param = any_val
 
 
-@pytest.fixture
-def owner_instance() -> _OwnerClass:
+@pytest.fixture(params=DTYPES_TO_TEST)
+def owner_instance(request) -> _OwnerClass:
     """
     Pytest fixture to provide a clean instance of _OwnerClass for each test.
     """
 
-    return _OwnerClass(positive_val=10.0, any_val=-5.0)
-
-
-@pytest.fixture
-def owner_instance_float32() -> _OwnerClassWithDType:
-    """
-    Pytest fixture to provide a clean instance of _OwnerClassWithDType for each test.
-    """
-
-    return _OwnerClassWithDType(positive_val=10.0, any_val=-5.0, dtype=np.float32)
+    dtype = request.param
+    return _OwnerClass(positive_val=10.0, any_val=-5.0, dtype=dtype)
 
 
 def test_parameter_initialization():
@@ -129,15 +108,17 @@ def test_get_from_instance_returns_value(owner_instance: _OwnerClass):
     returns the actual float value stored in the instance.
     """
 
+    dtype = owner_instance.dtype
+
     positive_value = owner_instance.positive_param
     expected_positive_value = 10.0
     any_value = owner_instance.any_param
     expected_any_value = -5.0
 
-    assert isinstance(positive_value, float)
-    assert positive_value == expected_positive_value
-    assert isinstance(any_value, float)
-    assert any_value == expected_any_value
+    assert isinstance(positive_value, dtype)
+    assert np.isclose(positive_value, expected_positive_value, atol=1e-3)
+    assert isinstance(any_value, dtype)
+    assert np.isclose(any_value, expected_any_value, atol=1e-3)
 
 
 def test_set_valid_value(owner_instance: _OwnerClass):
@@ -146,9 +127,12 @@ def test_set_valid_value(owner_instance: _OwnerClass):
     successfully assigned to the parameter.
     """
 
+    dtype = owner_instance.dtype
+
     new_positive_value = 25.5
     owner_instance.positive_param = new_positive_value
     assert owner_instance.positive_param == new_positive_value
+    assert isinstance(owner_instance.positive_param, dtype)
 
 
 @pytest.mark.parametrize(
@@ -205,33 +189,3 @@ def test_can_set_unfixed_parameter_after_fixing_another(owner_instance: _OwnerCl
 
     assert owner_instance.any_param == expected_any_value
     assert owner_instance.positive_param == expected_positive_value
-
-
-def test_get_from_instance_with_dtype_returns_correct_type(owner_instance_float32: _OwnerClassWithDType):
-    """
-    Tests that __get__ returns a value of the correct DType when the owner
-    instance has a `dtype` attribute.
-    """
-
-    positive_value = owner_instance_float32.positive_param
-    any_value = owner_instance_float32.any_param
-
-    assert isinstance(positive_value, np.float32)
-    assert isinstance(any_value, np.float32)
-
-    assert positive_value == np.float32(10.0)
-    assert any_value == np.float32(-5.0)
-
-
-def test_set_and_get_with_dtype_casting(owner_instance_float32: _OwnerClassWithDType):
-    """
-    Tests the full set -> get cycle with dtype casting.
-    """
-
-    new_positive_value = 123.45
-    owner_instance_float32.positive_param = new_positive_value
-
-    retrieved_value = owner_instance_float32.positive_param
-
-    assert isinstance(retrieved_value, np.float32)
-    assert retrieved_value == np.float32(new_positive_value)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -7,7 +7,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
-from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Beta
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import beta, kstest
 
@@ -225,7 +223,7 @@ class TestBetaLPDF:
 
         dist = Beta(shape1, shape2, left_border, right_border)
         custom_lpdf = dist.lpdf(x)
-        scipy_lpdf = beta.logpdf(x, shape1, shape2, loc=lower_bound, scale=upper_bound - lower_bound)
+        scipy_lpdf = beta.logpdf(x, shape1, shape2, loc=left_border, scale=right_border - left_border)
 
         np.testing.assert_allclose(custom_lpdf, scipy_lpdf, atol=1e-5)
 

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -7,6 +7,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Beta
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import beta, kstest
 
@@ -223,7 +225,7 @@ class TestBetaLPDF:
 
         dist = Beta(shape1, shape2, left_border, right_border)
         custom_lpdf = dist.lpdf(x)
-        scipy_lpdf = beta.logpdf(x, shape1, shape2, loc=left_border, scale=right_border - left_border)
+        scipy_lpdf = beta.logpdf(x, shape1, shape2, loc=lower_bound, scale=upper_bound - lower_bound)
 
         np.testing.assert_allclose(custom_lpdf, scipy_lpdf, atol=1e-5)
 

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -7,7 +7,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
-from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Beta
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import beta, kstest
 
@@ -72,82 +70,87 @@ def st_params_and_x_for_grad(draw):
     return (shape1, shape2, left, right, x)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestBetaInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         shape1, shape2, left_border, right_border = 0.5, 2.0, -1.0, 1.0
-        dist = Beta(alpha=shape1, beta=shape2, left_border=left_border, right_border=right_border)
-        assert isinstance(dist.alpha, float)
-        assert isinstance(dist.beta, float)
-        assert isinstance(dist.left_border, float)
-        assert isinstance(dist.right_border, float)
-        assert dist.alpha == shape1
-        assert dist.beta == shape2
-        assert dist.left_border == left_border
-        assert dist.right_border == right_border
+        dist = Beta(alpha=shape1, beta=shape2, lower_bound=left_border, upper_bound=right_border, dtype=dtype)
+        assert dist.alpha.dtype == dtype
+        assert dist.beta.dtype == dtype
+        assert dist.left_border.dtype == dtype
+        assert dist.right_border.dtype == dtype
+        assert dist.alpha == dtype(shape1)
+        assert dist.beta == dtype(shape2)
+        assert dist.left_border == dtype(left_border)
+        assert dist.right_border == dtype(right_border)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Beta(alpha=1.0, beta=2.0, left_border=-1.0, right_border=1.0)
+        dist = Beta(alpha=1.0, beta=2.0, left_border=-1.0, right_border=1.0, dtype=dtype)
         assert dist.name == "Beta"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Beta(alpha=1.0, beta=2.0, left_border=-1.0, right_border=1.0)
+        dist = Beta(alpha=1.0, beta=2.0, left_border=-1.0, right_border=1.0, dtype=dtype)
         assert dist.params == {"alpha", "beta", "left_border", "right_border"}
 
-    def test_alpha_invariant_violation(self):
+    def test_alpha_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive alpha raises a ValueError."""
 
         with pytest.raises(ValueError, match="Alpha parameter should be positive or zero"):
-            Beta(alpha=-1.0, beta=2.0, left_border=10.0, right_border=20.0)
+            Beta(alpha=-1.0, beta=2.0, left_border=10.0, right_border=20.0, dtype=dtype)
         with pytest.raises(ValueError, match="Alpha parameter should be positive or zero"):
-            Beta(alpha=-20.0, beta=2.0, left_border=10.0, right_border=20.0)
+            Beta(alpha=-20.0, beta=2.0, left_border=10.0, right_border=20.0, dtype=dtype)
 
-    def test_alpha_assignment_violation(self):
+    def test_alpha_assignment_violation(self, dtype):
         """Tests that assigning a non-positive rate after initialization raises a ValueError."""
 
-        dist = Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0)
+        dist = Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0, dtype=dtype)
         with pytest.raises(ValueError, match="Alpha parameter should be positive or zero"):
             dist.alpha = -1.0
         with pytest.raises(ValueError, match="Alpha parameter should be positive or zero"):
             dist.alpha = -10.0
 
-    def test_beta_invariant_violation(self):
+    def test_beta_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive beta raises a ValueError."""
 
         with pytest.raises(ValueError, match="Beta parameter should be positive or zero"):
-            Beta(alpha=1.0, beta=-2.0, left_border=10.0, right_border=20.0)
+            Beta(alpha=1.0, beta=-2.0, left_border=10.0, right_border=20.0, dtype=dtype)
         with pytest.raises(ValueError, match="Beta parameter should be positive or zero"):
-            Beta(alpha=1.0, beta=-20.0, left_border=10.0, right_border=20.0)
+            Beta(alpha=1.0, beta=-20.0, left_border=10.0, right_border=20.0, dtype=dtype)
 
-    def test_beta_assignment_violation(self):
+    def test_beta_assignment_violation(self, dtype):
         """Tests that assigning a non-positive beta after initialization raises a ValueError."""
 
-        dist = Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0)
+        dist = Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0, dtype=dtype)
         with pytest.raises(ValueError, match="Beta parameter should be positive or zero"):
             dist.beta = -1.0
         with pytest.raises(ValueError, match="Beta parameter should be positive or zero"):
             dist.beta = -10.0
 
-    def test_invariant_bounds_violation(self):
-        """Tests that initializing with a lower bound bigger upper bound  raises a ValueError."""
-        with pytest.raises(ValueError, match="Left border must be less than right border"):
-            Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=5.0)
-        with pytest.raises(ValueError, match="Left border must be less than right border"):
-            Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=10.0)
+    def test_invariant_bounds_violation(self, dtype):
+        """Tests that initializing with a left border bigger right border raises a ValueError."""
 
-    def test_repr_method(self):
+        with pytest.raises(ValueError, match="Left border must be less than right border"):
+            Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=5.0, dtype=dtype)
+        with pytest.raises(ValueError, match="Left border must be less than right border"):
+            Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=10.0, dtype=dtype)
+
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0)
+        dist = Beta(alpha=1.1, beta=2.1, lower_bound=10.1, upper_bound=20.1, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Beta(alpha=1.0, beta=2.0, left_border=10.0, right_border=20.0)"
+        assert (
+            repr_str == f"Beta(alpha={dist.alpha}, beta={dist.beta}, left_border={dist.left_border}, "
+            f"right_border={dist.right_border}, dtype=np.{dtype.__name__})"
+        )
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -156,19 +159,23 @@ class TestBetaInitialization:
 class TestBetaPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, x):
+    def test_pdf_properties(self, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
+
         alpha, beta, left_border, right_border = 1.0, 1.0, 2.9, 10.0
-        dist = Beta(alpha, beta, left_border, right_border)
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
     @pytest.mark.parametrize("x,shape1,shape2,left_border,right_border,expected_pdf", load_r_test_cases())
     def test_pdf_against_R(self, x, shape1, shape2, left_border, right_border, expected_pdf):
         """Compares the custom PDF implementation against scipy's implementation."""
+
         dist = Beta(shape1, shape2, left_border, right_border)
         custom_pdf = dist.pdf(x)
         np.testing.assert_allclose(custom_pdf, expected_pdf, atol=1e-9)
@@ -176,6 +183,7 @@ class TestBetaPDF:
     @given(params=st_valid_params())
     def test_pdf_integral_is_one(self, params):
         """Tests that the integral of the PDF over its support is equal to 1."""
+
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border)
         integral, error = quad(lambda x: dist.pdf(x).item(), left_border, right_border)
@@ -184,6 +192,7 @@ class TestBetaPDF:
     @given(x=st.floats(min_value=1e-4, max_value=1e2, allow_infinity=False))
     def test_pdf_outside_support(self, x):
         """Tests that the PDF is zero for values less than the location parameter."""
+
         x_val = 2.0 - abs(x)
         dist = Beta(1.0, 1.0, 2.0, 10.0)
         assert dist.pdf(x_val) == 0.0
@@ -192,13 +201,16 @@ class TestBetaPDF:
 class TestBetaLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(params=st_valid_params(), x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, params, x):
+    def test_lpdf_return_type_and_shape(self, params, x, dtype):
         """Tests the return type and shape of the lpdf method."""
+
         shape1, shape2, left_border, right_border = params
-        dist = Beta(shape1, shape2, left_border, right_border)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(params=st_valid_params(), x=st.floats(1e-6, 1e6))
@@ -218,6 +230,7 @@ class TestBetaLPDF:
     @given(params=st_valid_params(), x=st.floats(max_value=-1e6, allow_infinity=False))
     def test_lpdf_outside_support(self, params, x):
         """Tests that the LPDF is -inf for values less than the location parameter."""
+
         shape1, shape2, left_border, right_border = params
         x_val = left_border - abs(x)
         dist = Beta(shape1, shape2, left_border, right_border)
@@ -227,20 +240,24 @@ class TestBetaLPDF:
 class TestBetaPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         params=st_valid_params(), p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, params, p):
+    def test_ppf_return_type_and_shape(self, params, p, dtype):
         """Tests the return type and shape of the ppf method."""
+
         shape1, shape2, left_border, right_border = params
-        dist = Beta(shape1, shape2, left_border, right_border)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(params=st_valid_params(), p=st.floats(0, 1))
     def test_ppf_against_scipy(self, params, p):
         """Compares the custom PPF implementation against scipy's implementation."""
+
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border)
         custom_ppf = dist.ppf(p)
@@ -255,78 +272,88 @@ class TestBetaPPF:
         assert np.isnan(dist.ppf(p_val))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestBetaGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
     @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape1_numerical(self, params_x):
+    def test_dlog_shape1_numerical(self, params_x, dtype):
         """Checks the analytical gradient for 'shape1' against a numerical approximation."""
+
         shape1, shape2, left_border, right_border, x = params_x
 
-        dist = Beta(shape1, shape2, left_border, right_border)
-
-        lpdf_plus_h = Beta(shape1 + self.h, shape2, left_border, right_border).lpdf(x)
-        lpdf_minus_h = Beta(shape1 - self.h, shape2, left_border, right_border).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         analytical_grad = dist._dlog_alpha(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Beta(shape1 + self.h, shape2, left_border, right_border).lpdf(x)
+            lpdf_minus_h = Beta(shape1 - self.h, shape2, left_border, right_border).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape2_numerical(self, params_x):
+    def test_dlog_shape2_numerical(self, params_x, dtype):
         """Checks the analytical gradient for 'shape2' against a numerical approximation."""
         shape1, shape2, left_border, right_border, x = params_x
 
-        dist = Beta(shape1, shape2, left_border, right_border)
-
-        lpdf_plus_h = Beta(shape1, shape2 + self.h, left_border, right_border).lpdf(x)
-        lpdf_minus_h = Beta(shape1, shape2 - self.h, left_border, right_border).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         analytical_grad = dist._dlog_beta(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Beta(shape1, shape2 + self.h, left_border, right_border).lpdf(x)
+            lpdf_minus_h = Beta(shape1, shape2 - self.h, left_border, right_border).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_left_border_numerical(self, params_x):
+    def test_dlog_left_border_numerical(self, params_x, dtype):
         """Checks the analytical gradient for 'left_border' against a numerical approximation."""
         shape1, shape2, left_border, right_border, x = params_x
 
-        dist = Beta(shape1, shape2, left_border, right_border)
-
-        lpdf_plus_h = Beta(shape1, shape2, left_border + self.h, right_border).lpdf(x)
-        lpdf_minus_h = Beta(shape1, shape2, left_border - self.h, right_border).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         analytical_grad = dist._dlog_left_border(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Beta(shape1, shape2, left_border + self.h, right_border).lpdf(x)
+            lpdf_minus_h = Beta(shape1, shape2, left_border - self.h, right_border).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_right_border_numerical(self, params_x):
+    def test_dlog_right_border_numerical(self, params_x, dtype):
         """Checks the analytical gradient for 'right_border' against a numerical approximation."""
         shape1, shape2, left_border, right_border, x = params_x
 
-        dist = Beta(shape1, shape2, left_border, right_border)
-
-        lpdf_plus_h = Beta(shape1, shape2, left_border, right_border + self.h).lpdf(x)
-        lpdf_minus_h = Beta(shape1, shape2, left_border, right_border - self.h).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         analytical_grad = dist._dlog_right_border(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Beta(shape1, shape2, left_border, right_border + self.h).lpdf(x)
+            lpdf_minus_h = Beta(shape1, shape2, left_border, right_border - self.h).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -338,10 +365,10 @@ class TestBetaGradients:
             (["alpha", "beta", "left_border", "right_border"], 0, []),
         ],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Beta(1.0, 1.0, 1.0, 10.0)
+        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -349,6 +376,7 @@ class TestBetaGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_shape_col)
 
         if "alpha" in expected_params:
@@ -365,43 +393,40 @@ class TestBetaGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestBetaGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
-        random.seed(42)
-        dist = Beta(1.0, 1.0, 1.0, 10.0)
+        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Beta(1.0, 1.0, 1.0, 10.0)
+        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
-
-        dist = Beta(1.0, 1.0, 1.0, 10.0)
-
+        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         shape1, shape2, left_border, right_border = 1.0, 1.0, 1.0, 10.0
-        dist = Beta(shape1, shape2, left_border, right_border)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         size = 20000
 
         samples = dist.generate(size=size)
@@ -412,16 +437,16 @@ class TestBetaGenerate:
             (right_border - left_border) ** 2 * shape1 * shape2 / ((shape1 + shape2) ** 2 * (shape1 + shape2 + 1))
         )
 
-        assert np.mean(samples) == pytest.approx(theoretical_mean, rel=0.1)
-        assert np.var(samples) == pytest.approx(theoretical_var, rel=0.1)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(theoretical_mean, rel=0.1)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(theoretical_var, rel=0.1)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         shape1, shape2, left_border, right_border = 1.0, 1.0, 1.0, 10.0
-        dist = Beta(shape1, shape2, left_border, right_border)
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
         size = 1000
 
         samples = dist.generate(size=size)
@@ -429,30 +454,3 @@ class TestBetaGenerate:
         ks_statistic, p_value = kstest(samples, "beta", args=(shape1, shape2, left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestBetaDType(DTypeHandlingMixin):
-    distribution_class = Beta
-    default_params: ClassVar[dict] = {"alpha": 1.0, "beta": 2.0, "left_border": -1.0, "right_border": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1, 1)))
-    def test_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def test_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_alpha", "_dlog_beta", "_dlog_left_border", "_dlog_right_border"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1, 1)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -50,8 +50,8 @@ def load_r_test_cases():
 
 
 @st.composite
-def st_params_and_x_for_grad(draw):
-    """Generator of valid params with x for gradient test"""
+def st_params_and_array_x_for_grad(draw):
+    """Generator of valid params with an array x for gradient test"""
     shape1 = draw(st.floats(0.1, 100))
     shape2 = draw(st.floats(0.1, 100))
     left = draw(st.floats(-100, 100))
@@ -61,13 +61,26 @@ def st_params_and_x_for_grad(draw):
     x = draw(
         arrays(
             np.float64,
-            shape=draw(st.integers(1, 5)),
+            shape=draw(st.integers(2, 5)),
             elements=st.floats(
                 min_value=left + margin, max_value=right - margin, allow_nan=False, allow_infinity=False
             ),
         )
     )
     return (shape1, shape2, left, right, x)
+
+
+@st.composite
+def st_params_and_scalar_x_for_grad(draw):
+    """Generator of valid params with a scalar x for gradient test"""
+    shape1 = draw(st.floats(0.1, 100))
+    shape2 = draw(st.floats(0.1, 100))
+    lower = draw(st.floats(-100, 100))
+    upper = draw(st.floats(lower + 0.1, lower + 100))
+
+    margin = 1e-2
+    x = draw(st.floats(min_value=lower + margin, max_value=upper - margin, allow_nan=False, allow_infinity=False))
+    return (shape1, shape2, lower, upper, x)
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
@@ -161,8 +174,8 @@ class TestBetaPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         alpha, beta, left_border, right_border = 1.0, 1.0, 2.9, 10.0
         dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
@@ -171,6 +184,18 @@ class TestBetaPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = 1.0, 1.0, 2.9, 10.0
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @pytest.mark.parametrize("x,shape1,shape2,left_border,right_border,expected_pdf", load_r_test_cases())
     def test_pdf_against_R(self, x, shape1, shape2, left_border, right_border, expected_pdf):
@@ -203,8 +228,8 @@ class TestBetaLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(params=st_valid_params(), x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, params, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, params, x, dtype):
+        """Tests that for an array input, the LPDF returns an array with the correct type and shape."""
 
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -212,6 +237,17 @@ class TestBetaLPDF:
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(params=st_valid_params(), x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, params, x, dtype):
+        """Tests that for a scalar input, the LPDF returns a scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = params
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(params=st_valid_params(), x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, params, x):
@@ -244,8 +280,8 @@ class TestBetaPPF:
     @given(
         params=st_valid_params(), p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, params, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, params, p, dtype):
+        """Tests that for an array input, the PPDF returns an array with the correct type and shape."""
 
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -253,6 +289,17 @@ class TestBetaPPF:
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(params=st_valid_params(), p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, params, p, dtype):
+        """Tests that for a scalar input, the PPDF returns a scalar with the correct type and shape."""
+
+        alpha, beta, left_border, right_border = params
+        dist = Beta(alpha, beta, left_border, right_border, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(params=st_valid_params(), p=st.floats(0, 1))
     def test_ppf_against_scipy(self, params, p):
@@ -278,8 +325,8 @@ class TestBetaGradients:
 
     h = 1e-6
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape1_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_shape1_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'shape1' against a numerical approximation."""
 
         shape1, shape2, left_border, right_border, x = params_x
@@ -298,9 +345,22 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_shape2_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_shape1_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'shape1' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_alpha(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_shape2_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'shape2' against a numerical approximation."""
+
         shape1, shape2, left_border, right_border, x = params_x
 
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -317,9 +377,22 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_left_border_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_shape2_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'shape2' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_beta(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_left_border_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'left_border' against a numerical approximation."""
+
         shape1, shape2, left_border, right_border, x = params_x
 
         dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
@@ -336,8 +409,20 @@ class TestBetaGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(params_x=st_params_and_x_for_grad())
-    def test_dlog_right_border_numerical(self, params_x, dtype):
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_left_border_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'left_border' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_left_border(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(params_x=st_params_and_array_x_for_grad())
+    def test_dlog_right_border_numerical_for_array_input(self, params_x, dtype):
         """Checks the analytical gradient for 'right_border' against a numerical approximation."""
         shape1, shape2, left_border, right_border, x = params_x
 
@@ -354,6 +439,18 @@ class TestBetaGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_dlog_right_border_for_scalar_input(self, params_x, dtype):
+        """Checks that the gradient for 'right_border' for a scalar input returns scalar."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+        analytical_grad = dist._dlog_right_border(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -391,6 +488,19 @@ class TestBetaGradients:
         if "right_border" in expected_params:
             idx = sorted(expected_params).index("right_border")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
+
+    @given(params_x=st_params_and_scalar_x_for_grad())
+    def test_log_gradients_for_scalar_input(self, params_x, dtype):
+        """Checks that the log_gradients for a scalar input returns 1D-array."""
+
+        shape1, shape2, left_border, right_border, x = params_x
+        dist = Beta(shape1, shape2, left_border, right_border, dtype=dtype)
+
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -78,7 +78,7 @@ class TestBetaInitialization:
         """Tests that the instance is initialized correctly with valid parameters."""
 
         shape1, shape2, left_border, right_border = 0.5, 2.0, -1.0, 1.0
-        dist = Beta(alpha=shape1, beta=shape2, lower_bound=left_border, upper_bound=right_border, dtype=dtype)
+        dist = Beta(alpha=shape1, beta=shape2, left_border=left_border, right_border=right_border, dtype=dtype)
         assert dist.alpha.dtype == dtype
         assert dist.beta.dtype == dtype
         assert dist.left_border.dtype == dtype
@@ -145,7 +145,7 @@ class TestBetaInitialization:
     def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Beta(alpha=1.1, beta=2.1, lower_bound=10.1, upper_bound=20.1, dtype=dtype)
+        dist = Beta(alpha=1.1, beta=2.1, left_border=10.1, right_border=20.1, dtype=dtype)
         repr_str = repr(dist)
         assert (
             repr_str == f"Beta(alpha={dist.alpha}, beta={dist.beta}, left_border={dist.left_border}, "

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -7,16 +7,20 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Beta
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import beta, kstest
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 
 @st.composite
@@ -174,7 +178,7 @@ class TestBetaPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
         shape1, shape2, left_border, right_border = params
         dist = Beta(shape1, shape2, left_border, right_border)
-        integral, error = quad(dist.pdf, left_border, right_border)
+        integral, error = quad(lambda x: dist.pdf(x).item(), left_border, right_border)
         np.testing.assert_allclose(1.0, integral, rtol=1e-6, atol=1e-8)
 
     @given(x=st.floats(min_value=1e-4, max_value=1e2, allow_infinity=False))
@@ -202,6 +206,9 @@ class TestBetaLPDF:
         """Compares the custom LPDF implementation against scipy's implementation."""
 
         shape1, shape2, left_border, right_border = params
+
+        assume(left_border < x < right_border)
+
         dist = Beta(shape1, shape2, left_border, right_border)
         custom_lpdf = dist.lpdf(x)
         scipy_lpdf = beta.logpdf(x, shape1, shape2, loc=left_border, scale=right_border - left_border)
@@ -422,3 +429,30 @@ class TestBetaGenerate:
         ks_statistic, p_value = kstest(samples, "beta", args=(shape1, shape2, left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestBetaDType(DTypeHandlingMixin):
+    distribution_class = Beta
+    default_params: ClassVar[dict] = {"alpha": 1.0, "beta": 2.0, "left_border": -1.0, "right_border": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1, 1)))
+    def test_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def test_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_alpha", "_dlog_beta", "_dlog_left_border", "_dlog_right_border"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1, 1)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_beta.py
+++ b/rework_tests/unit/distributions/test_beta.py
@@ -507,21 +507,30 @@ class TestBetaGradients:
 class TestBetaGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-        dist = Beta(1.0, 1.0, 1.0, 10.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Cauchy
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import cauchy, kstest
 
@@ -287,30 +285,3 @@ class TestCauchyGenerate:
         ks_statistic, p_value = kstest(samples, "cauchy", args=(loc, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestCauchyDType(DTypeHandlingMixin):
-    distribution_class = Cauchy
-    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Cauchy
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import cauchy, kstest
 
@@ -24,54 +22,55 @@ st_scale = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infin
 st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestCauchyInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         loc, scale = 0.5, 2.0
-        dist = Cauchy(loc=loc, scale=scale)
-        assert isinstance(dist.loc, float)
-        assert isinstance(dist.scale, float)
-        assert dist.loc == loc
-        assert dist.scale == scale
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        assert dist.loc.dtype == dtype
+        assert dist.scale.dtype == dtype
+        assert dist.loc == dtype(loc)
+        assert dist.scale == dtype(scale)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Cauchy(loc=0.0, scale=1.0)
+        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
         assert dist.name == "Cauchy"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Cauchy(loc=0.0, scale=1.0)
+        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
         assert dist.params == {"loc", "scale"}
 
-    def test_scale_invariant_violation(self):
+    def test_scale_invariant_violation(self, dtype):
         """Tests that assigning a non-positive rate after initialization raises a ValueError."""
 
         with pytest.raises(ValueError, match="Scale parameter should be positive"):
-            Cauchy(loc=0.0, scale=-10.0)
+            Cauchy(loc=0.0, scale=-10.0, dtype=dtype)
         with pytest.raises(ValueError, match="Scale parameter should be positive"):
-            Cauchy(loc=0.0, scale=-0.02)
+            Cauchy(loc=0.0, scale=-0.02, dtype=dtype)
 
-    def test_scale_assignment_violation(self):
+    def test_scale_assignment_violation(self, dtype):
         """Tests that assigning a non-positive rate after initialization raises a ValueError."""
 
-        dist = Cauchy(loc=0.0, scale=1.0)
+        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
         with pytest.raises(ValueError, match="Scale parameter should be positive"):
             dist.scale = 0.0
         with pytest.raises(ValueError, match="Scale parameter should be positive"):
             dist.scale = -10.0
 
-    def test_repr_method(self):
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Cauchy(loc=1.23, scale=4.56)
+        dist = Cauchy(loc=1.23, scale=4.56, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Cauchy(loc=1.23, scale=4.56)"
+        assert repr_str == f"Cauchy(loc={dist.loc}, scale={dist.scale}, dtype=np.{dtype.__name__})"
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -80,13 +79,16 @@ class TestCauchyInitialization:
 class TestCauchyPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x):
+    def test_pdf_properties(self, loc, scale, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
 
-        dist = Cauchy(loc=loc, scale=scale)
+        loc, scale = 0.0, 1.0
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -112,13 +114,15 @@ class TestCauchyPDF:
 class TestLogCauchyPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x):
+    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
         """Tests the return type and shape of the lpdf method."""
 
-        dist = Cauchy(loc=loc, scale=scale)
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
@@ -134,15 +138,17 @@ class TestLogCauchyPDF:
 class TestCauchyPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, scale, p):
+    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
         """Tests the return type and shape of the ppf method."""
 
-        dist = Cauchy(loc=loc, scale=scale)
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
@@ -162,55 +168,60 @@ class TestCauchyPPF:
         assert np.isnan(dist.ppf(p_val))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestCauchyGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x):
+    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
         """Checks the analytical gradient for 'loc' against a numerical approximation."""
 
         assume(np.all(x > (loc + self.h)))
 
-        dist = Cauchy(loc=loc, scale=scale)
-
-        lpdf_plus_h = Cauchy(loc=loc + self.h, scale=scale).lpdf(x)
-        lpdf_minus_h = Cauchy(loc=loc - self.h, scale=scale).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Cauchy(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Cauchy(loc + self.h, scale).lpdf(x)
+            lpdf_minus_h = Cauchy(loc - self.h, scale).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x):
+    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
         """Checks the analytical gradient for 'scale' against a numerical approximation."""
 
         assume(np.all(x > (loc + self.h)))
 
-        dist = Cauchy(loc=loc, scale=scale)
-
-        lpdf_plus_h = Cauchy(loc=loc, scale=scale + self.h).lpdf(x)
-        lpdf_minus_h = Cauchy(loc=loc, scale=scale - self.h).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Cauchy(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Cauchy(loc, scale + self.h).lpdf(x)
+            lpdf_minus_h = Cauchy(loc, scale - self.h).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
         [([], 2, ["loc", "scale"]), (["loc"], 1, ["scale"]), (["scale"], 1, ["loc"]), (["loc", "scale"], 0, [])],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Cauchy(loc=1.0, scale=2.0)
+        dist = Cauchy(loc=1.0, scale=2.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -218,6 +229,7 @@ class TestCauchyGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_shape_col)
 
         if "loc" in expected_params:
@@ -228,43 +240,44 @@ class TestCauchyGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestCauchyGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
-        dist = Cauchy(loc=0.0, scale=2.0)
+        dist = Cauchy(loc=0.0, scale=2.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if the generating 0 number of samples returns an empty array"""
 
-        dist = Cauchy(loc=0.0, scale=1.0)
+        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
 
-        dist = Cauchy(loc=0.0, scale=1.0)
+        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         loc, scale = 10.0, 2.0
-        dist = Cauchy(loc=loc, scale=scale)
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         size = 1000
 
         samples = dist.generate(size=size)
@@ -272,30 +285,3 @@ class TestCauchyGenerate:
         ks_statistic, p_value = kstest(samples, "cauchy", args=(loc, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestCauchyDType(DTypeHandlingMixin):
-    distribution_class = Cauchy
-    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,6 +14,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Cauchy
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import cauchy, kstest
 
@@ -285,3 +287,30 @@ class TestCauchyGenerate:
         ks_statistic, p_value = kstest(samples, "cauchy", args=(loc, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestCauchyDType(DTypeHandlingMixin):
+    distribution_class = Cauchy
+    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -309,23 +309,31 @@ class TestCauchyGradients:
 class TestCauchyGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Cauchy(loc=0.0, scale=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Cauchy(loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,8 +14,11 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Cauchy
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import cauchy, kstest
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 st_scale = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False)
 st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False)
@@ -100,7 +104,7 @@ class TestCauchyPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
 
         dist = Cauchy(loc=loc, scale=scale)
-        integral, error = quad(dist.pdf, loc - 186_124 * scale, loc + 186_124 * scale)
+        integral, error = quad(lambda x: dist.pdf(x).item(), loc - 186_124 * scale, loc + 186_124 * scale)
         print(f"integral = {integral}, loc = {loc}, scale = {scale}")
         np.testing.assert_allclose(1.0, integral, rtol=1e-5)
 
@@ -268,3 +272,30 @@ class TestCauchyGenerate:
         ks_statistic, p_value = kstest(samples, "cauchy", args=(loc, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestCauchyDType(DTypeHandlingMixin):
+    distribution_class = Cauchy
+    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_cauchy.py
+++ b/rework_tests/unit/distributions/test_cauchy.py
@@ -81,16 +81,26 @@ class TestCauchyPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
-        loc, scale = 0.0, 1.0
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, loc, scale, x):
@@ -111,19 +121,29 @@ class TestCauchyPDF:
         np.testing.assert_allclose(1.0, integral, rtol=1e-5)
 
 
-class TestLogCauchyPDF:
+class TestCauchyLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, loc, scale, x):
@@ -142,14 +162,24 @@ class TestCauchyPPF:
     @given(
         loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
     def test_ppf_against_scipy(self, loc, scale, p):
@@ -175,8 +205,8 @@ class TestCauchyGradients:
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -194,9 +224,21 @@ class TestCauchyGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > loc + self.h)
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -213,6 +255,18 @@ class TestCauchyGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > loc + self.h)
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -238,6 +292,17 @@ class TestCauchyGradients:
         if "scale" in expected_params:
             idx = sorted(expected_params).index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Cauchy(loc, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
@@ -270,6 +335,23 @@ class TestCauchyGenerate:
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
+
+    def test_generate_statistical_properties(self, dtype):
+        """Tests if the generated samples have the correct statistical properties (median)."""
+
+        np.random.seed(123)
+        random.seed(123)
+        loc, scale = 5.0, 2.0
+        dist = Cauchy(loc=loc, scale=scale, dtype=dtype)
+        size = 5000
+
+        samples = dist.generate(size=size)
+
+        # The mean and variance of the Cauchy distribution are undefined.
+        # The median is equal to the location parameter 'loc'.
+        theoretical_median = loc
+
+        assert np.median(samples) == pytest.approx(theoretical_median, rel=0.1)
 
     def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""

--- a/rework_tests/unit/distributions/test_continuous_distribution.py
+++ b/rework_tests/unit/distributions/test_continuous_distribution.py
@@ -257,12 +257,12 @@ class TestContinuousDistribution:
             param_value = getattr(dummy_float32_dist, param_name)
             assert isinstance(param_value, np.float32)
 
-    # Test to_dtype method
+    # Test astype method
     # ----------------------------------
 
-    def test_to_dtype_successful_conversion(self, dummy_dist: DummyDistribution):
+    def test_astype_successful_conversion(self, dummy_dist: DummyDistribution):
         """
-        Tests that _to_dtype creates a new instance with the correct new dtype
+        Tests that astype creates a new instance with the correct new dtype
         and that the original instance remains unchanged.
         """
         assert dummy_dist.dtype == np.float64
@@ -285,9 +285,9 @@ class TestContinuousDistribution:
         for param in dummy_dist.params:
             assert isinstance(getattr(dummy_dist, param), np.float64)
 
-    def test_to_dtype_returns_self_if_same_dtype(self, dummy_dist: DummyDistribution):
+    def test_astype_returns_self_if_same_dtype(self, dummy_dist: DummyDistribution):
         """
-        Tests that _to_dtype returns the same instance if the target dtype
+        Tests that astype returns the same instance if the target dtype
         is identical to the current one, avoiding unnecessary copying.
         """
         assert dummy_dist.dtype == np.float64
@@ -296,7 +296,7 @@ class TestContinuousDistribution:
 
         assert same_dtype_dist is dummy_dist
 
-    def test_to_dtype_preserves_fixed_params(self, dummy_dist: DummyDistribution):
+    def test_astype_preserves_fixed_params(self, dummy_dist: DummyDistribution):
         """
         Tests that the set of fixed parameters is correctly copied to the
         new instance after dtype conversion.

--- a/rework_tests/unit/distributions/test_continuous_distribution.py
+++ b/rework_tests/unit/distributions/test_continuous_distribution.py
@@ -6,11 +6,13 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from copy import copy
+from typing import ClassVar
 
 import numpy as np
 import pytest
 from numpy.typing import ArrayLike, NDArray
-from rework_pysatl_mpest.distributions import ContinuousDistribution
+from rework_pysatl_mpest.core import Parameter
+from rework_pysatl_mpest.distributions import ContinuousDistribution, Exponential, Normal
 
 # Dummy distribution classes
 # --------------------------
@@ -23,29 +25,16 @@ class DummyDistribution(ContinuousDistribution):
     and test the non-abstract methods of the base class.
     """
 
-    def __init__(self, param1: float = 1.0, param2: float = 2.0, name: str = "Dummy"):
+    param1 = Parameter()
+    param2 = Parameter()
+
+    def __init__(self, param1: float = 1.0, param2: float = 2.0, name: str = "Dummy", dtype: np.floating = np.float64):
         """Initializes with two simple parameters."""
 
-        super().__init__()
-        self._param1 = param1
-        self._param2 = param2
+        super().__init__(dtype=dtype)
+        self.param1 = param1
+        self.param2 = param2
         self._name = name
-
-    @property
-    def param1(self):
-        return self._param1
-
-    @param1.setter
-    def param1(self, value):
-        self._param1 = value
-
-    @property
-    def param2(self):
-        return self._param2
-
-    @param2.setter
-    def param2(self, value):
-        self._param2 = value
 
     @property
     def name(self) -> str:
@@ -96,6 +85,11 @@ def dummy_dist() -> DummyDistribution:
     """Provides a fresh instance of DummyDistribution for each test."""
 
     return DummyDistribution(param1=10.0, param2=20.0)
+
+
+@pytest.fixture
+def dummy_float32_dist() -> DummyDistribution:
+    return DummyDistribution(param1=10.0, param2=20.0, dtype=np.float32)
 
 
 @pytest.fixture
@@ -193,6 +187,13 @@ class TestContinuousDistribution:
         with pytest.raises(ValueError, match="Invalid parameter names provided"):
             dummy_dist.get_params_vector(["param1", "invalid_param"])
 
+    def test_get_params_vector_returns_correct_types(self, dummy_float32_dist: DummyDistribution):
+        """Tests that get_params_vector returns a list of scalars with the correct dtype."""
+        param_names = ["param1", "param2"]
+        vector = dummy_float32_dist.get_params_vector(param_names)
+        for param in vector:
+            assert isinstance(param, np.float32)
+
     # Test set_params_from_vector method
     # ----------------------------------
 
@@ -236,6 +237,84 @@ class TestContinuousDistribution:
 
         with pytest.raises(ValueError, match=error_msg_match):
             dummy_dist.set_params_from_vector(param_names, vector)
+
+    @pytest.mark.parametrize(
+        "param_names, vector_to_set",
+        [
+            (["param1", "param2"], [100.0, 200.0]),
+            (("param2",), (99.0,)),
+            (["param1", "param2"], np.array([1.5, 2.5])),
+        ],
+    )
+    def test_set_params_from_vector_correct_dtype(
+        self, dummy_float32_dist: DummyDistribution, param_names, vector_to_set
+    ):
+        """Tests setting parameter values from a vector."""
+
+        dummy_float32_dist.set_params_from_vector(param_names, vector_to_set)
+
+        for param_name in param_names:
+            param_value = getattr(dummy_float32_dist, param_name)
+            assert isinstance(param_value, np.float32)
+
+    # Test to_dtype method
+    # ----------------------------------
+
+    def test_to_dtype_successful_conversion(self, dummy_dist: DummyDistribution):
+        """
+        Tests that _to_dtype creates a new instance with the correct new dtype
+        and that the original instance remains unchanged.
+        """
+        assert dummy_dist.dtype == np.float64
+        for param in dummy_dist.params:
+            assert isinstance(getattr(dummy_dist, param), np.float64)
+
+        target_dtype = np.float32
+        new_dist = dummy_dist.astype(target_dtype)
+
+        assert new_dist is not dummy_dist
+        assert new_dist != dummy_dist
+
+        assert new_dist.dtype == np.float32
+        for param in new_dist.params:
+            assert isinstance(getattr(new_dist, param), target_dtype)
+            assert getattr(new_dist, param) == np.float32(getattr(dummy_dist, param))
+
+        # original instance remains unchanged
+        assert dummy_dist.dtype == np.float64
+        for param in dummy_dist.params:
+            assert isinstance(getattr(dummy_dist, param), np.float64)
+
+    def test_to_dtype_returns_self_if_same_dtype(self, dummy_dist: DummyDistribution):
+        """
+        Tests that _to_dtype returns the same instance if the target dtype
+        is identical to the current one, avoiding unnecessary copying.
+        """
+        assert dummy_dist.dtype == np.float64
+
+        same_dtype_dist = dummy_dist.astype(np.float64)
+
+        assert same_dtype_dist is dummy_dist
+
+    def test_to_dtype_preserves_fixed_params(self, dummy_dist: DummyDistribution):
+        """
+        Tests that the set of fixed parameters is correctly copied to the
+        new instance after dtype conversion.
+        """
+        dummy_dist.fix_param("param1")
+        assert "param1" in dummy_dist._fixed_params
+
+        new_dist = dummy_dist.astype(np.float32)
+
+        assert new_dist.dtype == np.float32
+        for param in new_dist.params:
+            assert isinstance(getattr(new_dist, param), np.float32)
+            assert getattr(new_dist, param) == np.float32(getattr(dummy_dist, param))
+
+        assert "param1" in new_dist._fixed_params
+        assert new_dist._fixed_params == dummy_dist._fixed_params
+
+        assert new_dist._fixed_params is not dummy_dist._fixed_params
 
 
 class TestContinuousDistributionCopying:
@@ -299,8 +378,8 @@ class TestContinuousDistributionComparison:
     def test_neq_different_type(self):
         """Tests that two instances with different types are not equal."""
 
-        d1 = DummyDistribution(param1=1.0, param2=2.0)
-        d2 = DummyDistribution(param1=1.0, param2=2.0, name="Dummy2")
+        d1 = Normal(loc=0.0, scale=1.0)
+        d2 = Exponential(loc=0.0, rate=1.0)
         assert d1 != d2
 
     def test_neq_other_object(self):
@@ -309,6 +388,13 @@ class TestContinuousDistributionComparison:
         d1 = DummyDistribution(param1=1.0, param2=2.0)
         other = "not_a_distribution"
         assert d1 != other
+
+    def test_neq_different_dtype(self):
+        """Tests that two instances with different dtypes are not equal."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0, dtype=np.float32)
+        assert d1 != d2
 
     def test_hash_consistency(self):
         """Tests that two equal distribution instances have the same hash."""
@@ -333,3 +419,70 @@ class TestContinuousDistributionComparison:
         d2 = DummyDistribution(param1=1.0, param2=2.0, name="Dummy2")
         assert d1 != d2
         assert hash(d1) != hash(d2)
+
+    def test_hash_inequality_dtype(self):
+        """Tests that two non-equal type distribution instances have different hashes."""
+
+        d1 = DummyDistribution(param1=1.0, param2=2.0)
+        d2 = DummyDistribution(param1=1.0, param2=2.0, dtype=np.float32)
+        assert d1 != d2
+        assert hash(d1) != hash(d2)
+
+
+class DTypeHandlingMixin:
+    """A test mixin to verify correct dtype handling in all subclasses of ContinuousDistribution."""
+
+    distribution_class: ClassVar[type[ContinuousDistribution] | None] = None
+    default_params: ClassVar[dict] = {}
+
+    # Tests initialization
+    # --------------------
+
+    def check_init_with_dtype_sets_correct_types(self, dtype):
+        """Tests that the constructor and the Parameter descriptor correctly cast parameter types."""
+
+        dist = self.distribution_class(**self.default_params, dtype=dtype)
+
+        assert dist.dtype == dtype
+
+        for param_name in self.default_params:
+            param_value = getattr(dist, param_name)
+            assert isinstance(param_value, dtype)
+
+    # Tests generate
+    # --------------------
+
+    def check_generate_returns_correct_dtype(self, size, dtype):
+        """Tests the dtype of the array returned by the generate method."""
+        dist = self.distribution_class(**self.default_params, dtype=dtype)
+
+        result = dist.generate(size=size)
+
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == dtype
+
+    # Tests calculations
+    # --------------------
+
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        """Helper method with the logic for testing methods that take X."""
+        dist = self.distribution_class(**self.default_params, dtype=dtype)
+        method_to_test = getattr(dist, method_name)
+        result = method_to_test(x_data)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == dtype
+
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        """Helper method with the logic for testing the ppf method."""
+        dist = self.distribution_class(**self.default_params, dtype=dtype)
+        result = dist.ppf(p_data)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == dtype
+
+    def check_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        """Tests that each partial derivative method (_dlog_*) returns a NumPy array with the correct dtype."""
+
+        dist = self.distribution_class(**self.default_params, dtype=dtype)
+        method = getattr(dist, method_name)
+
+        assert method(x_data).dtype == dtype

--- a/rework_tests/unit/distributions/test_continuous_distribution.py
+++ b/rework_tests/unit/distributions/test_continuous_distribution.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from copy import copy
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -427,62 +426,3 @@ class TestContinuousDistributionComparison:
         d2 = DummyDistribution(param1=1.0, param2=2.0, dtype=np.float32)
         assert d1 != d2
         assert hash(d1) != hash(d2)
-
-
-class DTypeHandlingMixin:
-    """A test mixin to verify correct dtype handling in all subclasses of ContinuousDistribution."""
-
-    distribution_class: ClassVar[type[ContinuousDistribution] | None] = None
-    default_params: ClassVar[dict] = {}
-
-    # Tests initialization
-    # --------------------
-
-    def check_init_with_dtype_sets_correct_types(self, dtype):
-        """Tests that the constructor and the Parameter descriptor correctly cast parameter types."""
-
-        dist = self.distribution_class(**self.default_params, dtype=dtype)
-
-        assert dist.dtype == dtype
-
-        for param_name in self.default_params:
-            param_value = getattr(dist, param_name)
-            assert isinstance(param_value, dtype)
-
-    # Tests generate
-    # --------------------
-
-    def check_generate_returns_correct_dtype(self, size, dtype):
-        """Tests the dtype of the array returned by the generate method."""
-        dist = self.distribution_class(**self.default_params, dtype=dtype)
-
-        result = dist.generate(size=size)
-
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == dtype
-
-    # Tests calculations
-    # --------------------
-
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        """Helper method with the logic for testing methods that take X."""
-        dist = self.distribution_class(**self.default_params, dtype=dtype)
-        method_to_test = getattr(dist, method_name)
-        result = method_to_test(x_data)
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == dtype
-
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        """Helper method with the logic for testing the ppf method."""
-        dist = self.distribution_class(**self.default_params, dtype=dtype)
-        result = dist.ppf(p_data)
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == dtype
-
-    def check_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        """Tests that each partial derivative method (_dlog_*) returns a NumPy array with the correct dtype."""
-
-        dist = self.distribution_class(**self.default_params, dtype=dtype)
-        method = getattr(dist, method_name)
-
-        assert method(x_data).dtype == dtype

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Exponential
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import expon, kstest
 
@@ -24,54 +22,55 @@ st_rate = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infini
 st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestExponentialInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         loc, rate = 0.5, 2.0
-        dist = Exponential(loc=loc, rate=rate)
-        assert isinstance(dist.loc, float)
-        assert isinstance(dist.rate, float)
-        assert dist.loc == loc
-        assert dist.rate == rate
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
+        assert dist.loc.dtype == dtype
+        assert dist.rate.dtype == dtype
+        assert dist.loc == dtype(loc)
+        assert dist.rate == dtype(rate)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Exponential(loc=0.0, rate=1.0)
+        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
         assert dist.name == "Exponential"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Exponential(loc=0.0, rate=1.0)
+        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
         assert dist.params == {"loc", "rate"}
 
-    def test_rate_invariant_violation(self):
+    def test_rate_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive rate raises a ValueError."""
 
         with pytest.raises(ValueError, match="Rate parameter must be a positive"):
-            Exponential(loc=0.0, rate=0.0)
+            Exponential(loc=0.0, rate=0.0, dtype=dtype)
         with pytest.raises(ValueError, match="Rate parameter must be a positive"):
-            Exponential(loc=0.0, rate=-1.0)
+            Exponential(loc=0.0, rate=-1.0, dtype=dtype)
 
-    def test_rate_assignment_violation(self):
+    def test_rate_assignment_violation(self, dtype):
         """Tests that assigning a non-positive rate after initialization raises a ValueError."""
 
-        dist = Exponential(loc=0.0, rate=1.0)
+        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
         with pytest.raises(ValueError, match="Rate parameter must be a positive"):
             dist.rate = 0.0
         with pytest.raises(ValueError, match="Rate parameter must be a positive"):
             dist.rate = -10.0
 
-    def test_repr_method(self):
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Exponential(loc=1.23, rate=4.56)
+        dist = Exponential(loc=1.23, rate=4.56, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Exponential(loc=1.23, rate=4.56)"
+        assert repr_str == f"Exponential(loc={dist.loc}, rate={dist.rate}, dtype=np.{dtype.__name__})"
 
         recreated_dist = eval(repr_str)
         assert recreated_dist == dist
@@ -80,13 +79,15 @@ class TestExponentialInitialization:
 class TestExponentialPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, rate, x):
+    def test_pdf_properties(self, loc, rate, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
 
-        dist = Exponential(loc=loc, rate=rate)
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -121,13 +122,15 @@ class TestExponentialPDF:
 class TestExponentialLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, rate, x):
+    def test_lpdf_return_type_and_shape(self, loc, rate, x, dtype):
         """Tests the return type and shape of the lpdf method."""
 
-        dist = Exponential(loc=loc, rate=rate)
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
@@ -153,18 +156,20 @@ class TestExponentialLPDF:
 class TestExponentialPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         loc=st_loc, rate=st_rate, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, rate, p):
+    def test_ppf_return_type_and_shape(self, loc, rate, p, dtype):
         """Tests the return type and shape of the ppf method."""
 
-        dist = Exponential(loc=loc, rate=rate)
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
-    @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1))
+    @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
     def test_ppf_against_scipy(self, loc, rate, p):
         """Compares the custom PPF implementation against scipy's implementation."""
 
@@ -181,55 +186,60 @@ class TestExponentialPPF:
         assert np.isnan(dist.ppf(p_val))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestExponentialGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, rate, x):
+    def test_dlog_loc_numerical(self, loc, rate, x, dtype):
         """Checks the analytical gradient for 'loc' against a numerical approximation."""
 
         assume(np.all(x > (loc + self.h)))
 
-        dist = Exponential(loc=loc, rate=rate)
-
-        lpdf_plus_h = Exponential(loc=loc + self.h, rate=rate).lpdf(x)
-        lpdf_minus_h = Exponential(loc=loc - self.h, rate=rate).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Exponential(loc, rate, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Exponential(loc + self.h, rate).lpdf(x)
+            lpdf_minus_h = Exponential(loc - self.h, rate).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_rate_numerical(self, loc, rate, x):
+    def test_dlog_rate_numerical(self, loc, rate, x, dtype):
         """Checks the analytical gradient for 'rate' against a numerical approximation."""
 
         assume(np.all(x > (loc + self.h)))
 
-        dist = Exponential(loc=loc, rate=rate)
-
-        lpdf_plus_h = Exponential(loc=loc, rate=rate + self.h).lpdf(x)
-        lpdf_minus_h = Exponential(loc=loc, rate=rate - self.h).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Exponential(loc, rate, dtype=dtype)
         analytical_grad = dist._dlog_rate(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Exponential(loc, rate + self.h).lpdf(x)
+            lpdf_minus_h = Exponential(loc, rate - self.h).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
         [([], 2, ["loc", "rate"]), (["loc"], 1, ["rate"]), (["rate"], 1, ["loc"]), (["loc", "rate"], 0, [])],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Exponential(loc=1.0, rate=2.0)
+        dist = Exponential(loc=1.0, rate=2.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -237,6 +247,7 @@ class TestExponentialGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_shape_col)
 
         if "loc" in expected_params:
@@ -247,43 +258,44 @@ class TestExponentialGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_rate(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestExponentialGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
-        dist = Exponential(loc=0.0, rate=2.0)
+        dist = Exponential(loc=0.0, rate=2.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if the generating 0 number of samples returns an empty array"""
 
-        dist = Exponential(loc=0.0, rate=1.0)
+        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
 
-        dist = Exponential(loc=0.0, rate=1.0)
+        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         loc, rate = 5.0, 0.5
-        dist = Exponential(loc=loc, rate=rate)
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         size = 20000
 
         samples = dist.generate(size=size)
@@ -291,16 +303,16 @@ class TestExponentialGenerate:
         theoretical_mean = loc + 1 / rate
         theoretical_var = (1 / rate) ** 2
 
-        assert np.mean(samples) == pytest.approx(theoretical_mean, rel=0.1)
-        assert np.var(samples) == pytest.approx(theoretical_var, rel=0.1)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(theoretical_mean, rel=0.1)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(theoretical_var, rel=0.1)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         loc, rate = 10.0, 2.0
-        dist = Exponential(loc=loc, rate=rate)
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         size = 1000
 
         samples = dist.generate(size=size)
@@ -308,30 +320,3 @@ class TestExponentialGenerate:
         ks_statistic, p_value = kstest(samples, "expon", args=(loc, 1 / rate))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestExponentialDType(DTypeHandlingMixin):
-    distribution_class = Exponential
-    default_params: ClassVar[dict] = {"loc": 0.0, "rate": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_rate"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -325,23 +325,31 @@ class TestExponentialGradients:
 class TestExponentialGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Exponential(loc=0.0, rate=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Exponential(loc=0.0, rate=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,8 +14,11 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Exponential
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import expon, kstest
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 st_rate = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False)
 st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False)
@@ -90,6 +94,8 @@ class TestExponentialPDF:
     def test_pdf_against_scipy(self, loc, rate, x):
         """Compares the custom PDF implementation against scipy's implementation."""
 
+        assume(x > loc)
+
         dist = Exponential(loc=loc, rate=rate)
         custom_pdf = dist.pdf(x)
         scipy_pdf = expon.pdf(x, loc=loc, scale=1 / rate)
@@ -100,7 +106,7 @@ class TestExponentialPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
 
         dist = Exponential(loc=loc, rate=rate)
-        integral, error = quad(dist.pdf, loc, np.inf)
+        integral, error = quad(lambda x: dist.pdf(x).item(), loc, np.inf)
         np.testing.assert_allclose(1.0, integral)
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(max_value=-1e6, allow_infinity=False))
@@ -127,6 +133,8 @@ class TestExponentialLPDF:
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, loc, rate, x):
         """Compares the custom LPDF implementation against scipy's implementation."""
+
+        assume(x > loc)
 
         dist = Exponential(loc=loc, rate=rate)
         custom_lpdf = dist.lpdf(x)
@@ -300,3 +308,30 @@ class TestExponentialGenerate:
         ks_statistic, p_value = kstest(samples, "expon", args=(loc, 1 / rate))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestExponentialDType(DTypeHandlingMixin):
+    distribution_class = Exponential
+    default_params: ClassVar[dict] = {"loc": 0.0, "rate": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_rate"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Exponential
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import expon, kstest
 
@@ -322,30 +320,3 @@ class TestExponentialGenerate:
         ks_statistic, p_value = kstest(samples, "expon", args=(loc, 1 / rate))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestExponentialDType(DTypeHandlingMixin):
-    distribution_class = Exponential
-    default_params: ClassVar[dict] = {"loc": 0.0, "rate": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_rate"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -81,8 +81,8 @@ class TestExponentialPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, rate, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, rate, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -90,6 +90,17 @@ class TestExponentialPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, rate, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, loc, rate, x):
@@ -124,14 +135,24 @@ class TestExponentialLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, rate, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, rate, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, rate, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, rate=st_rate, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, loc, rate, x):
@@ -160,14 +181,24 @@ class TestExponentialPPF:
     @given(
         loc=st_loc, rate=st_rate, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True))
     )
-    def test_ppf_return_type_and_shape(self, loc, rate, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, rate, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Exponential(loc=loc, rate=rate, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, rate, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Exponential(loc=loc, rate=rate, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, rate=st_rate, p=st.floats(0, 1, exclude_max=True, exclude_min=True))
     def test_ppf_against_scipy(self, loc, rate, p):
@@ -193,8 +224,8 @@ class TestExponentialGradients:
     h = 1e-6
 
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, rate, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, rate, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -212,9 +243,20 @@ class TestExponentialGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > (loc + self.h))
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, rate=st_rate, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_rate_numerical(self, loc, rate, x, dtype):
-        """Checks the analytical gradient for 'rate' against a numerical approximation."""
+    def test_dlog_rate_numerical_for_array_input(self, loc, rate, x, dtype):
+        """Checks the analytical gradient for 'rate' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
 
@@ -231,6 +273,17 @@ class TestExponentialGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_dlog_rate_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the gradient for 'rate' for a scalar input returns a scalar."""
+
+        assume(x > (loc + self.h))
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        analytical_grad = dist._dlog_rate(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -256,6 +309,16 @@ class TestExponentialGradients:
         if "rate" in expected_params:
             idx = sorted(expected_params).index("rate")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_rate(x))
+
+    @given(loc=st_loc, rate=st_rate, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, rate, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Exponential(loc, rate, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_exponential.py
+++ b/rework_tests/unit/distributions/test_exponential.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,6 +14,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Exponential
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import expon, kstest
 
@@ -320,3 +322,30 @@ class TestExponentialGenerate:
         ks_statistic, p_value = kstest(samples, "expon", args=(loc, 1 / rate))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestExponentialDType(DTypeHandlingMixin):
+    distribution_class = Exponential
+    default_params: ClassVar[dict] = {"loc": 0.0, "rate": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_rate"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -296,20 +296,29 @@ class TestNormalGradients:
 class TestNormalGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
-        samples = dist.generate(size=100)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (100,)
+        samples = dist.generate(size=size)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -5,7 +5,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Normal
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, norm
 
@@ -279,30 +277,3 @@ class TestNormalGenerate:
         ks_statistic, p_value = kstest(samples, "norm", args=(loc, scale))
         expected_p_value = 0.05
         assert p_value > expected_p_value
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestNormalDType(DTypeHandlingMixin):
-    distribution_class = Normal
-    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -12,8 +13,11 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Normal
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, norm
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # Strategies for hypothesis
 st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False)
@@ -91,7 +95,7 @@ class TestNormalPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
 
         dist = Normal(loc=loc, scale=scale)
-        integral, error = quad(dist.pdf, loc - scale * 6, loc + scale * 6)
+        integral, error = quad(lambda x: dist.pdf(x).item(), loc - scale * 6, loc + scale * 6)
         np.testing.assert_allclose(1.0, integral, atol=1e-7)
 
 
@@ -228,3 +232,30 @@ class TestNormalGenerate:
         samples = dist.generate(size=size)
         ks_statistic, p_value = kstest(samples, "norm", args=(loc, scale))
         assert p_value > expected_p_value
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestNormalDType(DTypeHandlingMixin):
+    distribution_class = Normal
+    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -12,6 +13,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Normal
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, norm
 
@@ -277,3 +279,30 @@ class TestNormalGenerate:
         ks_statistic, p_value = kstest(samples, "norm", args=(loc, scale))
         expected_p_value = 0.05
         assert p_value > expected_p_value
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestNormalDType(DTypeHandlingMixin):
+    distribution_class = Normal
+    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -81,8 +81,8 @@ class TestNormalPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -90,6 +90,17 @@ class TestNormalPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
     def test_pdf_against_scipy(self, loc, scale, x):
@@ -114,14 +125,24 @@ class TestNormalLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
     def test_lpdf_against_scipy(self, loc, scale, x):
@@ -138,14 +159,24 @@ class TestNormalPPF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1)))
-    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Normal(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(loc=st_loc, scale=st_scale, p=st.floats(0, 1))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(1e-6, 1.0 - 1e-6))
     def test_ppf_against_scipy(self, loc, scale, p):
@@ -156,6 +187,13 @@ class TestNormalPPF:
         scipy_ppf = norm.ppf(p, loc=loc, scale=scale)
         np.testing.assert_allclose(custom_ppf, scipy_ppf, atol=1e-9)
 
+    @pytest.mark.parametrize("p_val", [-0.5, 1.1, 1.5])
+    def test_ppf_invalid_input(self, p_val):
+        """Tests that PPF returns NaN for probabilities outside the [0, 1] range."""
+
+        dist = Normal(loc=0.0, scale=1.0)
+        assert np.isnan(dist.ppf(p_val))
+
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestNormalGradients:
@@ -164,8 +202,8 @@ class TestNormalGradients:
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
@@ -181,9 +219,19 @@ class TestNormalGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
@@ -199,11 +247,21 @@ class TestNormalGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
         [([], 2, ["loc", "scale"]), (["loc"], 1, ["scale"]), (["scale"], 1, ["loc"]), (["loc", "scale"], 0, [])],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params, dtype):
+    def test_log_gradients_structure_for_array_input(self, fixed_params, expected_cols, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
         dist = Normal(loc=1.0, scale=2.0, dtype=dtype)
@@ -221,6 +279,17 @@ class TestNormalGradients:
         if "scale" in expected_params:
             idx = sorted_params.index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(loc=st_loc, scale=st_scale, x=st.floats(-1e3, 1e3))
+    def test_log_gradients_for_scalar_input(self, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        dist = Normal(loc, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_normal.py
+++ b/rework_tests/unit/distributions/test_normal.py
@@ -5,7 +5,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Normal
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, norm
 
@@ -24,45 +22,55 @@ st_loc = st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinit
 st_scale = st.floats(min_value=0.01, max_value=1e3, allow_nan=False, allow_infinity=False)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestNormalInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         loc, scale = 10.0, 2.5
-        dist = Normal(loc=loc, scale=scale)
-        assert isinstance(dist.loc, float)
-        assert isinstance(dist.scale, float)
-        assert dist.loc == loc
-        assert dist.scale == scale
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
+        assert dist.loc.dtype == dtype
+        assert dist.scale.dtype == dtype
+        assert dist.loc == dtype(loc)
+        assert dist.scale == dtype(scale)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Normal(loc=0.0, scale=1.0)
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
         assert dist.name == "Normal"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Normal(loc=0.0, scale=1.0)
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
         assert dist.params == {"loc", "scale"}
 
-    def test_scale_invariant_violation(self):
+    def test_scale_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive scale raises a ValueError."""
 
         with pytest.raises(ValueError, match="Scale parameter must be positive"):
-            Normal(loc=0.0, scale=0.0)
+            Normal(loc=0.0, scale=0.0, dtype=dtype)
         with pytest.raises(ValueError, match="Scale parameter must be positive"):
-            Normal(loc=0.0, scale=-1.0)
+            Normal(loc=0.0, scale=-1.0, dtype=dtype)
 
-    def test_repr_method(self):
+    def test_scale_assignment_violation(self, dtype):
+        """Tests that assigning a non-positive rate after initialization raises a ValueError."""
+
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
+        with pytest.raises(ValueError, match="Scale parameter must be positive"):
+            dist.scale = 0.0
+        with pytest.raises(ValueError, match="Scale parameter must be positive"):
+            dist.scale = -10.0
+
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Normal(loc=1.23, scale=4.56)
+        dist = Normal(loc=1.23, scale=4.56, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Normal(loc=1.23, scale=4.56)"
+        assert repr_str == f"Normal(loc={dist.loc}, scale={dist.scale}, dtype=np.{dtype.__name__})"
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -71,13 +79,15 @@ class TestNormalInitialization:
 class TestNormalPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_pdf_properties(self, loc, scale, x):
+    def test_pdf_properties(self, loc, scale, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
 
-        dist = Normal(loc=loc, scale=scale)
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -102,13 +112,15 @@ class TestNormalPDF:
 class TestNormalLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, loc, scale, x):
+    def test_lpdf_return_type_and_shape(self, loc, scale, x, dtype):
         """Tests the return type and shape of the lpdf method."""
 
-        dist = Normal(loc=loc, scale=scale)
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
@@ -124,13 +136,15 @@ class TestNormalLPDF:
 class TestNormalPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(loc=st_loc, scale=st_scale, p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1)))
-    def test_ppf_return_type_and_shape(self, loc, scale, p):
+    def test_ppf_return_type_and_shape(self, loc, scale, p, dtype):
         """Tests the return type and shape of the ppf method."""
 
-        dist = Normal(loc=loc, scale=scale)
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(loc=st_loc, scale=st_scale, p=st.floats(1e-6, 1.0 - 1e-6))
@@ -143,41 +157,56 @@ class TestNormalPPF:
         np.testing.assert_allclose(custom_ppf, scipy_ppf, atol=1e-9)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestNormalGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_loc_numerical(self, loc, scale, x):
+    def test_dlog_loc_numerical(self, loc, scale, x, dtype):
         """Checks the analytical gradient for 'loc' against a numerical approximation."""
 
-        dist = Normal(loc=loc, scale=scale)
-        lpdf_plus_h = Normal(loc=loc + self.h, scale=scale).lpdf(x)
-        lpdf_minus_h = Normal(loc=loc - self.h, scale=scale).lpdf(x)
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
+        assert analytical_grad.shape == x.shape
+
+        if dtype == np.float64:
+            lpdf_plus_h = Normal(loc + self.h, scale).lpdf(x)
+            lpdf_minus_h = Normal(loc - self.h, scale).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(loc=st_loc, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e3, 1e3)))
-    def test_dlog_scale_numerical(self, loc, scale, x):
+    def test_dlog_scale_numerical(self, loc, scale, x, dtype):
         """Checks the analytical gradient for 'scale' against a numerical approximation."""
 
-        dist = Normal(loc=loc, scale=scale)
-        lpdf_plus_h = Normal(loc=loc, scale=scale + self.h).lpdf(x)
-        lpdf_minus_h = Normal(loc=loc, scale=scale - self.h).lpdf(x)
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Normal(loc, scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+        assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
+        assert analytical_grad.shape == x.shape
+
+        if dtype == np.float64:
+            lpdf_plus_h = Normal(loc, scale + self.h).lpdf(x)
+            lpdf_minus_h = Normal(loc, scale - self.h).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
         [([], 2, ["loc", "scale"]), (["loc"], 1, ["scale"]), (["scale"], 1, ["loc"]), (["loc", "scale"], 0, [])],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Normal(loc=1.0, scale=2.0)
+        dist = Normal(loc=1.0, scale=2.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -194,68 +223,57 @@ class TestNormalGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestNormalGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
-        dist = Normal(loc=0.0, scale=1.0)
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
         samples = dist.generate(size=100)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (100,)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_zero_size(self, dtype):
+        """Tests if the generating 0 number of samples returns an empty array"""
+
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
+        assert len(dist.generate(size=0)) == 0
+
+    @pytest.mark.parametrize("size", [-1, -10])
+    def test_generate_negative_size(self, size, dtype):
+        """Tests that generating a negative number of samples raises ValueError."""
+
+        dist = Normal(loc=0.0, scale=1.0, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dist.generate(size=size)
+
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         loc, scale = 15.0, 3.0
-        dist = Normal(loc=loc, scale=scale)
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
         size = 50000
 
         samples = dist.generate(size=size)
-        assert np.mean(samples) == pytest.approx(loc, rel=0.05)
-        assert np.var(samples) == pytest.approx(scale**2, rel=0.05)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(loc, rel=0.05)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(scale**2, rel=0.05)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         loc, scale = -10.0, 5.0
-        dist = Normal(loc=loc, scale=scale)
+        dist = Normal(loc=loc, scale=scale, dtype=dtype)
         size = 1000
-        expected_p_value = 0.05
 
         samples = dist.generate(size=size)
         ks_statistic, p_value = kstest(samples, "norm", args=(loc, scale))
+        expected_p_value = 0.05
         assert p_value > expected_p_value
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestNormalDType(DTypeHandlingMixin):
-    distribution_class = Normal
-    default_params: ClassVar[dict] = {"loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -7,7 +7,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
-from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,6 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions.pareto import Pareto
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, pareto
 
@@ -42,71 +40,72 @@ def load_r_test_cases():
     return cases
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestParetoInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         shape, scale = 0.5, 2.0
-        dist = Pareto(shape=shape, scale=scale)
-        assert isinstance(dist.shape, float)
-        assert isinstance(dist.scale, float)
-        assert dist.shape == shape
-        assert dist.scale == scale
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
+        assert dist.shape.dtype == dtype
+        assert dist.scale.dtype == dtype
+        assert dist.shape == dtype(shape)
+        assert dist.scale == dtype(scale)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         assert dist.name == "Pareto"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Pareto(shape=1.0, scale=1.0)
+        dist = Pareto(shape=1.0, scale=1.0, dtype=dtype)
         assert dist.params == {"shape", "scale"}
 
-    def test_shape_invariant_violation(self):
+    def test_shape_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive shape raises a ValueError."""
 
         with pytest.raises(ValueError, match="Shape parameter must be a positive"):
-            Pareto(shape=0.0, scale=1.0)
+            Pareto(shape=0.0, scale=1.0, dtype=dtype)
         with pytest.raises(ValueError, match="Shape parameter must be a positive"):
-            Pareto(shape=-1.0, scale=1.0)
+            Pareto(shape=-1.0, scale=1.0, dtype=dtype)
 
-    def test_scale_invariant_violation(self):
+    def test_scale_invariant_violation(self, dtype):
         """Tests that initializing with a non-positive scale raises a ValueError."""
 
         with pytest.raises(ValueError, match="Scale parameter must be a positive"):
-            Pareto(shape=1.0, scale=0.0)
+            Pareto(shape=1.0, scale=0.0, dtype=dtype)
         with pytest.raises(ValueError, match="Scale parameter must be a positive"):
-            Pareto(shape=1.0, scale=-1.0)
+            Pareto(shape=1.0, scale=-1.0, dtype=dtype)
 
-    def test_shape_assignment_violation(self):
+    def test_shape_assignment_violation(self, dtype):
         """Tests that assigning a non-positive shape after initialization raises a ValueError."""
 
-        dist = Pareto(shape=1.0, scale=1.0)
+        dist = Pareto(shape=1.0, scale=1.0, dtype=dtype)
         with pytest.raises(ValueError, match="Shape parameter must be a positive"):
             dist.shape = 0.0
         with pytest.raises(ValueError, match="Shape parameter must be a positive"):
             dist.shape = -10.0
 
-    def test_scale_assignment_violation(self):
+    def test_scale_assignment_violation(self, dtype):
         """Tests that assigning a non-positive scale after initialization raises a ValueError."""
 
-        dist = Pareto(shape=1.0, scale=1.0)
+        dist = Pareto(shape=1.0, scale=1.0, dtype=dtype)
         with pytest.raises(ValueError, match="Scale parameter must be a positive"):
             dist.scale = 0.0
         with pytest.raises(ValueError, match="Scale parameter must be a positive"):
             dist.scale = -10.0
 
-    def test_repr_method(self):
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Pareto(shape=1.23, scale=4.56)
+        dist = Pareto(shape=1.23, scale=4.56, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Pareto(shape=1.23, scale=4.56)"
+        assert repr_str == f"Pareto(shape={dist.shape}, scale={dist.scale}, dtype=np.{dtype.__name__})"
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -115,13 +114,15 @@ class TestParetoInitialization:
 class TestParetoPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e2, 1e2)))
-    def test_pdf_properties(self, x):
+    def test_pdf_properties(self, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
 
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -168,13 +169,15 @@ class TestParetoPDF:
 class TestParetoLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, shape, scale, x):
+    def test_lpdf_return_type_and_shape(self, shape, scale, x, dtype):
         """Tests the return type and shape of the lpdf method."""
 
-        dist = Pareto(shape=shape, scale=scale)
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3, allow_infinity=False, allow_nan=False))
@@ -198,17 +201,19 @@ class TestParetoLPDF:
 class TestParetoPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         shape=st_shape,
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, scale, p):
+    def test_ppf_return_type_and_shape(self, shape, scale, p, dtype):
         """Tests the return type and shape of the ppf method."""
 
-        dist = Pareto(shape=shape, scale=scale)
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(shape=st_shape, scale=st_scale, p=st.floats(0, 1))
@@ -228,6 +233,7 @@ class TestParetoPPF:
         assert np.isnan(dist.ppf(p_val))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestParetoGradients:
     """Tests for gradient calculation methods."""
 
@@ -235,41 +241,45 @@ class TestParetoGradients:
 
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_shape_numerical(self, shape, scale, x):
+    def test_dlog_shape_numerical(self, shape, scale, x, dtype):
         """Checks the analytical gradient for 'shape' against a numerical approximation."""
 
         assume(np.all(x > scale))
 
-        dist = Pareto(shape=shape, scale=scale)
-
-        lpdf_plus_h = Pareto(shape=shape + self.h, scale=scale).lpdf(x)
-        lpdf_minus_h = Pareto(shape=shape - self.h, scale=scale).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         analytical_grad = dist._dlog_shape(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Pareto(shape=shape + self.h, scale=scale).lpdf(x)
+            lpdf_minus_h = Pareto(shape=shape - self.h, scale=scale).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, shape, scale, x):
+    def test_dlog_scale_numerical(self, shape, scale, x, dtype):
         """Checks the analytical gradient for 'scale' against a numerical approximation."""
 
         assume(np.all(x > scale + self.h))
 
-        dist = Pareto(shape=shape, scale=scale)
-
-        lpdf_plus_h = Pareto(shape=shape, scale=scale + self.h).lpdf(x)
-        lpdf_minus_h = Pareto(shape=shape, scale=scale - self.h).lpdf(x)
-
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Pareto(shape=shape, scale=scale + self.h).lpdf(x)
+            lpdf_minus_h = Pareto(shape=shape, scale=scale - self.h).lpdf(x)
+
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -280,10 +290,10 @@ class TestParetoGradients:
             (["shape", "scale"], 0, []),
         ],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -291,6 +301,7 @@ class TestParetoGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_shape_col)
 
         if "shape" in expected_params:
@@ -301,43 +312,44 @@ class TestParetoGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestParetoGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if the generating 0 number of samples returns an empty array"""
 
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
 
-        dist = Pareto(shape=1.0, scale=2.0)
+        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         shape, scale = 5.0, 0.5
-        dist = Pareto(shape=shape, scale=scale)
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         size = 20000
 
         samples = dist.generate(size=size)
@@ -345,47 +357,20 @@ class TestParetoGenerate:
         theoretical_mean = (shape * scale) / (shape - 1)
         theoretical_var = ((scale**2) * shape) / ((shape - 1) ** 2 * (shape - 2))
 
-        assert np.mean(samples) == pytest.approx(theoretical_mean, rel=0.1)
-        assert np.var(samples) == pytest.approx(theoretical_var, rel=0.1)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(theoretical_mean, rel=0.1)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(theoretical_var, rel=0.1)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
-        shape, scale, loc = 10.0, 2.0, 0.0
-        dist = Pareto(shape=shape, scale=scale)
+        shape, scale = 10.0, 2.0
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         size = 1000
 
         samples = dist.generate(size=size)
 
-        ks_statistic, p_value = kstest(samples, "pareto", args=(shape, loc, scale))
+        ks_statistic, p_value = kstest(samples, "pareto", args=(shape, 0, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestParetoDType(DTypeHandlingMixin):
-    distribution_class = Pareto
-    default_params: ClassVar[dict] = {"shape": 1.0, "scale": 2.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -380,23 +380,31 @@ class TestParetoGradients:
 class TestParetoGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -7,7 +7,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
-from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,6 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions.pareto import Pareto
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, pareto
 
@@ -376,30 +374,3 @@ class TestParetoGenerate:
         ks_statistic, p_value = kstest(samples, "pareto", args=(shape, 0, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestParetoDType(DTypeHandlingMixin):
-    distribution_class = Pareto
-    default_params: ClassVar[dict] = {"shape": 1.0, "scale": 2.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -116,8 +116,8 @@ class TestParetoPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e2, 1e2)))
-    def test_pdf_properties(self, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Pareto(shape=1.0, scale=2.0, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -125,6 +125,18 @@ class TestParetoPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e2, 1e2))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        shape, scale = 1.0, 2.0
+        dist = Pareto(shape, scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @pytest.mark.parametrize("x,shape,scale,expected_pdf", load_r_test_cases())
     def test_pdf_against_R(self, shape, scale, x, expected_pdf):
@@ -171,8 +183,8 @@ class TestParetoLPDF:
 
     @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_lpdf_return_type_and_shape(self, shape, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, shape, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
@@ -180,9 +192,20 @@ class TestParetoLPDF:
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, shape, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
+
     @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3, allow_infinity=False, allow_nan=False))
     def test_lpdf_against_scipy(self, shape, scale, x):
         """Compares the custom LPDF implementation against scipy's implementation."""
+
         assume(np.isfinite(pareto.logpdf(x, scale=scale, b=shape, loc=0.0)))
         dist = Pareto(shape=shape, scale=scale)
         custom_lpdf = dist.lpdf(x)
@@ -207,14 +230,24 @@ class TestParetoPPF:
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, shape, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Pareto(shape=shape, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, shape, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Pareto(shape=shape, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(shape=st_shape, scale=st_scale, p=st.floats(0, 1))
     def test_ppf_against_scipy(self, shape, scale, p):
@@ -241,8 +274,8 @@ class TestParetoGradients:
 
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_shape_numerical(self, shape, scale, x, dtype):
-        """Checks the analytical gradient for 'shape' against a numerical approximation."""
+    def test_dlog_shape_numerical_for_array_input(self, shape, scale, x, dtype):
+        """Checks the analytical gradient for 'shape' against a numerical approximation for array input."""
 
         assume(np.all(x > scale))
 
@@ -260,10 +293,20 @@ class TestParetoGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_shape_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the gradient for 'shape' for a scalar input returns a scalar."""
+
+        assume(x > scale)
+        dist = Pareto(shape, scale, dtype=dtype)
+        analytical_grad = dist._dlog_shape(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(shape=st_shape, scale=st_scale, x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)))
-    def test_dlog_scale_numerical(self, shape, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, shape, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > scale + self.h))
 
@@ -280,6 +323,16 @@ class TestParetoGradients:
 
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > scale + self.h)
+        dist = Pareto(shape, scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -310,6 +363,17 @@ class TestParetoGradients:
         if "scale" in expected_params:
             idx = sorted(expected_params).index("scale")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_scale(x))
+
+    @given(shape=st_shape, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, shape, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        assume(x > scale + self.h)
+        dist = Pareto(shape, scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -7,6 +7,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -15,8 +16,11 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions.pareto import Pareto
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, pareto
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 st_shape = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False)
 st_scale = st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False)
@@ -138,7 +142,7 @@ class TestParetoPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
 
         dist = Pareto(shape=shape, scale=scale)
-        integral, error = quad(dist.pdf, scale, np.inf, epsabs=1e-10, epsrel=1e-10, limit=100)
+        integral, error = quad(lambda x: dist.pdf(x).item(), scale, np.inf, epsabs=1e-10, epsrel=1e-10, limit=100)
         assert np.isfinite(integral), f"Integral diverged: {integral}"
         np.testing.assert_allclose(1.0, integral, rtol=1e-8, atol=1e-10)
 
@@ -180,7 +184,7 @@ class TestParetoLPDF:
         dist = Pareto(shape=shape, scale=scale)
         custom_lpdf = dist.lpdf(x)
         scipy_lpdf = pareto.logpdf(x, scale=scale, b=shape, loc=0.0)
-        np.testing.assert_allclose(custom_lpdf, scipy_lpdf, atol=1e-12)
+        np.testing.assert_allclose(custom_lpdf, scipy_lpdf, atol=1e-12, rtol=1e-3)
 
     @given(shape=st_shape, scale=st_scale, x=st.floats(min_value=1e2, max_value=1e4, allow_infinity=False))
     def test_lpdf_outside_support(self, shape, scale, x):
@@ -358,3 +362,30 @@ class TestParetoGenerate:
         ks_statistic, p_value = kstest(samples, "pareto", args=(shape, loc, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestParetoDType(DTypeHandlingMixin):
+    distribution_class = Pareto
+    default_params: ClassVar[dict] = {"shape": 1.0, "scale": 2.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_pareto.py
+++ b/rework_tests/unit/distributions/test_pareto.py
@@ -7,6 +7,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import random
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,7 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions.pareto import Pareto
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, pareto
 
@@ -374,3 +376,30 @@ class TestParetoGenerate:
         ks_statistic, p_value = kstest(samples, "pareto", args=(shape, 0, scale))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestParetoDType(DTypeHandlingMixin):
+    distribution_class = Pareto
+    default_params: ClassVar[dict] = {"shape": 1.0, "scale": 2.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(2, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -12,6 +13,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Uniform
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, uniform
 
@@ -354,3 +356,30 @@ class TestUniformGenerate:
         ks_statistic, p_value = kstest(samples, "uniform", args=(left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestUniformDType(DTypeHandlingMixin):
+    distribution_class = Uniform
+    default_params: ClassVar[dict] = {"left_border": 0.0, "right_border": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_left_border", "_dlog_right_border"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -5,7 +5,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Uniform
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, uniform
 
@@ -30,50 +28,54 @@ def st_valid_border(draw):
     return left_border, right_border
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestUniformInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         l_border, r_border = 0.5, 2.0
-        dist = Uniform(left_border=l_border, right_border=r_border)
-        assert isinstance(dist.left_border, float)
-        assert isinstance(dist.right_border, float)
-        assert dist.left_border == l_border
-        assert dist.right_border == r_border
+        dist = Uniform(left_border=l_border, right_border=r_border, dtype=dtype)
+        assert dist.left_border.dtype == dtype
+        assert dist.right_border.dtype == dtype
+        assert dist.left_border == dtype(l_border)
+        assert dist.right_border == dtype(r_border)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Uniform(left_border=0.0, right_border=1.0)
+        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
         assert dist.name == "Uniform"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Uniform(left_border=0.0, right_border=1.0)
+        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
         assert dist.params == {"left_border", "right_border"}
 
-    def test_invariant_violation(self):
+    def test_invariant_violation(self, dtype):
         """Tests that initializing with a infinite borders or left border bigger right border  raises a ValueError."""
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
-            Uniform(0.0, -1.0)
+            Uniform(0.0, -1.0, dtype=dtype)
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
-            Uniform(0.0, -2.0)
+            Uniform(0.0, -2.0, dtype=dtype)
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
-            Uniform(0.0, 0.0)
+            Uniform(0.0, 0.0, dtype=dtype)
         with pytest.raises(ValueError, match="Both borders should be finite values"):
-            Uniform(-np.inf, 0.0)
+            Uniform(-np.inf, 0.0, dtype=dtype)
         with pytest.raises(ValueError, match="Both borders should be finite values"):
-            Uniform(0.0, np.inf)
+            Uniform(0.0, np.inf, dtype=dtype)
 
-    def test_repr_method(self):
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Uniform(left_border=1.23, right_border=4.56)
+        dist = Uniform(left_border=1.23, right_border=4.56, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Uniform(left_border=1.23, right_border=4.56)"
+        assert (
+            repr_str == f"Uniform(left_border={dist.left_border}, right_border={dist.right_border}, "
+            f"dtype=np.{dtype.__name__})"
+        )
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -82,17 +84,19 @@ class TestUniformInitialization:
 class TestUniformPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         borders=st_valid_border(),
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, borders, x):
+    def test_pdf_properties(self, borders, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
         left_border, right_border = borders
 
-        dist = Uniform(left_border=left_border, right_border=right_border)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -122,19 +126,56 @@ class TestUniformPDF:
         assert dist.pdf(x_val) == 0.0
 
 
+class TestUniformLPDF:
+    """Tests for the lpdf (log-PDF) method using hypothesis."""
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(
+        borders=st_valid_border(),
+        x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
+    )
+    def test_lpdf_return_type_and_shape(self, borders, x, dtype):
+        """Tests the return type and shape of the lpdf method."""
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        lpdf_values = dist.lpdf(x)
+        assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
+        assert lpdf_values.shape == x.shape
+
+    @given(borders=st_valid_border(), x=st.floats(1e-6, 1e6))
+    def test_lpdf_against_scipy(self, borders, x):
+        """Compares the custom LPDF implementation against scipy's implementation."""
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border)
+        custom_lpdf = dist.lpdf(x)
+        scipy_lpdf = uniform.logpdf(x, loc=left_border, scale=right_border - left_border)
+        np.testing.assert_allclose(custom_lpdf, scipy_lpdf, atol=1e-9)
+
+    @given(borders=st_valid_border(), x=st.floats(min_value=1e-6))
+    def test_lpdf_outside_support(self, borders, x):
+        """Tests that the LPDF is -inf for values outside the support."""
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border)
+        assert dist.lpdf(left_border - x) == -np.inf
+        assert dist.lpdf(right_border + x) == -np.inf
+
+
 class TestUniformPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         borders=st_valid_border(),
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, borders, p):
+    def test_ppf_return_type_and_shape(self, borders, p, dtype):
         """Tests the return type and shape of the ppf method."""
         left_border, right_border = borders
-        dist = Uniform(left_border=left_border, right_border=right_border)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(borders=st_valid_border(), p=st.floats(0, 1))
@@ -176,56 +217,49 @@ def st_valid_grad_input(draw):
     return (left_border, right_border), x_values
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestUniformGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
     @given(input_data=st_valid_grad_input())
-    def test_dlog_left_border_numerical(self, input_data):
+    def test_dlog_left_border_numerical(self, input_data, dtype):
         """Checks the analytical gradient for 'left_border' against a numerical approximation."""
         borders, x = input_data
         left_border, right_border = borders
 
-        dist = Uniform(left_border=left_border, right_border=right_border)
-
-        lpdf_plus_h = Uniform(left_border=left_border + self.h, right_border=right_border).lpdf(x)
-        lpdf_minus_h = Uniform(left_border=left_border - self.h, right_border=right_border).lpdf(x)
-
-        finite_mask = np.isfinite(lpdf_plus_h) & np.isfinite(lpdf_minus_h)
-
-        if np.any(finite_mask):
-            numerical_grad = np.zeros_like(x)
-            numerical_grad[finite_mask] = (lpdf_plus_h[finite_mask] - lpdf_minus_h[finite_mask]) / (2 * self.h)
-
-            analytical_grad = dist._dlog_left_border(x)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_left_border(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Uniform(left_border=left_border + self.h, right_border=right_border).lpdf(x)
+            lpdf_minus_h = Uniform(left_border=left_border - self.h, right_border=right_border).lpdf(x)
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(input_data=st_valid_grad_input())
-    def test_dlog_right_border_numerical(self, input_data):
+    def test_dlog_right_border_numerical(self, input_data, dtype):
         """Checks the analytical gradient for 'right_border' against a numerical approximation."""
         borders, x = input_data
         left_border, right_border = borders
 
-        dist = Uniform(left_border=left_border, right_border=right_border)
-
-        lpdf_plus_h = Uniform(left_border=left_border, right_border=right_border + self.h).lpdf(x)
-        lpdf_minus_h = Uniform(left_border=left_border, right_border=right_border - self.h).lpdf(x)
-
-        finite_mask = np.isfinite(lpdf_plus_h) & np.isfinite(lpdf_minus_h)
-
-        if np.any(finite_mask):
-            numerical_grad = np.zeros_like(x)
-            numerical_grad[finite_mask] = (lpdf_plus_h[finite_mask] - lpdf_minus_h[finite_mask]) / (2 * self.h)
-
-            analytical_grad = dist._dlog_right_border(x)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_right_border(x)
 
         assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
         assert analytical_grad.shape == x.shape
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+        if dtype == np.float64:
+            lpdf_plus_h = Uniform(left_border=left_border, right_border=right_border + self.h).lpdf(x)
+            lpdf_minus_h = Uniform(left_border=left_border, right_border=right_border - self.h).lpdf(x)
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -236,10 +270,10 @@ class TestUniformGradients:
             (["left_border", "right_border"], 0, []),
         ],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_shape_col, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Uniform(left_border=1.0, right_border=3.0)
+        dist = Uniform(left_border=1.0, right_border=3.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -247,6 +281,7 @@ class TestUniformGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_shape_col)
 
         if "left_border" in expected_params:
@@ -257,43 +292,44 @@ class TestUniformGradients:
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestUniformGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
-        dist = Uniform(left_border=0.0, right_border=2.0)
+        dist = Uniform(left_border=0.0, right_border=2.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if the generating 0 number of samples returns an empty array"""
 
-        dist = Uniform(left_border=0.0, right_border=1.0)
+        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
 
-        dist = Uniform(left_border=0.0, right_border=1.0)
+        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
 
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         left_border, right_border = 5.0, 5.5
-        dist = Uniform(left_border=left_border, right_border=right_border)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         size = 20000
 
         samples = dist.generate(size=size)
@@ -301,16 +337,16 @@ class TestUniformGenerate:
         theoretical_mean = (right_border + left_border) / 2
         theoretical_var = (right_border - left_border) ** 2 / 12
 
-        assert np.mean(samples) == pytest.approx(theoretical_mean, rel=0.1)
-        assert np.var(samples) == pytest.approx(theoretical_var, rel=0.1)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(theoretical_mean, rel=0.1)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(theoretical_var, rel=0.1)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         left_border, right_border = 10.0, 12.0
-        dist = Uniform(left_border=left_border, right_border=right_border)
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         size = 1000
 
         samples = dist.generate(size=size)
@@ -318,30 +354,3 @@ class TestUniformGenerate:
         ks_statistic, p_value = kstest(samples, "uniform", args=(left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestUniformDType(DTypeHandlingMixin):
-    distribution_class = Uniform
-    default_params: ClassVar[dict] = {"left_border": 0.0, "right_border": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_left_border", "_dlog_right_border"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -5,7 +5,6 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Uniform
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, uniform
 
@@ -356,30 +354,3 @@ class TestUniformGenerate:
         ks_statistic, p_value = kstest(samples, "uniform", args=(left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestUniformDType(DTypeHandlingMixin):
-    distribution_class = Uniform
-    default_params: ClassVar[dict] = {"left_border": 0.0, "right_border": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_left_border", "_dlog_right_border"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -399,23 +399,31 @@ class TestUniformGradients:
 class TestUniformGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         np.random.seed(42)
         random.seed(42)
         dist = Uniform(left_border=0.0, right_border=2.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if the generating 0 number of samples returns an empty array"""
-
-        dist = Uniform(left_border=0.0, right_border=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -12,8 +13,11 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Uniform
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.stats import kstest, uniform
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 
 @st.composite
@@ -106,7 +110,7 @@ class TestUniformPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
-        integral, error = quad(dist.pdf, left_border, right_border)
+        integral, error = quad(lambda x: dist.pdf(x).item(), left_border, right_border)
         np.testing.assert_allclose(1.0, integral)
 
     @given(borders=st_valid_border(), x=st.floats(max_value=-1e9, allow_infinity=False))
@@ -314,3 +318,30 @@ class TestUniformGenerate:
         ks_statistic, p_value = kstest(samples, "uniform", args=(left_border, right_border - left_border))
         lower_bound = 0.05
         assert p_value > lower_bound
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestUniformDType(DTypeHandlingMixin):
+    distribution_class = Uniform
+    default_params: ClassVar[dict] = {"left_border": 0.0, "right_border": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e3, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_left_border", "_dlog_right_border"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_uniform.py
+++ b/rework_tests/unit/distributions/test_uniform.py
@@ -21,6 +21,7 @@ DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 @st.composite
 def st_valid_border(draw):
     """Generates valid borders"""
+
     left_border = draw(st.floats(min_value=-1e3, max_value=1e3 - 1, allow_nan=False, allow_infinity=False))
     right_border = draw(
         st.floats(min_value=left_border + 1e-6, max_value=left_border + 1e3, allow_nan=False, allow_infinity=False)
@@ -56,6 +57,7 @@ class TestUniformInitialization:
 
     def test_invariant_violation(self, dtype):
         """Tests that initializing with a infinite borders or left border bigger right border  raises a ValueError."""
+
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
             Uniform(0.0, -1.0, dtype=dtype)
         with pytest.raises(ValueError, match="right_border parameter must be strictly greater than left_border"):
@@ -89,8 +91,9 @@ class TestUniformPDF:
         borders=st_valid_border(),
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, borders, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, borders, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
+
         left_border, right_border = borders
 
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
@@ -100,9 +103,22 @@ class TestUniformPDF:
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        left_border, right_border = -1.0, 12.0
+        dist = Uniform(left_border, right_border, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
+
     @given(borders=st_valid_border(), x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, borders, x):
         """Compares the custom PDF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_pdf = dist.pdf(x)
@@ -112,6 +128,7 @@ class TestUniformPDF:
     @given(borders=st_valid_border())
     def test_pdf_integral_is_one(self, borders):
         """Tests that the integral of the PDF over its support is equal to 1."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         integral, error = quad(lambda x: dist.pdf(x).item(), left_border, right_border)
@@ -120,6 +137,7 @@ class TestUniformPDF:
     @given(borders=st_valid_border(), x=st.floats(max_value=-1e9, allow_infinity=False))
     def test_pdf_outside_support(self, borders, x):
         """Tests that the PDF is zero for values not in range of parameters."""
+
         left_border, right_border = borders
         x_val = left_border - abs(x)
         dist = Uniform(left_border=left_border, right_border=right_border)
@@ -134,8 +152,9 @@ class TestUniformLPDF:
         borders=st_valid_border(),
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_lpdf_return_type_and_shape(self, borders, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, borders, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         lpdf_values = dist.lpdf(x)
@@ -143,9 +162,21 @@ class TestUniformLPDF:
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(borders=st_valid_border(), x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, borders, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
+
     @given(borders=st_valid_border(), x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, borders, x):
         """Compares the custom LPDF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_lpdf = dist.lpdf(x)
@@ -155,6 +186,7 @@ class TestUniformLPDF:
     @given(borders=st_valid_border(), x=st.floats(min_value=1e-6))
     def test_lpdf_outside_support(self, borders, x):
         """Tests that the LPDF is -inf for values outside the support."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         assert dist.lpdf(left_border - x) == -np.inf
@@ -169,8 +201,9 @@ class TestUniformPPF:
         borders=st_valid_border(),
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, borders, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, borders, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
         ppf_values = dist.ppf(p)
@@ -178,9 +211,21 @@ class TestUniformPPF:
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(borders=st_valid_border(), p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, borders, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        left_border, right_border = borders
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
+
     @given(borders=st_valid_border(), p=st.floats(0, 1))
     def test_ppf_against_scipy(self, borders, p):
         """Compares the custom PPF implementation against scipy's implementation."""
+
         left_border, right_border = borders
         dist = Uniform(left_border=left_border, right_border=right_border)
         custom_ppf = dist.ppf(p)
@@ -196,8 +241,9 @@ class TestUniformPPF:
 
 
 @st.composite
-def st_valid_grad_input(draw):
-    """Generates valid borders to calculate gradient"""
+def st_valid_grad_input_array(draw):
+    """Generates valid borders to calculate gradient for an array of x."""
+
     left_border = draw(st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False))
     right_border = draw(
         st.floats(min_value=left_border + 0.1, max_value=left_border + 20.0, allow_nan=False, allow_infinity=False)
@@ -217,15 +263,35 @@ def st_valid_grad_input(draw):
     return (left_border, right_border), x_values
 
 
+@st.composite
+def st_valid_grad_input_scalar(draw):
+    """Generates valid borders to calculate gradient for a scalar x."""
+
+    left_border = draw(st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False))
+    right_border = draw(
+        st.floats(min_value=left_border + 0.1, max_value=left_border + 20.0, allow_nan=False, allow_infinity=False)
+    )
+
+    margin = 0.01
+    x_value = draw(
+        st.floats(
+            min_value=left_border + margin, max_value=right_border - margin, allow_nan=False, allow_infinity=False
+        )
+    )
+
+    return (left_border, right_border), x_value
+
+
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestUniformGradients:
     """Tests for gradient calculation methods."""
 
     h = 1e-6
 
-    @given(input_data=st_valid_grad_input())
-    def test_dlog_left_border_numerical(self, input_data, dtype):
-        """Checks the analytical gradient for 'left_border' against a numerical approximation."""
+    @given(input_data=st_valid_grad_input_array())
+    def test_dlog_left_border_numerical_for_array_input(self, input_data, dtype):
+        """Checks the analytical gradient for 'left_border' against a numerical approximation for array input."""
+
         borders, x = input_data
         left_border, right_border = borders
 
@@ -242,9 +308,22 @@ class TestUniformGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
-    @given(input_data=st_valid_grad_input())
-    def test_dlog_right_border_numerical(self, input_data, dtype):
-        """Checks the analytical gradient for 'right_border' against a numerical approximation."""
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_dlog_left_border_for_scalar_input(self, input_data, dtype):
+        """Checks that the gradient for 'left_border' for a scalar input returns a scalar."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_left_border(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
+    @given(input_data=st_valid_grad_input_array())
+    def test_dlog_right_border_numerical_for_array_input(self, input_data, dtype):
+        """Checks the analytical gradient for 'right_border' against a numerical approximation for array input."""
+
         borders, x = input_data
         left_border, right_border = borders
 
@@ -260,6 +339,18 @@ class TestUniformGradients:
             lpdf_minus_h = Uniform(left_border=left_border, right_border=right_border - self.h).lpdf(x)
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_dlog_right_border_for_scalar_input(self, input_data, dtype):
+        """Checks that the gradient for 'right_border' for a scalar input returns a scalar."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+
+        dist = Uniform(left_border=left_border, right_border=right_border, dtype=dtype)
+        analytical_grad = dist._dlog_right_border(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_shape_col, expected_params",
@@ -290,6 +381,18 @@ class TestUniformGradients:
         if "right_border" in expected_params:
             idx = sorted(expected_params).index("right_border")
             np.testing.assert_allclose(gradients[:, idx], dist._dlog_right_border(x))
+
+    @given(input_data=st_valid_grad_input_scalar())
+    def test_log_gradients_for_scalar_input(self, input_data, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        borders, x = input_data
+        left_border, right_border = borders
+        dist = Uniform(left_border, right_border, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,6 +14,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Weibull
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.special import gamma
 from scipy.stats import kstest, weibull_min
@@ -370,3 +372,30 @@ class TestWeibullGenerate:
         ks_statistic, p_value = kstest(samples, "weibull_min", args=(shape, loc, scale))
         expected_p_value = 0.05
         assert p_value > expected_p_value
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestWeibullDType(DTypeHandlingMixin):
+    distribution_class = Weibull
+    default_params: ClassVar[dict] = {"shape": 2.0, "loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Weibull
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.special import gamma
 from scipy.stats import kstest, weibull_min
@@ -27,53 +25,54 @@ st_loc = st.floats(min_value=-5, max_value=5, allow_nan=False, allow_infinity=Fa
 st_scale = st.floats(min_value=0.5, max_value=10, allow_nan=False, allow_infinity=False)
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestWeibullInitialization:
     """Tests for the __init__ method and basic properties."""
 
-    def test_initialization_successful(self):
+    def test_initialization_successful(self, dtype):
         """Tests that the instance is initialized correctly with valid parameters."""
 
         shape, loc, scale = 2.0, 0.5, 1.5
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
-        assert isinstance(dist.shape, float)
-        assert isinstance(dist.loc, float)
-        assert isinstance(dist.scale, float)
-        assert dist.shape == shape
-        assert dist.loc == loc
-        assert dist.scale == scale
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        assert dist.shape.dtype == dtype
+        assert dist.loc.dtype == dtype
+        assert dist.scale.dtype == dtype
+        assert dist.shape == dtype(shape)
+        assert dist.loc == dtype(loc)
+        assert dist.scale == dtype(scale)
 
-    def test_name_property(self):
+    def test_name_property(self, dtype):
         """Tests that the name property returns the correct string."""
 
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0)
+        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
         assert dist.name == "Weibull"
 
-    def test_params_property(self):
+    def test_params_property(self, dtype):
         """Tests that the params property returns the correct set of parameter names."""
 
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0)
+        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
         assert dist.params == {"shape", "loc", "scale"}
 
     @pytest.mark.parametrize("invalid_shape", [0.0, -1.0, -10.0])
-    def test_shape_invariant_violation(self, invalid_shape):
+    def test_shape_invariant_violation(self, invalid_shape, dtype):
         """Tests that initializing with a non-positive shape raises a ValueError."""
 
         with pytest.raises(ValueError, match="Shape parameter must be positive"):
-            Weibull(shape=invalid_shape, loc=0.0, scale=1.0)
+            Weibull(shape=invalid_shape, loc=0.0, scale=1.0, dtype=dtype)
 
     @pytest.mark.parametrize("invalid_scale", [0.0, -1.0, -10.0])
-    def test_scale_invariant_violation(self, invalid_scale):
+    def test_scale_invariant_violation(self, invalid_scale, dtype):
         """Tests that initializing with a non-positive scale raises a ValueError."""
 
         with pytest.raises(ValueError, match="Scale parameter must be positive"):
-            Weibull(shape=1.0, loc=0.0, scale=invalid_scale)
+            Weibull(shape=1.0, loc=0.0, scale=invalid_scale, dtype=dtype)
 
-    def test_repr_method(self):
+    def test_repr_method(self, dtype):
         """Tests that the __repr__ method provides a reproducible string."""
 
-        dist = Weibull(shape=1.23, loc=4.56, scale=7.89)
+        dist = Weibull(shape=1.23, loc=4.56, scale=7.89, dtype=dtype)
         repr_str = repr(dist)
-        assert repr_str == "Weibull(shape=1.23, loc=4.56, scale=7.89)"
+        assert repr_str == f"Weibull(shape={dist.shape}, loc={dist.loc}, scale={dist.scale}, dtype=np.{dtype.__name__})"
 
         recreated_dist = eval(repr_str)
         assert dist == recreated_dist
@@ -82,18 +81,20 @@ class TestWeibullInitialization:
 class TestWeibullPDF:
     """Tests for the pdf method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, shape, loc, scale, x):
+    def test_pdf_properties(self, shape, loc, scale, x, dtype):
         """Tests that the PDF is non-negative and has the correct return type and shape."""
 
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
         assert isinstance(pdf_values, np.ndarray)
+        assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
 
@@ -127,18 +128,20 @@ class TestWeibullPDF:
 class TestWeibullLPDF:
     """Tests for the lpdf (log-PDF) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_lpdf_return_type_and_shape(self, shape, loc, scale, x):
+    def test_lpdf_return_type_and_shape(self, shape, loc, scale, x, dtype):
         """Tests the return type and shape of the lpdf method."""
 
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
+        assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
@@ -163,18 +166,20 @@ class TestWeibullLPDF:
 class TestWeibullPPF:
     """Tests for the ppf (Percent Point Function) method using hypothesis."""
 
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, loc, scale, p):
+    def test_ppf_return_type_and_shape(self, shape, loc, scale, p, dtype):
         """Tests the return type and shape of the ppf method."""
 
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
+        assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, p=st.floats(0.01, 1))
@@ -186,7 +191,15 @@ class TestWeibullPPF:
         scipy_ppf = weibull_min.ppf(p, c=shape, loc=loc, scale=scale)
         np.testing.assert_allclose(custom_ppf, scipy_ppf, atol=1e-6)
 
+    @pytest.mark.parametrize("p_val", [-0.5, 1.1, 1.5])
+    def test_ppf_invalid_input(self, p_val):
+        """Tests that PPF returns NaN for probabilities outside the [0, 1) range."""
 
+        dist = Weibull(shape=1.0, loc=0.0, scale=1.0)
+        assert np.isnan(dist.ppf(p_val))
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestWeibullGradients:
     """Tests for gradient calculation methods."""
 
@@ -198,16 +211,21 @@ class TestWeibullGradients:
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_shape_numerical(self, shape, loc, scale, x):
+    def test_dlog_shape_numerical(self, shape, loc, scale, x, dtype):
         """Checks the analytical gradient for 'shape' against a numerical approximation."""
 
-        assume(np.all(x > loc + self.h))
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
-        lpdf_plus_h = Weibull(shape=shape + self.h, loc=loc, scale=scale).lpdf(x)
-        lpdf_minus_h = Weibull(shape=shape - self.h, loc=loc, scale=scale).lpdf(x)
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        assume(np.all(x > loc))
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         analytical_grad = dist._dlog_shape(x)
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+        assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
+        assert analytical_grad.shape == x.shape
+
+        if dtype == np.float64:
+            lpdf_plus_h = Weibull(shape=shape + self.h, loc=loc, scale=scale).lpdf(x)
+            lpdf_minus_h = Weibull(shape=shape - self.h, loc=loc, scale=scale).lpdf(x)
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(
         shape=st_shape,
@@ -215,16 +233,21 @@ class TestWeibullGradients:
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_loc_numerical(self, shape, loc, scale, x):
+    def test_dlog_loc_numerical(self, shape, loc, scale, x, dtype):
         """Checks the analytical gradient for 'loc' against a numerical approximation."""
 
         assume(np.all(x > (loc + self.h)))
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
-        lpdf_plus_h = Weibull(shape=shape, loc=loc + self.h, scale=scale).lpdf(x)
-        lpdf_minus_h = Weibull(shape=shape, loc=loc - self.h, scale=scale).lpdf(x)
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         analytical_grad = dist._dlog_loc(x)
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
+        assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
+        assert analytical_grad.shape == x.shape
+
+        if dtype == np.float64:
+            lpdf_plus_h = Weibull(shape=shape, loc=loc + self.h, scale=scale).lpdf(x)
+            lpdf_minus_h = Weibull(shape=shape, loc=loc - self.h, scale=scale).lpdf(x)
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
     @given(
         shape=st_shape,
@@ -232,16 +255,21 @@ class TestWeibullGradients:
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_scale_numerical(self, shape, loc, scale, x):
+    def test_dlog_scale_numerical(self, shape, loc, scale, x, dtype):
         """Checks the analytical gradient for 'scale' against a numerical approximation."""
 
-        assume(np.all(x > loc + self.h))
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
-        lpdf_plus_h = Weibull(shape=shape, loc=loc, scale=scale + self.h).lpdf(x)
-        lpdf_minus_h = Weibull(shape=shape, loc=loc, scale=scale - self.h).lpdf(x)
-        numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+        assume(np.all(x > loc))
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         analytical_grad = dist._dlog_scale(x)
-        np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+        assert isinstance(analytical_grad, np.ndarray)
+        assert analytical_grad.dtype == dtype
+        assert analytical_grad.shape == x.shape
+
+        if dtype == np.float64:
+            lpdf_plus_h = Weibull(shape=shape, loc=loc, scale=scale + self.h).lpdf(x)
+            lpdf_minus_h = Weibull(shape=shape, loc=loc, scale=scale - self.h).lpdf(x)
+            numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
+            np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
@@ -256,10 +284,10 @@ class TestWeibullGradients:
             (["loc", "scale", "shape"], 0, []),
         ],
     )
-    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params):
+    def test_log_gradients_structure(self, fixed_params, expected_cols, expected_params, dtype):
         """Tests the structure and content of log_gradients with various fixed parameters."""
 
-        dist = Weibull(shape=2.0, loc=1.0, scale=3.0)
+        dist = Weibull(shape=2.0, loc=1.0, scale=3.0, dtype=dtype)
         for param in fixed_params:
             dist.fix_param(param)
 
@@ -267,6 +295,7 @@ class TestWeibullGradients:
         gradients = dist.log_gradients(x)
 
         assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
         assert gradients.shape == (len(x), expected_cols)
 
         sorted_params = sorted(expected_params)
@@ -278,40 +307,41 @@ class TestWeibullGradients:
             np.testing.assert_allclose(gradients[:, sorted_params.index("shape")], dist._dlog_shape(x))
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestWeibullGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self):
+    def test_generate_type_and_shape(self, dtype):
         """Tests that generated samples have the correct type and shape."""
 
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0)
+        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
         size = 100
         samples = dist.generate(size=size)
         assert isinstance(samples, np.ndarray)
-        assert samples.dtype == np.float64
+        assert samples.dtype == dtype
         assert samples.shape == (size,)
 
-    def test_generate_zero_size(self):
+    def test_generate_zero_size(self, dtype):
         """Tests if generating 0 number of samples returns an empty array"""
 
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0)
+        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
         assert len(dist.generate(size=0)) == 0
 
     @pytest.mark.parametrize("size", [-1, -10])
-    def test_generate_negative_size(self, size):
+    def test_generate_negative_size(self, size, dtype):
         """Tests that generating a negative number of samples raises ValueError."""
 
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0)
+        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
         with pytest.raises(ValueError):
             dist.generate(size=size)
 
-    def test_generate_statistical_properties(self):
+    def test_generate_statistical_properties(self, dtype):
         """Tests if the generated samples have correct statistical properties (mean, variance)."""
 
         np.random.seed(123)
         random.seed(123)
         shape, loc, scale = 2.5, 5.0, 3.0
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         size = 50000
 
         samples = dist.generate(size=size)
@@ -322,48 +352,21 @@ class TestWeibullGenerate:
         theoretical_mean = loc + scale * g1
         theoretical_var = (scale**2) * (g2 - g1**2)
 
-        assert np.mean(samples) == pytest.approx(theoretical_mean, rel=0.05)
-        assert np.var(samples) == pytest.approx(theoretical_var, rel=0.05)
+        assert np.mean(samples, dtype=np.float64) == pytest.approx(theoretical_mean, rel=0.05)
+        assert np.var(samples, dtype=np.float64) == pytest.approx(theoretical_var, rel=0.05)
 
-    def test_generate_kolmogorov_smirnov(self):
+    def test_generate_kolmogorov_smirnov(self, dtype):
         """Performs a Kolmogorov-Smirnov test to check if samples fit the distribution."""
 
         np.random.seed(456)
         random.seed(456)
         shape, loc, scale = 3.0, 10.0, 2.0
-        dist = Weibull(shape=shape, loc=loc, scale=scale)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         size = 1000
-        expected_p_value = 0.05
 
         samples = dist.generate(size=size)
 
         # args for scipy's weibull_min are (shape, loc, scale)
         ks_statistic, p_value = kstest(samples, "weibull_min", args=(shape, loc, scale))
+        expected_p_value = 0.05
         assert p_value > expected_p_value
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestWeibullDType(DTypeHandlingMixin):
-    distribution_class = Weibull
-    default_params: ClassVar[dict] = {"shape": 2.0, "loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -384,21 +384,29 @@ class TestWeibullGradients:
 class TestWeibullGenerate:
     """Tests for the generate method."""
 
-    def test_generate_type_and_shape(self, dtype):
+    @pytest.mark.parametrize(
+        "size, expected_shape, is_scalar",
+        [
+            (None, (), True),
+            (0, (0,), False),
+            (10, (10,), False),
+            ((5,), (5,), False),
+            ((2, 3), (2, 3), False),
+        ],
+    )
+    def test_generate_type_and_shape(self, dtype, size, expected_shape, is_scalar):
         """Tests that generated samples have the correct type and shape."""
 
         dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
-        size = 100
         samples = dist.generate(size=size)
-        assert isinstance(samples, np.ndarray)
-        assert samples.dtype == dtype
-        assert samples.shape == (size,)
 
-    def test_generate_zero_size(self, dtype):
-        """Tests if generating 0 number of samples returns an empty array"""
-
-        dist = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
-        assert len(dist.generate(size=0)) == 0
+        if is_scalar:
+            assert np.isscalar(samples)
+            assert isinstance(samples, dtype)
+        else:
+            assert isinstance(samples, np.ndarray)
+            assert samples.shape == expected_shape
+            assert samples.dtype == dtype
 
     @pytest.mark.parametrize("size", [-1, -10])
     def test_generate_negative_size(self, size, dtype):

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -86,10 +86,10 @@ class TestWeibullPDF:
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
-        x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
+        x=arrays(np.float64, st.integers(1, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_pdf_properties(self, shape, loc, scale, x, dtype):
-        """Tests that the PDF is non-negative and has the correct return type and shape."""
+    def test_pdf_properties_for_array_input(self, shape, loc, scale, x, dtype):
+        """Tests that for an array input, the PDF returns a non-negative array with the correct type and shape."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         pdf_values = dist.pdf(x)
@@ -97,6 +97,17 @@ class TestWeibullPDF:
         assert pdf_values.dtype == dtype
         assert pdf_values.shape == x.shape
         assert np.all(pdf_values >= 0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_pdf_properties_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Tests that for a scalar input, the PDF returns a non-negative scalar with the correct type."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        pdf_value = dist.pdf(x)
+        assert np.isscalar(pdf_value)
+        assert isinstance(pdf_value, dtype)
+        assert pdf_value >= 0
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, shape, loc, scale, x):
@@ -135,14 +146,24 @@ class TestWeibullLPDF:
         scale=st_scale,
         x=arrays(np.float64, st.integers(0, 10), elements=st.floats(-1e6, 1e6)),
     )
-    def test_lpdf_return_type_and_shape(self, shape, loc, scale, x, dtype):
-        """Tests the return type and shape of the lpdf method."""
+    def test_lpdf_return_type_and_shape_for_array_input(self, shape, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for array input."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         lpdf_values = dist.lpdf(x)
         assert isinstance(lpdf_values, np.ndarray)
         assert lpdf_values.dtype == dtype
         assert lpdf_values.shape == x.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(-1e6, 1e6))
+    def test_lpdf_return_type_and_shape_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Tests the return type and shape of the lpdf method for scalar input."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        lpdf_value = dist.lpdf(x)
+        assert np.isscalar(lpdf_value)
+        assert isinstance(lpdf_value, dtype)
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_lpdf_against_scipy(self, shape, loc, scale, x):
@@ -173,14 +194,24 @@ class TestWeibullPPF:
         scale=st_scale,
         p=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)),
     )
-    def test_ppf_return_type_and_shape(self, shape, loc, scale, p, dtype):
-        """Tests the return type and shape of the ppf method."""
+    def test_ppf_return_type_and_shape_for_array_input(self, shape, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for array input."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
         ppf_values = dist.ppf(p)
         assert isinstance(ppf_values, np.ndarray)
         assert ppf_values.dtype == dtype
         assert ppf_values.shape == p.shape
+
+    @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, p=st.floats(0, 1, exclude_max=True))
+    def test_ppf_return_type_and_shape_for_scalar_input(self, shape, loc, scale, p, dtype):
+        """Tests the return type and shape of the ppf method for scalar input."""
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        ppf_value = dist.ppf(p)
+        assert np.isscalar(ppf_value)
+        assert isinstance(ppf_value, dtype)
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, p=st.floats(0.01, 1))
     def test_ppf_against_scipy(self, shape, loc, scale, p):
@@ -211,8 +242,8 @@ class TestWeibullGradients:
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_shape_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'shape' against a numerical approximation."""
+    def test_dlog_shape_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'shape' against a numerical approximation for array input."""
 
         assume(np.all(x > loc))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -227,14 +258,24 @@ class TestWeibullGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_shape_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'shape' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_shape(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_loc_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'loc' against a numerical approximation."""
+    def test_dlog_loc_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'loc' against a numerical approximation for array input."""
 
         assume(np.all(x > (loc + self.h)))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -249,14 +290,24 @@ class TestWeibullGradients:
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-4, rtol=1e-3)
 
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_loc_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'loc' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_loc(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
+
     @given(
         shape=st_shape,
         loc=st_loc,
         scale=st_scale,
         x=arrays(np.float64, st.integers(1, 10), elements=st.floats(1e-3, 1e3)),
     )
-    def test_dlog_scale_numerical(self, shape, loc, scale, x, dtype):
-        """Checks the analytical gradient for 'scale' against a numerical approximation."""
+    def test_dlog_scale_numerical_for_array_input(self, shape, loc, scale, x, dtype):
+        """Checks the analytical gradient for 'scale' against a numerical approximation for array input."""
 
         assume(np.all(x > loc))
         dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
@@ -270,6 +321,16 @@ class TestWeibullGradients:
             lpdf_minus_h = Weibull(shape=shape, loc=loc, scale=scale - self.h).lpdf(x)
             numerical_grad = (lpdf_plus_h - lpdf_minus_h) / (2 * self.h)
             np.testing.assert_allclose(analytical_grad, numerical_grad, atol=1e-3, rtol=1e-3)
+
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_dlog_scale_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the gradient for 'scale' for a scalar input returns a scalar."""
+
+        assume(x > loc)
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        analytical_grad = dist._dlog_scale(x)
+        assert np.isscalar(analytical_grad)
+        assert isinstance(analytical_grad, dtype)
 
     @pytest.mark.parametrize(
         "fixed_params, expected_cols, expected_params",
@@ -305,6 +366,18 @@ class TestWeibullGradients:
             np.testing.assert_allclose(gradients[:, sorted_params.index("scale")], dist._dlog_scale(x))
         if "shape" in expected_params:
             np.testing.assert_allclose(gradients[:, sorted_params.index("shape")], dist._dlog_shape(x))
+
+    @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-3, 1e3))
+    def test_log_gradients_for_scalar_input(self, shape, loc, scale, x, dtype):
+        """Checks that the log_gradients for a scalar input returns a 1D-array."""
+
+        assume(x > loc)
+
+        dist = Weibull(shape=shape, loc=loc, scale=scale, dtype=dtype)
+        gradients = dist.log_gradients(x)
+        assert isinstance(gradients, np.ndarray)
+        assert gradients.dtype == dtype
+        assert gradients.ndim == 1
 
 
 @pytest.mark.parametrize("dtype", DTYPES_TO_TEST)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -6,7 +6,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
-from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -14,7 +13,6 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Weibull
-from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.special import gamma
 from scipy.stats import kstest, weibull_min
@@ -372,30 +370,3 @@ class TestWeibullGenerate:
         ks_statistic, p_value = kstest(samples, "weibull_min", args=(shape, loc, scale))
         expected_p_value = 0.05
         assert p_value > expected_p_value
-
-
-@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
-class TestWeibullDType(DTypeHandlingMixin):
-    distribution_class = Weibull
-    default_params: ClassVar[dict] = {"shape": 2.0, "loc": 0.0, "scale": 1.0}
-
-    def test_init_with_dtype_sets_correct_types(self, dtype):
-        self.check_init_with_dtype_sets_correct_types(dtype)
-
-    @pytest.mark.parametrize("size", [0, 10])
-    def test_generate_returns_correct_dtype(self, size, dtype):
-        self.check_generate_returns_correct_dtype(size, dtype)
-
-    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
-    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
-        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
-
-    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
-    def check_ppf_returns_correct_dtype(self, p_data, dtype):
-        self.check_ppf_returns_correct_dtype(p_data, dtype)
-
-    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_loc", "_dlog_scale"])
-    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
-    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
-        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/distributions/test_weibull.py
+++ b/rework_tests/unit/distributions/test_weibull.py
@@ -6,6 +6,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 import random
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -13,9 +14,12 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from rework_pysatl_mpest.distributions import Weibull
+from rework_tests.unit.distributions.test_continuous_distribution import DTypeHandlingMixin
 from scipy.integrate import quad
 from scipy.special import gamma
 from scipy.stats import kstest, weibull_min
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # Strategies for generating valid Weibull parameters
 st_shape = st.floats(min_value=0.5, max_value=10, allow_nan=False, allow_infinity=False)
@@ -96,6 +100,7 @@ class TestWeibullPDF:
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(1e-6, 1e6))
     def test_pdf_against_scipy(self, shape, loc, scale, x):
         """Compares the custom PDF implementation against scipy's implementation."""
+        assume(x > loc)
 
         dist = Weibull(shape=shape, loc=loc, scale=scale)
         custom_pdf = dist.pdf(x)
@@ -107,7 +112,7 @@ class TestWeibullPDF:
         """Tests that the integral of the PDF over its support is equal to 1."""
 
         dist = Weibull(shape=shape, loc=loc, scale=scale)
-        integral, error = quad(dist.pdf, loc, np.inf)
+        integral, error = quad(lambda x: dist.pdf(x).item(), loc, np.inf)
         np.testing.assert_allclose(1.0, integral, atol=1e-6)
 
     @given(shape=st_shape, loc=st_loc, scale=st_scale, x=st.floats(max_value=-1e6, allow_infinity=False))
@@ -335,3 +340,30 @@ class TestWeibullGenerate:
         # args for scipy's weibull_min are (shape, loc, scale)
         ks_statistic, p_value = kstest(samples, "weibull_min", args=(shape, loc, scale))
         assert p_value > expected_p_value
+
+
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+class TestWeibullDType(DTypeHandlingMixin):
+    distribution_class = Weibull
+    default_params: ClassVar[dict] = {"shape": 2.0, "loc": 0.0, "scale": 1.0}
+
+    def test_init_with_dtype_sets_correct_types(self, dtype):
+        self.check_init_with_dtype_sets_correct_types(dtype)
+
+    @pytest.mark.parametrize("size", [0, 10])
+    def test_generate_returns_correct_dtype(self, size, dtype):
+        self.check_generate_returns_correct_dtype(size, dtype)
+
+    @pytest.mark.parametrize("method_name", ["pdf", "lpdf", "log_gradients"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e3)))
+    def check_methods_taking_x_return_correct_dtype(self, method_name, x_data, dtype):
+        self.check_methods_taking_x_return_correct_dtype(method_name, x_data, dtype)
+
+    @given(p_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1, exclude_max=True)))
+    def check_ppf_returns_correct_dtype(self, p_data, dtype):
+        self.check_ppf_returns_correct_dtype(p_data, dtype)
+
+    @pytest.mark.parametrize("method_name", ["_dlog_shape", "_dlog_loc", "_dlog_scale"])
+    @given(x_data=arrays(np.float64, st.integers(0, 10), elements=st.floats(0, 1e6)))
+    def test_dlog_methods_returns_correct_dtype(self, x_data, method_name, dtype):
+        self.check_dlog_methods_returns_correct_dtype(x_data, method_name, dtype)

--- a/rework_tests/unit/estimators/iterative/_strategies/moments/test_exponential_moments.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/moments/test_exponential_moments.py
@@ -1,0 +1,260 @@
+"""Tests for Moments optimization strategy for Exponential distribution"""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from rework_pysatl_mpest.distributions import Exponential
+from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
+from rework_pysatl_mpest.estimators.iterative._strategies import moments_strategy
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
+# Test Fixtures
+# -------------
+
+
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_exponential_setup(request) -> tuple[Exponential, PipelineState, np.floating]:
+    """
+    Creates a parametrized fixture providing an Exponential component and a
+    corresponding PipelineState for various dtypes.
+    """
+    dtype = request.param
+
+    component = Exponential(loc=0.0, rate=1.0, dtype=dtype)
+
+    state = PipelineState(
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
+        prev_mixture=None,
+        curr_mixture=None,
+        error=None,
+    )
+    return component, state, dtype
+
+
+# Tests
+# -----
+
+
+def test_moments_exponential_raises_value_error_if_h_is_none(parametrized_exponential_setup):
+    """
+    Verifies that a ValueError is raised if the responsibility
+    matrix H in the pipeline state has not been computed.
+    """
+    exponential_component, state, _ = parametrized_exponential_setup
+    state.H = None
+
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.MOMENTS
+    )
+
+    with pytest.raises(ValueError, match="Responsibility matrix H is not computed."):
+        moments_strategy(exponential_component, state, block, optimizer=None)
+
+
+def test_moments_exponential_returns_correct_types(parametrized_exponential_setup):
+    """
+    Verifies that the function returns a tuple with the correct
+    data types (int, dict[str, DType]).
+    """
+    exponential_component, pipeline_state, dtype = parametrized_exponential_setup
+
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.MOMENTS
+    )
+
+    result = moments_strategy(exponential_component, pipeline_state, block, optimizer=None)
+
+    assert isinstance(result, tuple)
+    assert isinstance(result[0], int)
+    assert isinstance(result[1], dict)
+
+    if result[1]:
+        key, value = next(iter(result[1].items()))
+        assert isinstance(key, str)
+        assert isinstance(value, dtype)
+
+
+@pytest.mark.parametrize(
+    "params_to_optimize_in_block, fixed_params_on_component, expected_keys",
+    [
+        ({"loc", "rate"}, set(), {"loc", "rate"}),  # Optimize both, none are fixed
+        ({"loc"}, set(), {"loc"}),  # Optimize only loc
+        ({"rate"}, set(), {"rate"}),  # Optimize only rate
+        ({"loc", "rate"}, {"loc"}, {"rate"}),  # Optimize both, but loc is fixed
+        ({"loc", "rate"}, {"rate"}, {"loc"}),  # Optimize both, but rate is fixed
+        ({"loc", "rate"}, {"loc", "rate"}, set()),  # Optimize both, but both are fixed
+        ({"non_existent_param", "loc"}, set(), {"loc"}),  # Ignore non-existent params
+        (set(), set(), set()),  # Optimize nothing
+    ],
+)
+def test_moments_exponential_respects_fixed_and_optimizable_params(
+    parametrized_exponential_setup, params_to_optimize_in_block, fixed_params_on_component, expected_keys
+):
+    """
+    Verifies that the strategy correctly identifies which parameters
+    to update based on the optimization block and the component's fixed parameters.
+    """
+    exponential_component, pipeline_state, _ = parametrized_exponential_setup
+
+    for param in fixed_params_on_component:
+        exponential_component.fix_param(param)
+
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize=params_to_optimize_in_block,
+        maximization_strategy=MaximizationStrategy.MOMENTS,
+    )
+
+    _, new_params = moments_strategy(exponential_component, pipeline_state, block, optimizer=None)
+
+    assert set(new_params.keys()) == expected_keys
+
+
+def test_moments_exponential_handles_negligible_responsibility(parametrized_exponential_setup):
+    """
+    Verifies that if a component's total responsibility (N_j) is near zero,
+    its parameters are not updated.
+    """
+
+    exponential_component, pipeline_state, dtype = parametrized_exponential_setup
+
+    pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize={"loc", "rate"},
+        maximization_strategy=MaximizationStrategy.MOMENTS,
+    )
+
+    _, new_params = moments_strategy(exponential_component, pipeline_state, block, optimizer=None)
+
+    assert new_params == {}
+
+
+def test_moments_exponential_rate_fallback_when_mean_equals_loc(parametrized_exponential_setup):
+    """
+    Tests the edge case where the weighted mean of the data equals the component's location.
+
+    In the formula `rate = 1 / (mean - loc)`, if `mean == loc`, a division by zero would occur.
+    The code should handle this by keeping the component's original rate.
+    """
+    component, state, dtype = parametrized_exponential_setup
+
+    loc_val = component.loc
+    state.X = np.array([loc_val, loc_val], dtype=dtype)
+    state.H = np.array([[1.0], [1.0]], dtype=dtype)
+
+    component.fix_param("loc")
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"rate"}, maximization_strategy=MaximizationStrategy.MOMENTS
+    )
+
+    _, new_params = moments_strategy(component, state, block, optimizer=None)
+
+    assert Exponential.PARAM_RATE in new_params
+    assert new_params[Exponential.PARAM_RATE] == component.rate
+
+
+@pytest.mark.parametrize(
+    "x_val,",
+    [
+        # Case 1: Overflow during first moment calculation (weighted_sum_X)
+        40000.0,
+        # Case 2: Overflow ONLY during second moment calculation (weighted_sum_X2)
+        300.0,
+    ],
+    ids=["overflow_first_moment", "overflow_second_moment"],
+)
+def test_moments_exponential_overflow_handling(parametrized_exponential_setup, x_val):
+    """
+    Verifies that NumericalStabilityError is correctly set in state
+    upon overflow in either the first moment or the second moment calculation.
+    """
+    component, state, _ = parametrized_exponential_setup
+
+    # --- Arrange ---
+    # Use float16, which has a small range, and large values to force an overflow.
+    # The max value for float16 is ~65504. The sum of X will exceed this.
+    dtype = np.float16
+    component = Exponential(loc=0.0, rate=1.0, dtype=dtype)
+    X = np.array([x_val, x_val], dtype=dtype)
+    H = np.array([[1.0], [1.0]], dtype=dtype)
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.MOMENTS
+    )
+    state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
+
+    _, new_params = moments_strategy(component, state, block, optimizer=None)
+
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+    assert "Overflow detected during Moments optimization" in str(state.error)
+    assert new_params == {}
+
+
+# Property-Based Test with Hypothesis
+# -----------------------------------
+
+
+@st.composite
+def exponential_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float64])):
+    """
+    Generates a true Exponential component and a data sample from it,
+    all configured with a specific dtype.
+    """
+    dtype = draw(dtype_strategy)
+
+    true_loc = draw(st.floats(min_value=-100, max_value=100))
+    true_rate = draw(st.floats(min_value=0.1, max_value=100))
+    true_component = Exponential(loc=true_loc, rate=true_rate, dtype=dtype)
+
+    # 2. Generate a data sample from this distribution
+    sample_size = draw(st.integers(min_value=10000, max_value=10000))
+    X = true_component.generate(size=sample_size).astype(dtype)
+
+    return X, dtype(true_loc), dtype(true_rate), dtype
+
+
+@settings(max_examples=50)
+@given(data=exponential_data_and_true_params())
+def test_moments_exponential_recovers_true_params_on_ideal_data(data):
+    """
+    Scenario 3 (Statistical Sanity Check): Verifies that the analytical formulas
+    can recover the original parameters from a sample when responsibilities are 1.0.
+    This confirms the statistical validity of the implemented formulas in an ideal case.
+    """
+    # --- Arrange ---
+    X, true_loc, true_rate, dtype = data
+
+    # This is the key assumption for this test: perfect knowledge that all
+    # data points belong to our component of interest.
+    H_j = np.ones_like(X, dtype=dtype)
+    H = np.vstack([H_j, np.zeros_like(H_j)]).T  # Simulate a 2-component mixture
+
+    # Use a starting component with completely different parameters
+    start_component = Exponential(loc=-999.0, rate=0.001, dtype=dtype)
+
+    state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.MOMENTS
+    )
+
+    _, new_params = moments_strategy(start_component, state, block, optimizer=None)
+
+    # The estimated parameters won't be exactly the same due to sampling noise,
+    # so we use pytest.approx with a relative tolerance.
+    # For a large enough sample, the estimates should be reasonably close.
+    assert new_params[Exponential.PARAM_LOC] == pytest.approx(true_loc, abs=0.2)
+    assert new_params[Exponential.PARAM_RATE] == pytest.approx(true_rate, rel=0.1)
+
+    # Verify that the returned parameters have the correct dtype.
+    assert isinstance(new_params[Exponential.PARAM_LOC], dtype)
+    assert isinstance(new_params[Exponential.PARAM_RATE], dtype)

--- a/rework_tests/unit/estimators/iterative/_strategies/moments/test_generalized_moments.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/moments/test_generalized_moments.py
@@ -69,7 +69,7 @@ def test_moments_strategy_base_implementation_raises_not_implemented():
     mock_block = Mock(spec=OptimizationBlock)
     mock_optimizer = Mock(spec=Optimizer)
 
-    expected_error_msg = "Moments strategy is not implemented for distribution 'DummyDistribution'."
+    expected_error_msg = "Moments strategy is not implemented for distribution 'Dummy'."
 
     # Act & Assert
     with pytest.raises(NotImplementedError, match=expected_error_msg):

--- a/rework_tests/unit/estimators/iterative/_strategies/moments/test_generalized_moments.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/moments/test_generalized_moments.py
@@ -1,0 +1,76 @@
+"""Tests for the base implementation of the Moments strategy."""
+
+__author__ = "Aleksandra Ri"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from rework_pysatl_mpest.core import Parameter
+from rework_pysatl_mpest.distributions import ContinuousDistribution
+from rework_pysatl_mpest.estimators.iterative import OptimizationBlock, PipelineState
+from rework_pysatl_mpest.estimators.iterative._strategies import moments_strategy
+from rework_pysatl_mpest.optimizers import Optimizer
+
+
+class DummyDistribution(ContinuousDistribution):
+    """
+    A simple dummy implementation of ContinuousDistribution for testing purposes.
+    It has two parameters: 'param1' and 'param2'.
+    """
+
+    param1 = Parameter()
+    param2 = Parameter()
+
+    def __init__(self, param1: float, param2: float, dtype: np.floating = np.float64):
+        super().__init__(dtype=dtype)
+        self.param1 = param1
+        self.param2 = param2
+
+    @property
+    def name(self) -> str:
+        return "Dummy"
+
+    @property
+    def params(self) -> set[str]:
+        return {"param1", "param2"}
+
+    def pdf(self, X):
+        return np.array([])
+
+    def ppf(self, P):
+        return np.array([])
+
+    def lpdf(self, X):
+        return np.log(np.array([0.5] * len(X), dtype=self.dtype))
+
+    def log_gradients(self, X):
+        return np.array([])
+
+    def generate(self, size: int):
+        return np.array([])
+
+
+def test_moments_strategy_base_implementation_raises_not_implemented():
+    """
+    Verifies that the base implementation of `moments_strategy` (via singledispatch)
+    raises a NotImplementedError when called with a distribution that has no
+    specifically registered implementation.
+    """
+
+    # Arrange
+    dist = DummyDistribution(param1=1.0, param2=2.0)
+
+    # Mocks for arguments that are not used before the error is raised
+    mock_state = Mock(spec=PipelineState)
+    mock_block = Mock(spec=OptimizationBlock)
+    mock_optimizer = Mock(spec=Optimizer)
+
+    expected_error_msg = "Moments strategy is not implemented for distribution 'DummyDistribution'."
+
+    # Act & Assert
+    with pytest.raises(NotImplementedError, match=expected_error_msg):
+        moments_strategy(dist, mock_state, mock_block, mock_optimizer)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
@@ -83,6 +83,61 @@ def test_q_function_exponential_returns_correct_types(parametrized_exponential_s
         assert isinstance(value, dtype)
 
 
+def test_q_function_exponential_denominator_zero_rate_update(parametrized_exponential_setup):
+    """
+    Tests the branch where weighted average matches location (denominator ~ 0)
+    in rate update logic.
+    """
+    component, state, dtype = parametrized_exponential_setup
+
+    # X = 2.0, loc = 2.0 -> X - loc = 0.
+    state.X = np.array([2.0], dtype=dtype)
+    state.H = np.array([[1.0, 0.0]], dtype=dtype)  # 1 sample
+
+    component.loc = dtype(2.0)
+    component.rate = dtype(5.0)
+
+    component.fix_param("loc")
+
+    block = OptimizationBlock(0, {"rate"}, MaximizationStrategy.QFUNCTION)
+
+    _, new_params = q_function_strategy(component, state, block, optimizer=None)
+
+    # Should keep original rate to avoid division by zero
+    assert Exponential.PARAM_RATE in new_params
+    assert new_params["rate"] == component.rate
+
+
+def test_exponential_loc_fallback_low_individual_weights():
+    """
+    Tests the fallback branch for Exponential 'loc' (Line 155) where
+    individual weights are below tolerance (so relevant_X is empty),
+    but their sum is significant enough to bypass the early exit check.
+    """
+    dtype = np.float64
+    tolerance = 1e-9
+
+    # Create weights slightly below tolerance
+    weight_val = 0.5 * tolerance  # 0.5e-9
+
+    # Create enough samples so their sum is > tolerance
+    # 10 * 0.5e-9 = 5e-9 > 1e-9
+    n_samples = 10
+    X = np.arange(n_samples, dtype=dtype)
+    H = np.full((n_samples, 2), weight_val, dtype=dtype)
+
+    comp = Exponential(loc=5.0, rate=1.0, dtype=dtype)
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"loc"}, maximization_strategy=MaximizationStrategy.QFUNCTION
+    )
+
+    _, new_params = q_function_strategy(comp, state, block, optimizer=None)
+
+    assert Exponential.PARAM_LOC in new_params
+    assert new_params[Exponential.PARAM_LOC] == comp.loc
+
+
 @pytest.mark.parametrize(
     "params_to_optimize_in_block, fixed_params_on_component, expected_keys",
     [
@@ -125,16 +180,16 @@ def test_q_function_exponential_handles_negligible_responsibility(parametrized_e
     its parameters are not updated.
     """
 
-    normal_component, pipeline_state, dtype = parametrized_exponential_setup
+    exponential_component, pipeline_state, dtype = parametrized_exponential_setup
 
     pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
     block = OptimizationBlock(
         component_id=0,
-        params_to_optimize={"shape", "loc", "scale"},
+        params_to_optimize={"loc", "rate"},
         maximization_strategy=MaximizationStrategy.QFUNCTION,
     )
 
-    _, new_params = q_function_strategy(normal_component, pipeline_state, block, optimizer=None)
+    _, new_params = q_function_strategy(exponential_component, pipeline_state, block, optimizer=None)
 
     assert new_params == {}
 
@@ -161,6 +216,8 @@ def test_q_function_exponential_handles_numerical_overflow():
 
     assert state.error is not None
     assert isinstance(state.error, NumericalStabilityError)
+    assert "Overflow detected during Q-function optimization" in str(state.error)
+    assert new_params == {}
 
 
 # Property-Based Test with Hypothesis

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
@@ -238,7 +238,7 @@ def exponential_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.fl
 
     # 2. Generate a data sample from this distribution
     sample_size = draw(st.integers(min_value=10000, max_value=10000))
-    X = true_component.generate(size=sample_size).astype(dtype)
+    X = true_component.generate(size=sample_size)
 
     return (X, dtype(true_loc), dtype(true_rate), dtype)
 

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
@@ -1,6 +1,6 @@
 """Tests for Q-function optimization strategy for Exponential distribution"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -12,41 +12,46 @@ from hypothesis import strategies as st
 from rework_pysatl_mpest.distributions import Exponential
 from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from rework_pysatl_mpest.estimators.iterative._strategies import q_function_strategy
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # Test Fixtures
 # -------------
 
 
-@pytest.fixture
-def exponential_component() -> Exponential:
-    """Fixture that creates a default Exponential component."""
-    return Exponential(loc=0.0, rate=1.0)
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_exponential_setup(request) -> tuple[Exponential, PipelineState, np.floating]:
+    """
+    Creates a parametrized fixture providing an Exponential component and a
+    corresponding PipelineState for various dtypes.
+    """
+    dtype = request.param
 
+    component = Exponential(loc=0.0, rate=1.0, dtype=dtype)
 
-@pytest.fixture
-def pipeline_state() -> PipelineState:
-    """Fixture that creates a basic PipelineState with some data."""
     state = PipelineState(
-        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]]),
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
         prev_mixture=None,
         curr_mixture=None,
         error=None,
     )
-    return state
+    return component, state, dtype
 
 
 # Tests
 # -----
 
 
-def test_q_function_exponential_raises_value_error_if_h_is_none(exponential_component):
+def test_q_function_exponential_raises_value_error_if_h_is_none(parametrized_exponential_setup):
     """
     Verifies that a ValueError is raised if the responsibility
     matrix H in the pipeline state has not been computed.
     """
+    exponential_component, state, _ = parametrized_exponential_setup
+    state.H = None
 
-    state = PipelineState(X=np.array([1, 2, 3]), H=None, curr_mixture=None, prev_mixture=None, error=None)
     block = OptimizationBlock(
         component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.QFUNCTION
     )
@@ -55,11 +60,12 @@ def test_q_function_exponential_raises_value_error_if_h_is_none(exponential_comp
         q_function_strategy(exponential_component, state, block, optimizer=None)
 
 
-def test_q_function_exponential_returns_correct_types(exponential_component, pipeline_state):
+def test_q_function_exponential_returns_correct_types(parametrized_exponential_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, float]).
+    data types (int, dict[str, DType]).
     """
+    exponential_component, pipeline_state, dtype = parametrized_exponential_setup
 
     block = OptimizationBlock(
         component_id=0, params_to_optimize={"loc", "rate"}, maximization_strategy=MaximizationStrategy.QFUNCTION
@@ -74,7 +80,7 @@ def test_q_function_exponential_returns_correct_types(exponential_component, pip
     if result[1]:
         key, value = next(iter(result[1].items()))
         assert isinstance(key, str)
-        assert isinstance(value, float)
+        assert isinstance(value, dtype)
 
 
 @pytest.mark.parametrize(
@@ -91,12 +97,13 @@ def test_q_function_exponential_returns_correct_types(exponential_component, pip
     ],
 )
 def test_q_function_exponential_respects_fixed_and_optimizable_params(
-    exponential_component, pipeline_state, params_to_optimize_in_block, fixed_params_on_component, expected_keys
+    parametrized_exponential_setup, params_to_optimize_in_block, fixed_params_on_component, expected_keys
 ):
     """
     Verifies that the strategy correctly identifies which parameters
     to update based on the optimization block and the component's fixed parameters.
     """
+    exponential_component, pipeline_state, _ = parametrized_exponential_setup
 
     for param in fixed_params_on_component:
         exponential_component.fix_param(param)
@@ -112,23 +119,71 @@ def test_q_function_exponential_respects_fixed_and_optimizable_params(
     assert set(new_params.keys()) == expected_keys
 
 
+def test_q_function_exponential_handles_negligible_responsibility(parametrized_exponential_setup):
+    """
+    Verifies that if a component's total responsibility (N_j) is near zero,
+    its parameters are not updated.
+    """
+
+    normal_component, pipeline_state, dtype = parametrized_exponential_setup
+
+    pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize={"shape", "loc", "scale"},
+        maximization_strategy=MaximizationStrategy.QFUNCTION,
+    )
+
+    _, new_params = q_function_strategy(normal_component, pipeline_state, block, optimizer=None)
+
+    assert new_params == {}
+
+
+def test_q_function_exponential_handles_numerical_overflow():
+    """
+    Verifies that if a numerical overflow occurs during calculations,
+    a `NumericalStabilityError` is correctly registered in the pipeline state.
+    """
+    # --- Arrange ---
+    # Use float16, which has a small range, and large values to force an overflow.
+    # The max value for float16 is ~65504. The sum of X will exceed this.
+    dtype = np.float16
+    component = Exponential(loc=0.0, rate=1.0, dtype=dtype)
+    X = np.array([60000, 60000], dtype=dtype)
+    H_j = np.array([1.0, 1.0], dtype=dtype)
+    H = np.vstack([H_j, np.zeros_like(H_j)]).T
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"rate"}, maximization_strategy=MaximizationStrategy.QFUNCTION
+    )
+    state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
+
+    _, new_params = q_function_strategy(component, state, block, optimizer=None)
+
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+
+
 # Property-Based Test with Hypothesis
 # -----------------------------------
 
 
 @st.composite
-def exponential_data_and_true_params(draw):
-    """Generates a true component, and a data sample from it."""
-    # 1. Generate realistic parameters for the true distribution
+def exponential_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float32, np.float64])):
+    """
+    Generates a true Exponential component and a data sample from it,
+    all configured with a specific dtype.
+    """
+    dtype = draw(dtype_strategy)
+
     true_loc = draw(st.floats(min_value=-100, max_value=100))
     true_rate = draw(st.floats(min_value=0.1, max_value=100))
-    true_component = Exponential(loc=true_loc, rate=true_rate)
+    true_component = Exponential(loc=true_loc, rate=true_rate, dtype=dtype)
 
     # 2. Generate a data sample from this distribution
     sample_size = draw(st.integers(min_value=10000, max_value=10000))
-    X = true_component.generate(size=sample_size)
+    X = true_component.generate(size=sample_size).astype(dtype)
 
-    return (X, true_loc, true_rate)
+    return (X, dtype(true_loc), dtype(true_rate), dtype)
 
 
 @settings(max_examples=50)
@@ -140,15 +195,15 @@ def test_q_function_exponential_recovers_true_params_on_ideal_data(data):
     This confirms the statistical validity of the implemented formulas in an ideal case.
     """
     # --- Arrange ---
-    X, true_loc, true_rate = data
+    X, true_loc, true_rate, dtype = data
 
     # This is the key assumption for this test: perfect knowledge that all
     # data points belong to our component of interest.
-    H_j = np.ones_like(X)
+    H_j = np.ones_like(X, dtype=dtype)
     H = np.vstack([H_j, np.zeros_like(H_j)]).T  # Simulate a 2-component mixture
 
     # Use a starting component with completely different parameters
-    start_component = Exponential(loc=-999.0, rate=0.001)
+    start_component = Exponential(loc=-999.0, rate=0.001, dtype=dtype)
 
     state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
     block = OptimizationBlock(
@@ -160,5 +215,9 @@ def test_q_function_exponential_recovers_true_params_on_ideal_data(data):
     # The estimated parameters won't be exactly the same due to sampling noise,
     # so we use pytest.approx with a relative tolerance.
     # For a large enough sample, the estimates should be reasonably close.
-    assert new_params[Exponential.PARAM_LOC] == pytest.approx(true_loc, abs=0.01)
-    assert new_params[Exponential.PARAM_RATE] == pytest.approx(true_rate, rel=0.01)
+    assert new_params[Exponential.PARAM_LOC] == pytest.approx(true_loc, abs=0.05)
+    assert new_params[Exponential.PARAM_RATE] == pytest.approx(true_rate, rel=0.05)
+
+    # Verify that the returned parameters have the correct dtype.
+    assert isinstance(new_params[Exponential.PARAM_LOC], dtype)
+    assert isinstance(new_params[Exponential.PARAM_RATE], dtype)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_generalized_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_generalized_q_function.py
@@ -13,7 +13,10 @@ from rework_pysatl_mpest.core import MixtureModel, Parameter
 from rework_pysatl_mpest.distributions import ContinuousDistribution
 from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from rework_pysatl_mpest.estimators.iterative._strategies import q_function_strategy
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
 from rework_pysatl_mpest.optimizers import Optimizer
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # Helper classes for test isolation
 # ---------------------------------
@@ -48,7 +51,7 @@ class DummyDistribution(ContinuousDistribution):
         return np.array([])
 
     def lpdf(self, X):
-        return np.log(np.array([0.5] * len(X)))
+        return np.log(np.array([0.5] * len(X), dtype=self.dtype))
 
     def log_gradients(self, X):
         return np.array([])
@@ -65,71 +68,50 @@ class DummyDistribution(ContinuousDistribution):
 # --- Test Fixtures ---
 
 
-@pytest.fixture
-def mock_component() -> DummyDistribution:
-    """Fixture that creates an instance of DummyDistribution."""
-
-    return DummyDistribution(param1=1.0, param2=2.0)
-
-
-@pytest.fixture
-def mock_mixture(mocker, mock_component) -> MixtureModel:
-    """Fixture that creates a mock MixtureModel."""
-
-    mixture = mocker.create_autospec(MixtureModel, instance=True)
-    mixture.components = (mock_component,)  # Make the component accessible
-    return mixture
-
-
-@pytest.fixture
-def pipeline_state(mock_mixture) -> PipelineState:
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_setup(
+    mocker, request
+) -> tuple[ContinuousDistribution, PipelineState, OptimizationBlock, OptimizationBlock, np.floating]:
     """
     Fixture that creates a more complete PipelineState with data.
     """
+    dtype = request.param
+
+    component = DummyDistribution(param1=1.0, param2=2.0, dtype=dtype)
+
+    mock_mixture = mocker.create_autospec(MixtureModel, instance=True)
+    mock_mixture.components = (component,)
 
     state = PipelineState(
-        X=np.array([10.0, 20.0, 30.0]),
-        H=np.array([[0.8, 0.2], [0.7, 0.3], [0.6, 0.4]]),
+        X=np.array([10.0, 20.0, 30.0], dtype=dtype),
+        H=np.array([[0.8, 0.2], [0.7, 0.3], [0.6, 0.4]], dtype=dtype),
         prev_mixture=None,
         curr_mixture=mock_mixture,
         error=None,
     )
-    return state
-
-
-@pytest.fixture
-def optimization_block() -> OptimizationBlock:
-    """
-    Fixture that creates a more complete optimization block for the component with ID=0.
-    """
-
-    return OptimizationBlock(
+    block = OptimizationBlock(
         component_id=0, params_to_optimize={"param1", "param2"}, maximization_strategy=MaximizationStrategy.QFUNCTION
     )
 
-
-@pytest.fixture
-def mock_optimizer(mocker) -> Optimizer:
-    """Fixture that creates a mock Optimizer object."""
-
     optimizer = mocker.create_autospec(Optimizer, instance=True)
-    return optimizer
+    optimizer.minimize.return_value = [dtype(99.0), dtype(101.0)]
+
+    return component, state, block, optimizer, dtype
 
 
 # Tests
 # -----
 
 
-def test_q_function_strategy_does_not_modify_original_component(
-    mock_component, pipeline_state, optimization_block, mock_optimizer
-):
+def test_q_function_strategy_does_not_modify_original_component(parametrized_setup):
     """
     Verifies that the original component object is not modified,
     as the function should work with its copy.
     """
 
+    mock_component, pipeline_state, optimization_block, mock_optimizer, dtype = parametrized_setup
+
     original_component = copy(mock_component)
-    mock_optimizer.minimize.return_value = [99.0, 101.0]
 
     q_function_strategy(mock_component, pipeline_state, optimization_block, mock_optimizer)
 
@@ -137,26 +119,22 @@ def test_q_function_strategy_does_not_modify_original_component(
     assert mock_component.param2 == original_component.param2, "param2 should not have been changed"
 
 
-def test_q_function_strategy_calls_optimizer_minimize_once(
-    mock_component, pipeline_state, optimization_block, mock_optimizer
-):
+def test_q_function_strategy_calls_optimizer_minimize_once(parametrized_setup):
     """
     Verifies that the optimizer's minimize method is called exactly once.
     """
+    mock_component, pipeline_state, optimization_block, mock_optimizer, dtype = parametrized_setup
 
-    mock_optimizer.minimize.return_value = [5.0, 10.0]
     q_function_strategy(mock_component, pipeline_state, optimization_block, mock_optimizer)
     mock_optimizer.minimize.assert_called_once()
 
 
-def test_q_function_strategy_returns_correct_types(mock_component, pipeline_state, optimization_block, mock_optimizer):
+def test_q_function_strategy_returns_correct_types(parametrized_setup):
     """
     Verifies that the function returns a tuple with the correct
     data types (int, dict[str, float]).
     """
-
-    mock_optimizer.minimize.return_value = [5.0, 10.0]
-
+    mock_component, pipeline_state, optimization_block, mock_optimizer, dtype = parametrized_setup
     result = q_function_strategy(mock_component, pipeline_state, optimization_block, mock_optimizer)
 
     assert isinstance(result, tuple)
@@ -166,17 +144,16 @@ def test_q_function_strategy_returns_correct_types(mock_component, pipeline_stat
     if result[1]:
         key, value = next(iter(result[1].items()))
         assert isinstance(key, str)
-        assert isinstance(value, float)
+        assert isinstance(value, dtype)
 
 
-def test_q_function_strategy_raises_value_error_if_h_is_none(
-    mock_component, pipeline_state, optimization_block, mock_optimizer
-):
+def test_q_function_strategy_raises_value_error_if_h_is_none(parametrized_setup):
     """
     Verifies that a ValueError is raised if the responsibility
     matrix H in the pipeline state has not been computed (is None).
     """
 
+    mock_component, pipeline_state, optimization_block, mock_optimizer, _ = parametrized_setup
     pipeline_state.H = None
 
     with pytest.raises(ValueError, match="Responsibility matrix H is not computed."):
@@ -193,7 +170,7 @@ def test_q_function_strategy_raises_value_error_if_h_is_none(
     ],
 )
 def test_q_function_strategy_correctness_and_interaction(
-    mock_component, pipeline_state, mock_optimizer, params_to_optimize_in_block, expected_optimized_params_keys
+    parametrized_setup, params_to_optimize_in_block, expected_optimized_params_keys
 ):
     """
     Comprehensive test for correctness and interaction.
@@ -202,6 +179,8 @@ def test_q_function_strategy_correctness_and_interaction(
     - The optimizer is called with the correct initial values.
     - The target function logic works as expected (returns -q_function).
     """
+
+    mock_component, pipeline_state, optimization_block, mock_optimizer, dtype = parametrized_setup
 
     component_id = 0
     block = OptimizationBlock(
@@ -212,7 +191,7 @@ def test_q_function_strategy_correctness_and_interaction(
 
     # Simulate the return value from the optimizer.
     num_params_to_optimize = len(expected_optimized_params_keys)
-    mocked_new_params_vector = [p * 10.0 for p in range(1, num_params_to_optimize + 1)]
+    mocked_new_params_vector = [dtype(p * 10.0) for p in range(1, num_params_to_optimize + 1)]
     mock_optimizer.minimize.return_value = mocked_new_params_vector
 
     sorted_keys = sorted(list(expected_optimized_params_keys))
@@ -244,17 +223,18 @@ def test_q_function_strategy_correctness_and_interaction(
     assert target_func(test_vector) == -expected_q_value
 
 
-def test_q_function_strategy_respects_fixed_params(mock_component, pipeline_state, optimization_block, mock_optimizer):
+def test_q_function_strategy_respects_fixed_params(parametrized_setup):
     """
     Verifies that 'fixed' parameters are not passed to the
     optimizer, even if they are specified in the optimization_block.
     """
+    mock_component, pipeline_state, optimization_block, mock_optimizer, dtype = parametrized_setup
 
     # Fix 'param1', it should not be optimized
     mock_component.fix_param("param1")
 
     # The optimizer should return a value only for 'param2'
-    new_param2_value = 99.0
+    new_param2_value = dtype(99.0)
     mock_optimizer.minimize.return_value = [new_param2_value]
 
     _, new_params_dict = q_function_strategy(mock_component, pipeline_state, optimization_block, mock_optimizer)
@@ -269,3 +249,38 @@ def test_q_function_strategy_respects_fixed_params(mock_component, pipeline_stat
     _, initial_vector = args
     assert len(initial_vector) == 1
     assert initial_vector[0] == mock_component.param2
+
+
+def test_q_function_strategy_handles_numerical_overflow():
+    """
+    Verifies that the generic strategy correctly registers an error
+    when a numerical overflow occurs within the target function.
+    """
+    # --- Arrange ---
+    dtype = np.float16
+
+    class OverflowDistribution(DummyDistribution):
+        def lpdf(self, X):
+            return np.array([-40000, -40000], dtype=self.dtype)
+
+    component = OverflowDistribution(1.0, 2.0, dtype=dtype)
+    state = PipelineState(
+        X=np.array([1, 2], dtype=dtype),
+        H=np.array([[1.0, 0.0], [1.0, 0.0]], dtype=dtype),
+        curr_mixture=None,
+        prev_mixture=None,
+        error=None,
+    )
+    block = OptimizationBlock(0, {"param1", "param2"}, MaximizationStrategy.QFUNCTION)
+
+    class MockOptimizer(Optimizer):
+        def minimize(self, target, initial_vector):
+            target(initial_vector)
+            return initial_vector
+
+    # --- Act ---
+    q_function_strategy(component, state, block, MockOptimizer())
+
+    # --- Assert ---
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_generalized_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_generalized_q_function.py
@@ -28,8 +28,8 @@ class DummyDistribution(ContinuousDistribution):
     param1 = Parameter()
     param2 = Parameter()
 
-    def __init__(self, param1: float, param2: float):
-        super().__init__()
+    def __init__(self, param1: float, param2: float, dtype: np.floating = np.float64):
+        super().__init__(dtype=dtype)
         self.param1 = param1
         self.param2 = param2
 

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
@@ -1,6 +1,6 @@
 """Tests for Q-function optimization strategy for Normal distribution"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -12,43 +12,46 @@ from hypothesis import strategies as st
 from rework_pysatl_mpest.distributions import Normal
 from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from rework_pysatl_mpest.estimators.iterative._strategies import q_function_strategy
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # Test Fixtures
 # -------------
 
 
-@pytest.fixture
-def normal_component() -> Normal:
-    """Fixture that creates a default Normal component (standard normal)."""
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_normal_setup(request) -> tuple[Normal, PipelineState, np.floating]:
+    """
+    Creates a parametrized fixture providing a Normal component (standard normal) and a
+    corresponding PipelineState for various dtypes.
+    """
+    dtype = request.param
 
-    return Normal(loc=0.0, scale=1.0)
-
-
-@pytest.fixture
-def pipeline_state() -> PipelineState:
-    """Fixture that creates a basic PipelineState with some data."""
+    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
 
     state = PipelineState(
-        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]]),
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
         prev_mixture=None,
         curr_mixture=None,
         error=None,
     )
-    return state
+    return component, state, dtype
 
 
 # Tests
 # -----
 
 
-def test_q_function_normal_raises_value_error_if_h_is_none(normal_component):
+def test_q_function_normal_raises_value_error_if_h_is_none(parametrized_normal_setup):
     """
     Verifies that a ValueError is raised if the responsibility
     matrix H in the pipeline state has not been computed.
     """
+    normal_component, state, _ = parametrized_normal_setup
+    state.H = None
 
-    state = PipelineState(X=np.array([1, 2, 3]), H=None, curr_mixture=None, prev_mixture=None, error=None)
     block = OptimizationBlock(
         component_id=0, params_to_optimize={"loc", "scale"}, maximization_strategy=MaximizationStrategy.QFUNCTION
     )
@@ -57,11 +60,12 @@ def test_q_function_normal_raises_value_error_if_h_is_none(normal_component):
         q_function_strategy(normal_component, state, block, optimizer=None)
 
 
-def test_q_function_normal_returns_correct_types(normal_component, pipeline_state):
+def test_q_function_normal_returns_correct_types(parametrized_normal_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, float]).
+    data types (int, dict[str, DType]).
     """
+    normal_component, pipeline_state, dtype = parametrized_normal_setup
 
     expected_len = 2
 
@@ -79,7 +83,7 @@ def test_q_function_normal_returns_correct_types(normal_component, pipeline_stat
     if result[1]:
         key, value = next(iter(result[1].items()))
         assert isinstance(key, str)
-        assert isinstance(value, float)
+        assert isinstance(value, dtype)
 
 
 @pytest.mark.parametrize(
@@ -96,12 +100,13 @@ def test_q_function_normal_returns_correct_types(normal_component, pipeline_stat
     ],
 )
 def test_q_function_normal_respects_fixed_and_optimizable_params(
-    normal_component, pipeline_state, params_to_optimize_in_block, fixed_params_on_component, expected_keys
+    parametrized_normal_setup, params_to_optimize_in_block, fixed_params_on_component, expected_keys
 ):
     """
     Verifies that the strategy correctly identifies which parameters
     to update based on the optimization block and the component's fixed parameters.
     """
+    normal_component, pipeline_state, _ = parametrized_normal_setup
 
     for param in fixed_params_on_component:
         normal_component.fix_param(param)
@@ -117,23 +122,74 @@ def test_q_function_normal_respects_fixed_and_optimizable_params(
     assert set(new_params.keys()) == expected_keys
 
 
+def test_q_function_normal_handles_negligible_responsibility(parametrized_normal_setup):
+    """
+    Verifies that if a component's total responsibility (N_j) is near zero,
+    its parameters are not updated.
+    """
+
+    normal_component, pipeline_state, dtype = parametrized_normal_setup
+
+    pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize={"shape", "loc", "scale"},
+        maximization_strategy=MaximizationStrategy.QFUNCTION,
+    )
+
+    _, new_params = q_function_strategy(normal_component, pipeline_state, block, optimizer=None)
+
+    assert new_params == {}
+
+
+@pytest.mark.parametrize("param_to_optimize_in_block", ["loc", "scale"])
+def test_q_function_exponential_handles_numerical_overflow(param_to_optimize_in_block):
+    """
+    Verifies that if a numerical overflow occurs during calculations,
+    a `NumericalStabilityError` is correctly registered in the pipeline state.
+    """
+    # --- Arrange ---
+    # Use float16, which has a small range, and large values to force an overflow.
+    # The max value for float16 is ~65504. The sum of X will exceed this.
+    dtype = np.float16
+    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
+    X = np.array([60000, 60000], dtype=dtype)
+    H_j = np.array([1.0, 1.0], dtype=dtype)
+    H = np.vstack([H_j, np.zeros_like(H_j)]).T
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize={param_to_optimize_in_block},
+        maximization_strategy=MaximizationStrategy.QFUNCTION,
+    )
+    state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
+
+    _, new_params = q_function_strategy(component, state, block, optimizer=None)
+
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+
+
 # Property-Based Test with Hypothesis
 # -----------------------------------
 
 
 @st.composite
-def normal_data_and_true_params(draw):
-    """Generates a true Normal component and a data sample from it."""
+def normal_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float32, np.float64])):
+    """
+    Generates a true Normal component and a data sample from it,
+    all configured with a specific dtype.
+    """
+    dtype = draw(dtype_strategy)
 
     # 1. Generate realistic parameters for the true distribution
     true_loc = draw(st.floats(min_value=-1000, max_value=1000, allow_nan=False, allow_infinity=False))
     true_scale = draw(st.floats(min_value=0.1, max_value=100, allow_nan=False, allow_infinity=False))
-    true_component = Normal(loc=true_loc, scale=true_scale)
+    true_component = Normal(loc=true_loc, scale=true_scale, dtype=dtype)
 
     # 2. Generate a large data sample from this distribution
     X = true_component.generate(size=1000000)
 
-    return (X, true_loc, true_scale)
+    return (X, dtype(true_loc), dtype(true_scale), dtype)
 
 
 @settings(max_examples=50, deadline=None)
@@ -146,16 +202,16 @@ def test_q_function_normal_recovers_true_params_on_ideal_data(data):
     """
 
     # --- Arrange ---
-    X, true_loc, true_scale = data
+    X, true_loc, true_scale, dtype = data
 
     # This is the key assumption for this test: perfect knowledge that all
     # data points belong to our component of interest (responsibilities are all 1.0).
-    H_j = np.ones_like(X)
+    H_j = np.ones_like(X, dtype=dtype)
     H = np.vstack([H_j, np.zeros_like(H_j)]).T  # Simulate a 2-component mixture context
 
     # Use a starting component with completely different parameters to ensure
     # the update is based on data, not the initial guess.
-    start_component = Normal(loc=-999.0, scale=0.001)
+    start_component = Normal(loc=-999.0, scale=0.001, dtype=dtype)
 
     state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
     block = OptimizationBlock(
@@ -166,5 +222,11 @@ def test_q_function_normal_recovers_true_params_on_ideal_data(data):
     _, new_params = q_function_strategy(start_component, state, block, optimizer=None)
 
     # --- Assert ---
-    assert new_params[Normal.PARAM_LOC] == pytest.approx(true_loc, rel=0.05, abs=0.2)
-    assert new_params[Normal.PARAM_SCALE] == pytest.approx(true_scale, rel=0.05)
+    tolerance = {"rel": 0.05, "abs": 0.2} if dtype == np.float64 else {"rel": 2.0, "abs": 1.0}
+
+    assert new_params[Normal.PARAM_LOC] == pytest.approx(true_loc, **tolerance)
+    assert new_params[Normal.PARAM_SCALE] == pytest.approx(true_scale, **tolerance)
+
+    # Verify that the returned parameters have the correct dtype.
+    assert isinstance(new_params[Normal.PARAM_LOC], dtype)
+    assert isinstance(new_params[Normal.PARAM_SCALE], dtype)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
@@ -86,6 +86,29 @@ def test_q_function_normal_returns_correct_types(parametrized_normal_setup):
         assert isinstance(value, dtype)
 
 
+def test_q_function_normal_zero_variance_update(parametrized_normal_setup):
+    """
+    Tests the branch where weighted variance is close to 0.
+    """
+    component, state, dtype = parametrized_normal_setup
+
+    # All data points equal to current mean -> variance = 0
+    state.X = np.array([10.0, 10.0], dtype=dtype)
+    state.H = np.array([[1.0, 0.0], [1.0, 0.0]], dtype=dtype)
+
+    component.loc = dtype(10.0)
+    component.scale = dtype(2.5)
+
+    component.fix_param("loc")
+
+    block = OptimizationBlock(0, {"scale"}, MaximizationStrategy.QFUNCTION)
+
+    _, new_params = q_function_strategy(component, state, block, optimizer=None)
+
+    # Should keep original scale
+    assert new_params["scale"] == component.scale
+
+
 @pytest.mark.parametrize(
     "params_to_optimize_in_block, fixed_params_on_component, expected_keys",
     [
@@ -167,6 +190,8 @@ def test_q_function_exponential_handles_numerical_overflow(param_to_optimize_in_
 
     assert state.error is not None
     assert isinstance(state.error, NumericalStabilityError)
+    assert "Overflow detected during Q-function optimization" in str(state.error)
+    assert new_params == {}
 
 
 # Property-Based Test with Hypothesis

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
@@ -216,7 +216,7 @@ def pareto_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float32
     # 1. Generate realistic parameters for the true distribution
     true_shape = draw(st.floats(min_value=0.1, max_value=100, allow_nan=False, allow_infinity=False))
     true_scale = draw(st.floats(min_value=0.1, max_value=100, allow_nan=False, allow_infinity=False))
-    true_component = Pareto(shape=true_shape, scale=true_scale)
+    true_component = Pareto(shape=true_shape, scale=true_scale, dtype=dtype)
 
     # 2. Generate a large data sample from this distribution
     X = true_component.generate(size=1000000)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
@@ -1,6 +1,6 @@
 """Tests for Q-function optimization strategy for Pareto type 1 distribution"""
 
-__author__ = "Maksim Pastukhov"
+__author__ = "Maksim Pastukhov, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -13,42 +13,46 @@ from rework_pysatl_mpest.distributions import Pareto
 from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from rework_pysatl_mpest.estimators.iterative._strategies import q_function_strategy
 
+DTYPES_TO_TEST: list[np.floating] = [np.float16, np.float32, np.float64]
+
 # Test Fixtures
 # -------------
 
 
-@pytest.fixture
-def pareto_component() -> Pareto:
-    """Fixture that creates a default Pareto component."""
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_pareto_setup(request) -> tuple[Pareto, PipelineState, np.floating]:
+    """
+    Creates a parametrized fixture providing a default Pareto component, and a
+    corresponding PipelineState for various dtypes.
+    """
+    dtype = request.param
 
-    return Pareto(shape=1.0, scale=0.5)
-
-
-@pytest.fixture
-def pipeline_state() -> PipelineState:
-    """Fixture that creates a basic PipelineState with some data."""
+    component = Pareto(shape=1.0, scale=0.5, dtype=dtype)
 
     state = PipelineState(
-        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]]),
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
         prev_mixture=None,
         curr_mixture=None,
         error=None,
     )
-    return state
+
+    return component, state, dtype
 
 
 # Tests
 # -----
 
 
-def test_q_function_pareto_raises_value_error_if_h_is_none(pareto_component):
+def test_q_function_pareto_raises_value_error_if_h_is_none(parametrized_pareto_setup):
     """
     Verifies that a ValueError is raised if the responsibility
     matrix H in the pipeline state has not been computed.
     """
+    pareto_component, state, _ = parametrized_pareto_setup
 
-    state = PipelineState(X=np.array([1, 2, 3]), H=None, curr_mixture=None, prev_mixture=None, error=None)
+    state.H = None
+
     block = OptimizationBlock(
         component_id=0, params_to_optimize={"shape", "scale"}, maximization_strategy=MaximizationStrategy.QFUNCTION
     )
@@ -57,11 +61,13 @@ def test_q_function_pareto_raises_value_error_if_h_is_none(pareto_component):
         q_function_strategy(pareto_component, state, block, optimizer=None)
 
 
-def test_q_function_pareto_returns_correct_types(pareto_component, pipeline_state):
+def test_q_function_pareto_returns_correct_types(parametrized_pareto_setup):
     """
     Verifies that the function returns a tuple with the correct
     data types (int, dict[str, float]).
     """
+
+    pareto_component, pipeline_state, dtype = parametrized_pareto_setup
 
     expected_len = 2
 
@@ -79,7 +85,7 @@ def test_q_function_pareto_returns_correct_types(pareto_component, pipeline_stat
     if result[1]:
         key, value = next(iter(result[1].items()))
         assert isinstance(key, str)
-        assert isinstance(value, float)
+        assert isinstance(value, dtype)
 
 
 @pytest.mark.parametrize(
@@ -96,12 +102,14 @@ def test_q_function_pareto_returns_correct_types(pareto_component, pipeline_stat
     ],
 )
 def test_q_function_pareto_respects_fixed_and_optimizable_params(
-    pareto_component, pipeline_state, params_to_optimize_in_block, fixed_params_on_component, expected_keys
+    parametrized_pareto_setup, params_to_optimize_in_block, fixed_params_on_component, expected_keys
 ):
     """
     Verifies that the strategy correctly identifies which parameters
     to update based on the optimization block and the component's fixed parameters.
     """
+
+    pareto_component, pipeline_state, dtype = parametrized_pareto_setup
 
     for param in fixed_params_on_component:
         pareto_component.fix_param(param)
@@ -122,8 +130,10 @@ def test_q_function_pareto_respects_fixed_and_optimizable_params(
 
 
 @st.composite
-def pareto_data_and_true_params(draw):
+def pareto_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float32, np.float64])):
     """Generates a true Pareto component and a data sample from it."""
+
+    dtype = draw(dtype_strategy)
 
     # 1. Generate realistic parameters for the true distribution
     true_shape = draw(st.floats(min_value=0.1, max_value=100, allow_nan=False, allow_infinity=False))
@@ -133,7 +143,7 @@ def pareto_data_and_true_params(draw):
     # 2. Generate a large data sample from this distribution
     X = true_component.generate(size=1000000)
 
-    return (X, true_shape, true_scale)
+    return (X, dtype(true_shape), dtype(true_scale), dtype)
 
 
 @settings(max_examples=50, deadline=None)
@@ -146,16 +156,16 @@ def test_q_function_pareto_recovers_true_params_on_ideal_data(data):
     """
 
     # --- Arrange ---
-    X, true_shape, true_scale = data
+    X, true_shape, true_scale, dtype = data
 
     # This is the key assumption for this test: perfect knowledge that all
     # data points belong to our component of interest (responsibilities are all 1.0).
-    H_j = np.ones_like(X)
+    H_j = np.ones_like(X, dtype=dtype)
     H = np.vstack([H_j, np.zeros_like(H_j)]).T  # Simulate a 2-component mixture context
 
     # Use a starting component with completely different parameters to ensure
     # the update is based on data, not the initial guess.
-    start_component = Pareto(shape=0.001, scale=0.001)
+    start_component = Pareto(shape=0.001, scale=0.001, dtype=dtype)
 
     state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
     block = OptimizationBlock(
@@ -168,3 +178,7 @@ def test_q_function_pareto_recovers_true_params_on_ideal_data(data):
     # --- Assert ---
     assert new_params[Pareto.PARAM_SHAPE] == pytest.approx(true_shape, rel=0.05, abs=0.2)
     assert new_params[Pareto.PARAM_SCALE] == pytest.approx(true_scale, rel=0.05)
+
+    # Verify that the returned parameters have the correct dtype.
+    assert isinstance(new_params[Pareto.PARAM_SHAPE], dtype)
+    assert isinstance(new_params[Pareto.PARAM_SCALE], dtype)

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_pareto_q_function.py
@@ -125,6 +125,84 @@ def test_q_function_pareto_respects_fixed_and_optimizable_params(
     assert set(new_params.keys()) == expected_keys
 
 
+def test_q_function_pareto_handles_negligible_responsibility(parametrized_pareto_setup):
+    """
+    Verifies that if a component's total responsibility (N_j) is near zero,
+    its parameters are not updated.
+    """
+
+    pareto_component, pipeline_state, dtype = parametrized_pareto_setup
+
+    pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
+    block = OptimizationBlock(
+        component_id=0,
+        params_to_optimize={"shape", "scale"},
+        maximization_strategy=MaximizationStrategy.QFUNCTION,
+    )
+
+    _, new_params = q_function_strategy(pareto_component, pipeline_state, block, optimizer=None)
+
+    assert new_params == {}
+
+
+def test_pareto_scale_fallback_with_invalid_data():
+    """
+    Tests that Pareto scale optimization falls back to current value if no valid data
+    points are found (mask is empty) (Line 384 else branch).
+    """
+    dtype = np.float64
+    # Responsibilities are high (1.0), so we pass the early N_j check.
+    # However, data X is negative. Pareto requires X > 0 (and X >= scale).
+    # The mask (H > tol) & (X > 0) will be all False.
+
+    X = np.array([-1.0, -2.0], dtype=dtype)
+    H = np.array([[1.0, 0.0], [1.0, 0.0]], dtype=dtype)
+
+    original_scale = 1.5
+    comp = Pareto(shape=2.0, scale=original_scale, dtype=dtype)
+
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"scale"}, maximization_strategy=MaximizationStrategy.QFUNCTION
+    )
+
+    _, params = q_function_strategy(comp, state, block, optimizer=None)
+
+    assert Pareto.PARAM_SCALE in params
+    assert params[Pareto.PARAM_SCALE] == original_scale
+
+
+def test_pareto_shape_fallback_zero_denominator():
+    """
+    Tests the fallback branch for Pareto 'shape' (Line 394).
+    It triggers when the denominator (weighted sum of log(X/scale)) is close to zero.
+    This implies X is very close to scale (log(1) = 0).
+    """
+    dtype = np.float64
+    # log(X/scale) = log(1) = 0
+    # denominator = sum(H * 0) = 0
+
+    X = np.array([2.0], dtype=dtype)
+    H = np.array([[1.0, 0.0]], dtype=dtype)
+
+    original_shape = 3.0
+    original_scale = 2.0
+    comp = Pareto(shape=original_shape, scale=original_scale, dtype=dtype)
+
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"shape"}, maximization_strategy=MaximizationStrategy.QFUNCTION
+    )
+
+    _, params = q_function_strategy(comp, state, block, optimizer=None)
+
+    # Should fall back to the original shape because denominator is 0
+    assert Pareto.PARAM_SHAPE in params
+    assert params[Pareto.PARAM_SHAPE] == original_shape
+
+
 # Property-Based Test with Hypothesis
 # -----------------------------------
 

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
@@ -208,6 +208,40 @@ def test_q_function_weibull_handles_invalid_loc_for_scale_calculation(parametriz
     assert new_params[Weibull.PARAM_SCALE] == original_scale
 
 
+def test_weibull_scale_fallback_zero_weighted_sum():
+    """
+    Tests the fallback branch for Weibull 'scale' (Line 321).
+    It triggers when the weighted sum is effectively zero, BUT only if
+    X > loc (otherwise the earlier check catches it).
+    """
+    dtype = np.float64
+    # Check `loc >= X` (0.0 >= 1e-10) is False. Goes to `else`.
+
+    # X_minus_loc = 1e-10.
+    # safe_X_minus_loc = max(1e-10, 1e-9) = 1e-9.
+    # shape = 2.0.
+    # weighted_sum = 1.0 * (1e-9)**2 = 1e-18.
+
+    val_close_to_loc = 1e-10
+    X = np.array([val_close_to_loc], dtype=dtype)
+    H = np.array([[1.0, 0.0]], dtype=dtype)
+
+    original_scale = 5.5
+    comp = Weibull(shape=2.0, loc=0.0, scale=original_scale, dtype=dtype)
+
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+
+    block = OptimizationBlock(
+        component_id=0, params_to_optimize={"scale"}, maximization_strategy=MaximizationStrategy.QFUNCTION
+    )
+
+    _, params = q_function_strategy(comp, state, block, optimizer=None)
+
+    # Should fall back to the original scale
+    assert Weibull.PARAM_SCALE in params
+    assert params[Weibull.PARAM_SCALE] == original_scale
+
+
 def test_q_function_weibull_handles_numerical_overflow():
     """
     Verifies that if a numerical overflow occurs during calculations,
@@ -231,6 +265,8 @@ def test_q_function_weibull_handles_numerical_overflow():
     # --- Assert ---
     assert state.error is not None
     assert isinstance(state.error, NumericalStabilityError)
+    assert "Overflow detected during Q-function optimization" in str(state.error)
+    assert new_params == {}
 
 
 # Property-Based Test with Hypothesis

--- a/rework_tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
+++ b/rework_tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
@@ -1,6 +1,6 @@
 """Tests for Q-function optimization strategy for Weibull distribution"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Ri Aleksandra"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -12,54 +12,51 @@ from hypothesis import strategies as st
 from rework_pysatl_mpest.distributions import Weibull
 from rework_pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from rework_pysatl_mpest.estimators.iterative._strategies import q_function_strategy
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
 from rework_pysatl_mpest.optimizers import Optimizer
+
+DTYPES_TO_TEST: list[np.floating] = [np.float16, np.float32, np.float64]
 
 # Test Fixtures
 # -------------
 
 
-@pytest.fixture
-def weibull_component() -> Weibull:
-    """Fixture that creates a default Weibull component."""
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_weibull_setup(request, mocker) -> tuple[Weibull, PipelineState, Optimizer, np.floating]:
+    """
+    Creates a parametrized fixture providing a default Weibull component, a
+    corresponding PipelineState for various dtypes and mock Optimizer object.
+    """
+    dtype = request.param
 
-    return Weibull(shape=2.0, loc=0.0, scale=1.0)
-
-
-@pytest.fixture
-def pipeline_state() -> PipelineState:
-    """Fixture that creates a basic PipelineState with some data."""
+    component = Weibull(shape=2.0, loc=0.0, scale=1.0, dtype=dtype)
 
     state = PipelineState(
-        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]]),
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
         prev_mixture=None,
         curr_mixture=None,
         error=None,
     )
-    return state
-
-
-@pytest.fixture
-def mock_optimizer(mocker) -> Optimizer:
-    """Fixture that creates a mock Optimizer object."""
-
     optimizer = mocker.create_autospec(Optimizer, instance=True)
     # Default return value for optimizer
-    optimizer.minimize.return_value = [1.5]  # e.g., for a single param like shape
-    return optimizer
+    optimizer.minimize.return_value = [dtype(1.5)]  # e.g., for a single param like shape
+
+    return component, state, optimizer, dtype
 
 
 # Tests
 # -----
 
 
-def test_q_function_weibull_raises_value_error_if_h_is_none(weibull_component, mock_optimizer):
+def test_q_function_weibull_raises_value_error_if_h_is_none(parametrized_weibull_setup):
     """
     Verifies that a ValueError is raised if the responsibility
     matrix H in the pipeline state has not been computed.
     """
 
-    state = PipelineState(X=np.array([1, 2, 3]), H=None, curr_mixture=None, prev_mixture=None, error=None)
+    weibull_component, state, mock_optimizer, _ = parametrized_weibull_setup
+    state.H = None
     block = OptimizationBlock(
         component_id=0,
         params_to_optimize={"shape", "loc", "scale"},
@@ -70,18 +67,20 @@ def test_q_function_weibull_raises_value_error_if_h_is_none(weibull_component, m
         q_function_strategy(weibull_component, state, block, optimizer=mock_optimizer)
 
 
-def test_q_function_weibull_returns_correct_types(weibull_component, pipeline_state, mock_optimizer):
+def test_q_function_weibull_returns_correct_types(parametrized_weibull_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, float]).
+    data types (int, dict[str, DType]).
     """
+
+    weibull_component, pipeline_state, mock_optimizer, dtype = parametrized_weibull_setup
 
     block = OptimizationBlock(
         component_id=0,
         params_to_optimize={"shape", "loc", "scale"},
         maximization_strategy=MaximizationStrategy.QFUNCTION,
     )
-    mock_optimizer.minimize.return_value = [1.9, 0.1]  # shape, loc
+    mock_optimizer.minimize.return_value = [dtype(1.9), dtype(0.1)]  # shape, loc
 
     result = q_function_strategy(weibull_component, pipeline_state, block, optimizer=mock_optimizer)
 
@@ -92,7 +91,7 @@ def test_q_function_weibull_returns_correct_types(weibull_component, pipeline_st
     if result[1]:
         key, value = next(iter(result[1].items()))
         assert isinstance(key, str)
-        assert isinstance(value, float)
+        assert isinstance(value, dtype)
 
 
 @pytest.mark.parametrize(
@@ -114,9 +113,7 @@ def test_q_function_weibull_returns_correct_types(weibull_component, pipeline_st
 )
 def test_q_function_weibull_respects_params_and_calls_optimizer_correctly(
     mocker,
-    weibull_component,
-    pipeline_state,
-    mock_optimizer,
+    parametrized_weibull_setup,
     params_to_optimize_in_block,
     fixed_params_on_component,
     expected_numerical_params,
@@ -128,6 +125,8 @@ def test_q_function_weibull_respects_params_and_calls_optimizer_correctly(
     that fixed parameters are always respected.
     """
 
+    weibull_component, pipeline_state, mock_optimizer, dtype = parametrized_weibull_setup
+
     for param in fixed_params_on_component:
         weibull_component.fix_param(param)
 
@@ -138,10 +137,12 @@ def test_q_function_weibull_respects_params_and_calls_optimizer_correctly(
     )
 
     # 1. Define the plausible result that the generic numerical function should return.
-    mock_numerical_result = {param: (i + 1) * 1.1 for i, param in enumerate(sorted(list(expected_numerical_params)))}
+    mock_numerical_result = {
+        param: dtype((i + 1) * 1.1) for i, param in enumerate(sorted(list(expected_numerical_params)))
+    }
 
     # 2. Create a mock for the generic function itself.
-    mock_generic_function = mocker.Mock(return_value=(0, mock_numerical_result))
+    mock_generic_function = mocker.Mock(return_value=(dtype(0), mock_numerical_result))
 
     # 3. Patch the .dispatch method to return our new mock function.
     mocker.patch(
@@ -166,13 +167,15 @@ def test_q_function_weibull_respects_params_and_calls_optimizer_correctly(
         mock_generic_function.assert_not_called()
 
 
-def test_q_function_weibull_handles_negligible_responsibility(weibull_component, pipeline_state, mock_optimizer):
+def test_q_function_weibull_handles_negligible_responsibility(parametrized_weibull_setup):
     """
     Verifies that if a component's total responsibility (N_j) is near zero,
     its parameters are not updated.
     """
 
-    pipeline_state.H.fill(1e-10)  # Make all responsibilities negligible
+    weibull_component, pipeline_state, mock_optimizer, dtype = parametrized_weibull_setup
+
+    pipeline_state.H.fill(dtype(1e-10))  # Make all responsibilities negligible
     block = OptimizationBlock(
         component_id=0,
         params_to_optimize={"shape", "loc", "scale"},
@@ -184,13 +187,13 @@ def test_q_function_weibull_handles_negligible_responsibility(weibull_component,
     assert new_params == {}
 
 
-def test_q_function_weibull_handles_invalid_loc_for_scale_calculation(
-    weibull_component, pipeline_state, mock_optimizer
-):
+def test_q_function_weibull_handles_invalid_loc_for_scale_calculation(parametrized_weibull_setup):
     """
     Verifies that if `loc` is >= X, the `scale` parameter is not updated to
     avoid numerical errors, and the original scale is kept.
     """
+
+    weibull_component, pipeline_state, _, dtype = parametrized_weibull_setup
 
     # Set a loc that is larger than the first data point
     weibull_component.loc = 1.5
@@ -205,23 +208,52 @@ def test_q_function_weibull_handles_invalid_loc_for_scale_calculation(
     assert new_params[Weibull.PARAM_SCALE] == original_scale
 
 
+def test_q_function_weibull_handles_numerical_overflow():
+    """
+    Verifies that if a numerical overflow occurs during calculations,
+    a `NumericalStabilityError` is correctly registered in the pipeline state.
+    """
+    # --- Arrange ---
+    # Use float16, which has a small range, and large values to force an overflow.
+    # The max value for float16 is ~65504. The sum of X will exceed this.
+    dtype = np.float16
+    component = Weibull(shape=4.0, loc=0.0, scale=1.0, dtype=dtype)
+    X = np.array([20.0, 20.0], dtype=dtype)
+    H_j = np.array([1.0, 1.0], dtype=dtype)
+    H = np.vstack([H_j, np.zeros_like(H_j)]).T
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+
+    block = OptimizationBlock(0, {"scale"}, MaximizationStrategy.QFUNCTION)
+
+    # --- Act ---
+    _, new_params = q_function_strategy(component, state, block, optimizer=None)
+
+    # --- Assert ---
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+
+
 # Property-Based Test with Hypothesis
 # -----------------------------------
 
 
 @st.composite
-def weibull_data_and_true_params(draw):
-    """Generates a true Weibull component and a data sample from it."""
+def weibull_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float32, np.float64])):
+    """
+    Generates a true Weibull component and a data sample from it,
+    all configured with a specific dtype.
+    """
+    dtype = draw(dtype_strategy)
 
     true_shape = draw(st.floats(min_value=1.0, max_value=5.0))
     true_loc = draw(st.floats(min_value=-10.0, max_value=10.0))
     true_scale = draw(st.floats(min_value=0.5, max_value=10.0))
-    true_component = Weibull(shape=true_shape, loc=true_loc, scale=true_scale)
+    true_component = Weibull(shape=true_shape, loc=true_loc, scale=true_scale, dtype=dtype)
 
     sample_size = draw(st.integers(min_value=50000, max_value=50000))
     X = true_component.generate(size=sample_size)
 
-    return (X, true_shape, true_loc, true_scale)
+    return (X, true_shape, true_loc, true_scale, dtype)
 
 
 @settings(max_examples=30, deadline=None)
@@ -235,15 +267,15 @@ def test_q_function_weibull_analytical_scale_recovers_true_param(data):
     """
 
     # --- Arrange ---
-    X, true_shape, true_loc, true_scale = data
+    X, true_shape, true_loc, true_scale, dtype = data
 
     # Assume perfect knowledge: all data points belong to our component (H_j = 1.0)
-    H_j = np.ones_like(X)
+    H_j = np.ones_like(X, dtype=dtype)
     H = np.vstack([H_j, np.zeros_like(H_j)]).T  # Simulate a 2-component mixture
 
     # Create a component with the TRUE shape and loc, but a WRONG scale.
     # This isolates the test to only the analytical scale calculation.
-    start_component = Weibull(shape=true_shape, loc=true_loc, scale=999.9)
+    start_component = Weibull(shape=true_shape, loc=true_loc, scale=999.9, dtype=dtype)
 
     state = PipelineState(X=X, H=H, curr_mixture=None, prev_mixture=None, error=None)
     # We only want to optimize the scale parameter
@@ -256,3 +288,6 @@ def test_q_function_weibull_analytical_scale_recovers_true_param(data):
 
     # --- Assert ---
     assert new_params[Weibull.PARAM_SCALE] == pytest.approx(true_scale, rel=0.05)
+
+    # Verify that the returned parameters have the correct dtype.
+    assert isinstance(new_params[Weibull.PARAM_SCALE], dtype)

--- a/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
+++ b/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
@@ -4,32 +4,36 @@ __author__ = "Maksim Pastukhov"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-import numpy as np
-import pytest
 from unittest.mock import Mock
 
+import numpy as np
+import pytest
 from rework_pysatl_mpest.estimators.iterative import PipelineState
-from rework_pysatl_mpest.estimators.iterative.breakpointers.likelihood_breakpointer import  LikelihoodBreakpointer
+from rework_pysatl_mpest.estimators.iterative.breakpointers.likelihood_breakpointer import LikelihoodBreakpointer
 
 
 @pytest.fixture
 def mock_mixture_with_likelihood():
     """Returns a mock mixture that returns predefined log-likelihoods."""
+
     def make_mixture(ll_values):
         mixture = Mock()
         gen = iter(ll_values)
         mixture.loglikelihood = lambda X: next(gen)
         return mixture
+
     return make_mixture
 
 
 @pytest.fixture
 def dummy_state_factory():
     """Factory to create PipelineState with custom mixture."""
+
     def _make_state(mixture, X=None):
         if X is None:
             X = np.array([1.0, 2.0, 3.0])
         return PipelineState(X, None, None, mixture, None)
+
     return _make_state
 
 
@@ -56,11 +60,12 @@ class TestInitialization:
 
 class TestCheckLogic:
     def test_first_call_never_stops(self, mock_mixture_with_likelihood, dummy_state_factory):
+        FIRST_CALL = 5.0
         mixture = mock_mixture_with_likelihood([5.0])
         state = dummy_state_factory(mixture)
         bp = LikelihoodBreakpointer(0.1)
         assert not bp.check(state)
-        assert bp._L_old == 5.0
+        assert bp._L_old == FIRST_CALL
 
     def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory):
         mixture = mock_mixture_with_likelihood([10.0, 10.05])
@@ -76,7 +81,7 @@ class TestCheckLogic:
         bp = LikelihoodBreakpointer(0.5)
 
         assert not bp.check(state)
-        assert not bp.check(state)  
+        assert not bp.check(state)
 
     def test_reset_after_convergence_enables_reuse(self, mock_mixture_with_likelihood, dummy_state_factory):
         mixture = mock_mixture_with_likelihood([10.0, 10.01, 20.0, 20.005])
@@ -84,12 +89,12 @@ class TestCheckLogic:
         bp = LikelihoodBreakpointer(0.02)
 
         # First cycle
-        assert not bp.check(state)  
+        assert not bp.check(state)
         assert bp.check(state)
 
         # After reset, should behave like new
-        assert not bp.check(state)  
-        assert bp.check(state)     
+        assert not bp.check(state)
+        assert bp.check(state)
 
         # Internal state reset
         assert bp._L_old is None

--- a/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
+++ b/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
@@ -1,0 +1,96 @@
+"""Tests for LikelihoodBreakpointer"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import numpy as np
+import pytest
+from unittest.mock import Mock
+
+from rework_pysatl_mpest.estimators.iterative import PipelineState
+from rework_pysatl_mpest.estimators.iterative.breakpointers.likelihood_breakpointer import  LikelihoodBreakpointer
+
+
+@pytest.fixture
+def mock_mixture_with_likelihood():
+    """Returns a mock mixture that returns predefined log-likelihoods."""
+    def make_mixture(ll_values):
+        mixture = Mock()
+        gen = iter(ll_values)
+        mixture.loglikelihood = lambda X: next(gen)
+        return mixture
+    return make_mixture
+
+
+@pytest.fixture
+def dummy_state_factory():
+    """Factory to create PipelineState with custom mixture."""
+    def _make_state(mixture, X=None):
+        if X is None:
+            X = np.array([1.0, 2.0, 3.0])
+        return PipelineState(X, None, None, mixture, None)
+    return _make_state
+
+
+# --- Initialization Tests ---
+
+
+class TestInitialization:
+    @pytest.mark.parametrize("threshold", [0.01, 0.5, 10.0])
+    def test_initialization_with_valid_threshold(self, threshold: float):
+        bp = LikelihoodBreakpointer(threshold)
+        assert bp.threshold == threshold
+        assert bp._L_old is None
+        assert bp._L_new is None
+
+    def test_initialization_rejects_non_positive_threshold(self):
+        with pytest.raises(ValueError, match="The threshold must be greater than 0"):
+            LikelihoodBreakpointer(0.0)
+        with pytest.raises(ValueError, match="The threshold must be greater than 0"):
+            LikelihoodBreakpointer(-1.0)
+
+
+# --- Core Logic Tests ---
+
+
+class TestCheckLogic:
+    def test_first_call_never_stops(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([5.0])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.1)
+        assert not bp.check(state)
+        assert bp._L_old == 5.0
+
+    def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([10.0, 10.05])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.1)
+
+        assert not bp.check(state)
+        assert bp.check(state)
+
+    def test_no_convergence_continues(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([5.0, 6.0])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.5)
+
+        assert not bp.check(state)
+        assert not bp.check(state)  
+
+    def test_reset_after_convergence_enables_reuse(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([10.0, 10.01, 20.0, 20.005])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.02)
+
+        # First cycle
+        assert not bp.check(state)  
+        assert bp.check(state)
+
+        # After reset, should behave like new
+        assert not bp.check(state)  
+        assert bp.check(state)     
+
+        # Internal state reset
+        assert bp._L_old is None
+        assert bp._L_new is None

--- a/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
+++ b/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
@@ -45,8 +45,7 @@ class TestInitialization:
     def test_initialization_with_valid_threshold(self, threshold: float):
         bp = LikelihoodBreakpointer(threshold)
         assert bp.threshold == threshold
-        assert bp._L_old is None
-        assert bp._L_new is None
+        assert bp._likelihood_old is None
 
     def test_initialization_rejects_non_positive_threshold(self):
         with pytest.raises(ValueError, match="The threshold must be greater than 0"):
@@ -65,7 +64,7 @@ class TestCheckLogic:
         state = dummy_state_factory(mixture)
         bp = LikelihoodBreakpointer(0.1)
         assert not bp.check(state)
-        assert bp._L_old == FIRST_CALL
+        assert bp._likelihood_old == FIRST_CALL
 
     def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory):
         mixture = mock_mixture_with_likelihood([10.0, 10.05])
@@ -97,5 +96,5 @@ class TestCheckLogic:
         assert bp.check(state)
 
         # Internal state reset
-        assert bp._L_old is None
-        assert bp._L_new is None
+        assert bp._likelihood_old is None
+        assert bp._likelihood_new is None

--- a/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
+++ b/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
@@ -19,8 +19,8 @@ from rework_pysatl_mpest.estimators.iterative import PipelineState, PriorThresho
 class DummyDistribution(ContinuousDistribution):
     """A simple mock implementation of ContinuousDistribution for testing purposes."""
 
-    def __init__(self, name: str):
-        super().__init__()
+    def __init__(self, name: str, dtype: np.floating = np.float64):
+        super().__init__(dtype=dtype)
         self._name = name
 
     @property

--- a/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
+++ b/rework_tests/unit/estimators/iterative/pruners/test_prior_pruner.py
@@ -1,9 +1,10 @@
 """Tests for PriorThresholdPruner"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from copy import copy
 
 import numpy as np
 import pytest
@@ -14,6 +15,8 @@ from numpy.typing import ArrayLike, NDArray
 from rework_pysatl_mpest.core import MixtureModel
 from rework_pysatl_mpest.distributions import ContinuousDistribution
 from rework_pysatl_mpest.estimators.iterative import PipelineState, PriorThresholdPruner
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 
 class DummyDistribution(ContinuousDistribution):
@@ -47,7 +50,7 @@ class DummyDistribution(ContinuousDistribution):
         pass
 
     def __repr__(self):
-        return f"DummyDistribution(name='{self.name}')"
+        return f"DummyDistribution(name='{self.name}, dtype='{self.dtype}')"
 
 
 # --- Fixtures ---
@@ -99,6 +102,7 @@ def test_init_raises_value_error_for_invalid_threshold(invalid_threshold):
 # --- Tests for the prune method ---
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 @pytest.mark.parametrize(
     "threshold, initial_weights, expected_n_components, expected_remaining_indices, expected_removed_indices",
     [
@@ -128,6 +132,7 @@ def test_prune_removes_correct_components(
     expected_n_components,
     expected_remaining_indices,
     expected_removed_indices,
+    dtype,
 ):
     """
     Basic and edge case tests: checks the core logic of component removal.
@@ -136,25 +141,36 @@ def test_prune_removes_correct_components(
     """
 
     pruner = PriorThresholdPruner(threshold)
-    initial_mixture = MixtureModel(dummy_components, weights=initial_weights)
-    state = PipelineState(X=np.array([]), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None)
+    components = [DummyDistribution(f"comp_{i}", dtype=dtype) for i in range(len(initial_weights))]
+    initial_mixture = MixtureModel(components, weights=initial_weights, dtype=dtype)
+    state = PipelineState(
+        X=np.array([], dtype=dtype), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None
+    )
 
     new_state, removed_components_indices = pruner.prune(state)
-
     assert removed_components_indices == expected_removed_indices
 
+    new_mixture = new_state.curr_mixture
+
     # Check that the number of components matches the expected value
-    assert new_state.curr_mixture.n_components == expected_n_components
+    assert new_mixture.n_components == expected_n_components
 
     # Check that the correct components remain
-    expected_components = tuple(dummy_components[i] for i in expected_remaining_indices)
-    assert new_state.curr_mixture.components == expected_components
+    expected_components = tuple(components[i] for i in expected_remaining_indices)
+    assert new_mixture.components == expected_components
 
     # Check that the sum of weights after pruning is 1.0
-    assert np.isclose(np.sum(new_state.curr_mixture.weights), 1.0)
+    assert np.isclose(np.sum(new_mixture.weights), 1.0)
+
+    # --- Assert dtype preservation ---
+    assert new_mixture.dtype == dtype
+    assert new_mixture.weights.dtype == dtype
+    for comp in new_mixture.components:
+        assert comp.dtype == dtype
 
 
-def test_prune_does_not_remove_last_component(dummy_components):
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
+def test_prune_does_not_remove_last_component(dtype):
     """
     Edge case test: verifies that the pruner does not remove the last component,
     even if its weight is below the threshold.
@@ -162,12 +178,19 @@ def test_prune_does_not_remove_last_component(dummy_components):
 
     pruner = PriorThresholdPruner(threshold=0.9)
     # Mixture with two components, both below the threshold
-    initial_mixture = MixtureModel(dummy_components[:2], weights=[0.5, 0.5])
-    state = PipelineState(X=np.array([]), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None)
+    components = [DummyDistribution("comp_0", dtype=dtype), DummyDistribution("comp_1", dtype=dtype)]
+    initial_mixture = MixtureModel(components[:2], weights=[0.5, 0.5], dtype=dtype)
+    state = PipelineState(
+        X=np.array([], dtype=dtype), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None
+    )
 
     # After the first prune, one component will remain, which should not be removed
     new_state, _ = pruner.prune(state)
     assert new_state.curr_mixture.n_components == 1
+
+    # type correct
+    assert new_state.curr_mixture.dtype == dtype
+    assert new_state.curr_mixture.weights.dtype == dtype
 
 
 def test_prune_preserves_other_pipeline_state_attributes(dummy_components):
@@ -209,28 +232,26 @@ def test_prune_preserves_other_pipeline_state_attributes(dummy_components):
     assert new_state.curr_mixture.n_components == 1  # The component with weight 0.1 should have been removed
 
 
-# This code commented, because need change copy to deepcopy in pruner and
-# for testing this need __eq__ and __ne__ methods for ContinuousDistribution
-# def test_prune_does_not_modify_original_mixture_object(dummy_components):
-#     """
-#     Verifies that the original MixtureModel object passed into PipelineState
-#     is not mutated, as `prune` is expected to work on a copy.
-#     """
-#
-#     pruner = PriorThresholdPruner(threshold=0.5)
-#     initial_mixture = MixtureModel(dummy_components[:2], weights=[0.1, 0.9])
-#
-#     # Create a deep copy for later comparison
-#     original_mixture_snapshot = deepcopy(initial_mixture)
-#
-#     state = PipelineState(X=np.array([]), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None)
-#
-#     pruner.prune(state)
-#
-#     # Verify that the original `initial_mixture` object has not changed
-#     assert initial_mixture.n_components == original_mixture_snapshot.n_components
-#     assert np.allclose(initial_mixture.weights, original_mixture_snapshot.weights)
-#     assert initial_mixture.components == original_mixture_snapshot.components
+def test_prune_does_not_modify_original_mixture_object(dummy_components):
+    """
+    Verifies that the original MixtureModel object passed into PipelineState
+    is not mutated, as `prune` is expected to work on a copy.
+    """
+
+    pruner = PriorThresholdPruner(threshold=0.5)
+    initial_mixture = MixtureModel(dummy_components[:2], weights=[0.1, 0.9])
+
+    # Create a deep copy for later comparison
+    original_mixture_snapshot = copy(initial_mixture)
+
+    state = PipelineState(X=np.array([]), H=None, prev_mixture=None, curr_mixture=initial_mixture, error=None)
+
+    pruner.prune(state)
+
+    # Verify that the original `initial_mixture` object has not changed
+    assert initial_mixture.n_components == original_mixture_snapshot.n_components
+    assert np.allclose(initial_mixture.weights, original_mixture_snapshot.weights)
+    assert initial_mixture.components == original_mixture_snapshot.components
 
 
 # --- Tests using Hypothesis ---

--- a/rework_tests/unit/estimators/iterative/steps/test_expectation_step.py
+++ b/rework_tests/unit/estimators/iterative/steps/test_expectation_step.py
@@ -1,6 +1,6 @@
 """Tests for ExpectationStep"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -13,37 +13,36 @@ from rework_pysatl_mpest.estimators.iterative import ExpectationStep, Maximizati
 
 # --- Test Fixtures ---
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
-@pytest.fixture
-def mock_mixture(mocker):
+
+@pytest.fixture(params=DTYPES_TO_TEST)
+def initial_pipeline_state(request, mocker) -> PipelineState:
     """
-    Creates a mock MixtureModel object with two components using pytest-mock.
-    This allows for complete control over the inputs for the step being tested.
+    Creates an initial PipelineState for use in tests.
+
+    This fixture is executed for each data type in DTYPES_TO_TEST. It constructs
+    a mock mixture model and a pipeline state where all relevant components
+    (lpdf return values, weights, input data X) share the same parametrized dtype.
     """
+    dtype = request.param
 
     mock_component_1 = mocker.MagicMock()
     mock_component_2 = mocker.MagicMock()
 
-    mock_component_1.lpdf.return_value = np.log([0.6, 0.8])
-    mock_component_2.lpdf.return_value = np.log([0.1, 0.3])
+    mock_component_1.lpdf.return_value = np.log([0.6, 0.8]).astype(dtype)
+    mock_component_2.lpdf.return_value = np.log([0.1, 0.3]).astype(dtype)
 
     mixture = mocker.create_autospec(MixtureModel, instance=True)
     mixture.components = (mock_component_1, mock_component_2)
-    mixture.log_weights = np.log([0.7, 0.3])
+    mixture.log_weights = np.log([0.7, 0.3]).astype(dtype)
+    mixture.dtype = dtype
 
-    return mixture
-
-
-@pytest.fixture
-def initial_pipeline_state(mock_mixture) -> PipelineState:
-    """
-    Creates an initial PipelineState for use in tests.
-    """
     return PipelineState(
-        X=np.array([[1], [2]]),
+        X=np.array([[1], [2]], dtype=dtype),
         H=None,
         prev_mixture=None,
-        curr_mixture=mock_mixture,
+        curr_mixture=mixture,
         error=None,
     )
 
@@ -89,12 +88,15 @@ def test_run_soft_assignment_calculates_h_correctly(initial_pipeline_state):
     state = initial_pipeline_state
     step = ExpectationStep(is_soft=True)
 
-    expected_h = np.array([[0.42 / 0.45, 0.03 / 0.45], [0.56 / 0.65, 0.09 / 0.65]])
+    expected_h = np.array([[0.42 / 0.45, 0.03 / 0.45], [0.56 / 0.65, 0.09 / 0.65]], dtype=state.curr_mixture.dtype)
 
     result_state = step.run(state)
 
     assert result_state.H is not None
-    assert_allclose(result_state.H, expected_h, rtol=1e-6, err_msg="Soft H matrix calculation is incorrect")
+    atol = 1e-3 if state.curr_mixture.dtype == np.float16 else 1e-6
+    assert_allclose(result_state.H, expected_h, rtol=1e-6, atol=atol, err_msg="Soft H matrix calculation is incorrect")
+    # dtype correct
+    assert result_state.H.dtype == state.curr_mixture.dtype
 
 
 def test_run_hard_assignment_calculates_h_correctly(initial_pipeline_state):
@@ -106,7 +108,7 @@ def test_run_hard_assignment_calculates_h_correctly(initial_pipeline_state):
     state = initial_pipeline_state
     step = ExpectationStep(is_soft=False)
 
-    expected_h_hard = np.array([[1.0, 0.0], [1.0, 0.0]])
+    expected_h_hard = np.array([[1.0, 0.0], [1.0, 0.0]], dtype=state.curr_mixture.dtype)
 
     result_state = step.run(state)
 
@@ -116,6 +118,8 @@ def test_run_hard_assignment_calculates_h_correctly(initial_pipeline_state):
         expected_h_hard,
         err_msg="Hard H matrix calculation is incorrect",
     )
+    # dtype correct
+    assert result_state.H.dtype == state.curr_mixture.dtype
 
 
 def test_run_returns_state_and_modifies_only_h(initial_pipeline_state):

--- a/rework_tests/unit/estimators/iterative/steps/test_maximization_step.py
+++ b/rework_tests/unit/estimators/iterative/steps/test_maximization_step.py
@@ -1,6 +1,6 @@
 """Tests for MaximizationStep"""
 
-__author__ = "Danil Totmyanin"
+__author__ = "Danil Totmyanin, Aleksandra Ri"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
@@ -20,6 +20,8 @@ from rework_pysatl_mpest.estimators.iterative import (
 )
 from rework_pysatl_mpest.optimizers import Optimizer
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
 
 @pytest.fixture
 def mock_optimizer(mocker: MockerFixture) -> Optimizer:
@@ -28,31 +30,30 @@ def mock_optimizer(mocker: MockerFixture) -> Optimizer:
     return mocker.MagicMock(spec=Optimizer)
 
 
-@pytest.fixture
-def mock_components(mocker: MockerFixture) -> list[ContinuousDistribution]:
-    """Fixture to create a list of mock distribution components."""
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_state(request, mocker: MockerFixture) -> PipelineState:
+    """
+    Creates a parametrized PipelineState fixture for various dtypes.
+
+    This fixture runs for each data type in DTYPES_TO_TEST, constructing a
+    mock MixtureModel and PipelineState where all relevant arrays (X, H) and
+    model attributes share the same parametrized dtype. This enables robust
+    testing of data type preservation.
+    """
+    dtype = request.param
 
     comp1 = mocker.MagicMock(spec=ContinuousDistribution)
     comp2 = mocker.MagicMock(spec=ContinuousDistribution)
-    return [comp1, comp2]
-
-
-@pytest.fixture
-def mock_mixture(mocker: MockerFixture, mock_components: list) -> MixtureModel:
-    """Fixture to create a mock MixtureModel with two components."""
+    mock_components = [comp1, comp2]
 
     mixture = mocker.MagicMock(spec=MixtureModel)
     mixture.__getitem__.side_effect = lambda i: mock_components[i]
-    return mixture
+    mixture.__iter__.return_value = iter(mock_components)
+    mixture.dtype = dtype
 
-
-@pytest.fixture
-def pipeline_state(mock_mixture: MixtureModel) -> PipelineState:
-    """Fixture to create a basic PipelineState."""
-
-    X = np.array([[1.0], [2.0], [3.0], [4.0]])
-    H = np.array([[0.8, 0.2], [0.7, 0.3], [0.1, 0.9], [0.2, 0.8]])
-    return PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=mock_mixture, error=None)
+    X = np.array([[1.0], [2.0], [3.0], [4.0]], dtype=dtype)
+    H = np.array([[0.8, 0.2], [0.7, 0.3], [0.1, 0.9], [0.2, 0.8]], dtype=dtype)
+    return PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=mixture, error=None)
 
 
 class TestMaximizationStep:
@@ -90,19 +91,20 @@ class TestMaximizationStep:
         assert next_steps[0] == ExpectationStep
 
     def test_run_with_none_h_matrix_sets_error_and_returns_state(
-        self, mock_optimizer: Optimizer, pipeline_state: PipelineState
+        self, mock_optimizer: Optimizer, parametrized_state: PipelineState
     ):
         """
         Verifies that if state.H is None, the step sets an
         error and returns the state unmodified.
         """
+        state = parametrized_state
 
-        pipeline_state.H = None
+        state.H = None
         step = MaximizationStep(blocks=[], optimizer=mock_optimizer)
 
-        result_state = step.run(pipeline_state)
+        result_state = step.run(state)
 
-        assert result_state is pipeline_state
+        assert result_state is state
         assert isinstance(result_state.error, ValueError)
         assert "Responsibility matrix H is not computed" in str(result_state.error)
 
@@ -110,13 +112,14 @@ class TestMaximizationStep:
         self,
         mocker: MockerFixture,
         mock_optimizer: Optimizer,
-        mock_components: list,
-        pipeline_state: PipelineState,
+        parametrized_state: PipelineState,
     ):
         """
         Verifies that the correct strategy is called with
         the correct arguments and that the component parameters are updated.
         """
+        state = parametrized_state
+        dtype = state.curr_mixture.dtype
 
         block = OptimizationBlock(
             component_id=0,
@@ -129,19 +132,19 @@ class TestMaximizationStep:
         mock_strategy = mocker.patch(
             "rework_pysatl_mpest.estimators.iterative.steps.maximization_step.q_function_strategy"
         )
-        optimized_params = {"loc": 1.5, "rate": 2.5}
+        optimized_params = {"loc": dtype(1.5), "rate": dtype(2.5)}
         mock_strategy.return_value = (0, optimized_params)
 
         # _strategies dict patching
         new_strategies = {MaximizationStrategy.QFUNCTION: mock_strategy}
         mocker.patch.object(MaximizationStep, "_strategies", new_strategies)
 
-        target_component = mock_components[0]
+        target_component = state.curr_mixture[0]
 
-        step.run(pipeline_state)
+        step.run(state)
 
         # mock_strategy was called once
-        mock_strategy.assert_called_once_with(target_component, pipeline_state, block, mock_optimizer)
+        mock_strategy.assert_called_once_with(target_component, state, block, mock_optimizer)
 
         # The component parameters were updated
         # _update_components_params calls set_params_from_vector
@@ -149,25 +152,31 @@ class TestMaximizationStep:
         param_values = list(optimized_params.values())
         target_component.set_params_from_vector.assert_called_once_with(param_names, param_values)
 
+        # type correct
+        for value in param_values:
+            assert isinstance(value, dtype)
+
     def test_run_updates_mixture_weights_correctly(
-        self, mocker: MockerFixture, mock_optimizer: Optimizer, pipeline_state: PipelineState
+        self, mocker: MockerFixture, mock_optimizer: Optimizer, parametrized_state: PipelineState
     ):
         """
         Verifies the correct update of mixture weights.
         """
+        state = parametrized_state
+        dtype = state.curr_mixture.dtype
 
         # Sum of responsibilities for component 0: 0.8 + 0.7 + 0.1 + 0.2 = 1.8
         # Sum of responsibilities for component 1: 0.2 + 0.3 + 0.9 + 0.8 = 2.2
         # New weights: [1.8/4, 2.2/4] = [0.45, 0.55]
-        expected_new_weights = np.array([0.45, 0.55])
-        expected_log_weights = np.log(expected_new_weights + 1e-30)
+        expected_new_weights = np.array([0.45, 0.55], dtype=dtype)
+        expected_log_weights = np.log(expected_new_weights + 1e-30).astype(dtype)
 
         # `log_weigths` patching
         p = mocker.PropertyMock()
-        type(pipeline_state.curr_mixture).log_weights = p
+        type(state.curr_mixture).log_weights = p
 
         step = MaximizationStep(blocks=[], optimizer=mock_optimizer)
-        step.run(pipeline_state)
+        step.run(state)
 
         # Check that `log_weigths` setter was called once
         property_mock = p
@@ -175,18 +184,22 @@ class TestMaximizationStep:
 
         # Check that `log_weigths` was set correctly
         actual_log_weights = p.call_args.args[0]
-        np.testing.assert_allclose(actual_log_weights, expected_log_weights)
+        atol = 1e-4 if dtype == np.float16 else 1e-7
+        np.testing.assert_allclose(actual_log_weights, expected_log_weights, atol=atol)
+
+        # type correct
+        assert actual_log_weights.dtype == dtype
 
     def test_run_processes_blocks_sequentially(
         self,
         mocker: MockerFixture,
         mock_optimizer: Optimizer,
-        mock_components: list,
-        pipeline_state: PipelineState,
+        parametrized_state: PipelineState,
     ):
         """
         Verifies that optimization blocks are processed sequentially in the specified order.
         """
+        state = parametrized_state
 
         expected_call_count = 2
 
@@ -213,14 +226,13 @@ class TestMaximizationStep:
             (0, {"loc": 2.2}),  # Return value for block0
         ]
 
-        component0 = mock_components[0]
-        component1 = mock_components[1]
+        component0, component1 = state.curr_mixture
 
         new_strategies = {MaximizationStrategy.QFUNCTION: mock_strategy}
         mocker.patch.object(MaximizationStep, "_strategies", new_strategies)
 
         # Act
-        step.run(pipeline_state)
+        step.run(state)
 
         # Assert
         assert mock_strategy.call_count == expected_call_count

--- a/rework_tests/unit/estimators/iterative/steps/test_maximization_step.py
+++ b/rework_tests/unit/estimators/iterative/steps/test_maximization_step.py
@@ -337,3 +337,29 @@ class TestMaximizationStep:
 
         assert step.blocks[0].params_to_optimize == {"loc"}
         assert step.blocks[1].params_to_optimize == {"scale"}
+
+    def test_run_aborts_if_error_occurs_in_strategy(self, mock_optimizer, parametrized_state, mocker):
+        """
+        Tests that if a strategy returns an error state, subsequent blocks are ignored.
+        """
+        state = parametrized_state
+        block1 = OptimizationBlock(0, {"loc"}, MaximizationStrategy.QFUNCTION)
+        block2 = OptimizationBlock(1, {"loc"}, MaximizationStrategy.QFUNCTION)
+
+        step = MaximizationStep([block1, block2], mock_optimizer)
+
+        # Strategy that sets error on first call
+        def failing_strategy(*args):
+            state.error = ValueError("Fail")
+            return 0, {}
+
+        mocker.patch.object(MaximizationStep, "_strategies", {MaximizationStrategy.QFUNCTION: failing_strategy})
+        spy = mocker.spy(step, "_update_components_params")
+
+        result = step.run(state)
+
+        # Should return state with error
+        assert isinstance(result, PipelineState)
+        assert str(state.error) == "Fail"
+        # Params update should NOT be called because we returned early
+        spy.assert_not_called()

--- a/rework_tests/unit/estimators/iterative/test_logger.py
+++ b/rework_tests/unit/estimators/iterative/test_logger.py
@@ -99,6 +99,17 @@ class TestIndex:
         with pytest.raises(IndexError, match=expected):
             _ = setup_logger_for_index[index]
 
+    @pytest.mark.parametrize(
+        ("once_in_iterations", "expected_msg"),
+        [
+            (0, "once_in_iterations must be a positive integer"),
+        ],
+    )
+    def test_getitem_negative_index_out_of_bounds(self, once_in_iterations, expected_msg):
+        """Tests the specific branch `once_in_iterations < 1` in __init__."""
+        with pytest.raises(ValueError, match=expected_msg):
+            IterationsHistory(once_in_iterations)
+
 
 class TestLoggingAndLen:
     @pytest.mark.parametrize(("once_in_iter", "n", "expected"), [(1, 5, 5), (2, 8, 4), (3, 10, 4)])

--- a/rework_tests/unit/estimators/iterative/test_pipeline.py
+++ b/rework_tests/unit/estimators/iterative/test_pipeline.py
@@ -5,8 +5,8 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
+from collections.abc import Callable
 from copy import copy
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/rework_tests/unit/estimators/iterative/test_pipeline.py
+++ b/rework_tests/unit/estimators/iterative/test_pipeline.py
@@ -15,6 +15,9 @@ from rework_pysatl_mpest.distributions import Exponential
 from rework_pysatl_mpest.estimators.iterative import Breakpointer, Pipeline, PipelineState, PipelineStep, Pruner
 from rework_pysatl_mpest.estimators.iterative._logger import IterationRecord, IterationsHistory
 from rework_pysatl_mpest.estimators.iterative.steps import MaximizationStep, OptimizationBlock
+from rework_pysatl_mpest.exceptions import NumericalStabilityError
+
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
 
 # --- Mock objects for isolated testing ---
 
@@ -86,6 +89,19 @@ class MockStepWithError(MockSingleStep):
         pass
 
 
+class MockStepThatOverlowsOnFloat16(MockSingleStep):
+    """A mock step that simulates an error occurring only on float16"""
+
+    @property
+    def available_next_steps(self) -> list[type[PipelineStep]]:
+        return [ParameterIncrementStep]
+
+    def run(self, state: PipelineState) -> PipelineState:
+        if state.curr_mixture.dtype == np.float16:
+            state.error = NumericalStabilityError("Overflow!")
+        return state
+
+
 class ModifyingStep(PipelineStep):
     """A concrete mock step that actively modifies the mixture's state."""
 
@@ -116,7 +132,7 @@ class ParameterIncrementStep(PipelineStep):
 
     @property
     def available_next_steps(self) -> list[type[PipelineStep]]:
-        return [ParameterIncrementStep]
+        return [MockStepThatOverlowsOnFloat16, ParameterIncrementStep]
 
     def run(self, state: PipelineState) -> PipelineState:
         # Increment 'loc' for each component by 1
@@ -174,17 +190,19 @@ class MockPruner(Pruner):
 # --- Fixtures for tests ---
 
 
-@pytest.fixture
-def initial_mixture() -> MixtureModel:
-    """Provides a basic MixtureModel with two components."""
-    components = [Exponential(loc=0, rate=1), Exponential(loc=5, rate=2)]
-    return MixtureModel(components, weights=[0.5, 0.5])
+@pytest.fixture(params=DTYPES_TO_TEST)
+def initial_mixture(request) -> MixtureModel:
+    """Provides a basic MixtureModel with two components with parametrized dtype."""
+    dtype = request.param
+    components = [Exponential(loc=0, rate=1, dtype=dtype), Exponential(loc=5, rate=2, dtype=dtype)]
+    return MixtureModel(components, weights=[0.5, 0.5], dtype=dtype)
 
 
-@pytest.fixture
-def sample_data() -> np.ndarray:
-    """Provides a simple data array."""
-    return np.array([1, 2, 6, 7])
+@pytest.fixture(params=DTYPES_TO_TEST)
+def sample_data(request) -> np.ndarray:
+    """Provides a simple data array with parametrized dtype."""
+    dtype = request.param
+    return np.array([1, 2, 6, 7], dtype=dtype)
 
 
 # --- Initialization (`__init__`) Tests ---
@@ -291,6 +309,7 @@ class TestPipelineFit:
         """
 
         expected_n_components = 2
+        dtype = initial_mixture.dtype
 
         steps = [ParameterIncrementStep()]
         breakpointers = [MockBreakpointer(stop_at_iteration=3)]
@@ -304,27 +323,39 @@ class TestPipelineFit:
         # Iter 1: locs=[1, 6], weights=[0.6, 0.4]
         # Iter 2: locs=[2, 7], weights=[0.7, 0.3]
 
-        expected_final_locs = [2.0, 7.0]
-        expected_final_rates = [1.0, 2.0]  # Rates should not change
-        expected_final_weights = [0.7, 0.3]
+        expected_final_locs = np.array([2.0, 7.0], dtype=dtype)
+        expected_final_rates = np.array([1.0, 2.0], dtype=dtype)  # Rates should not change
+        expected_final_weights = np.array([0.7, 0.3], dtype=dtype)
 
         fitted_mixture = pipeline.fit(sample_data, initial_mixture)
 
         assert fitted_mixture.n_components == expected_n_components
+        # Check type
+        assert fitted_mixture.dtype == dtype
+        assert fitted_mixture.weights.dtype == dtype
+        for component in fitted_mixture.components:
+            assert component.dtype == dtype
 
         # Check weights
+        if dtype == np.float16:
+            rtol = 1e-3
+        elif dtype == np.float32:
+            rtol = 1e-5
+        else:  # float64
+            rtol = 1e-7
+
         np.testing.assert_allclose(
             fitted_mixture.weights,
             expected_final_weights,
-            rtol=1e-6,
+            rtol=rtol,
             err_msg="Mixture weights did not reach the expected values.",
         )
 
-        final_locs = [comp.loc for comp in fitted_mixture.components]
-        final_rates = [comp.rate for comp in fitted_mixture.components]
+        final_locs = np.array([comp.loc for comp in fitted_mixture.components], dtype=dtype)
+        final_rates = np.array([comp.rate for comp in fitted_mixture.components], dtype=dtype)
 
-        assert final_locs == expected_final_locs
-        assert final_rates == expected_final_rates
+        np.testing.assert_allclose(final_locs, expected_final_locs, rtol=rtol)
+        np.testing.assert_allclose(final_rates, expected_final_rates, rtol=rtol)
 
     def test_fit_does_not_modify_original_mixture(self, initial_mixture, sample_data):
         """
@@ -521,6 +552,34 @@ class TestPipelineFit:
         assert len(call_log) == LEN_CALL_LOG  # Called for each step
         for removed_indices in call_log:
             assert removed_indices == [0]
+
+    def test_fit_handles_numerical_stability_error_and_upcasts_dtype(self, mocker):
+        """Tests that Pipeline catches NumericalStabilityError and upgrades the dtype precision to float64."""
+
+        initial_mixture_f16 = MixtureModel([Exponential(loc=0, rate=1, dtype=np.float16)], dtype=np.float16)
+        sample_data_f16 = np.array([1, 2], dtype=np.float16)
+
+        steps = [MockStepThatOverlowsOnFloat16(), ParameterIncrementStep()]
+        breakpointers = [MockBreakpointer(stop_at_iteration=3)]
+
+        pipeline = Pipeline(steps, breakpointers)
+
+        fit_spy = mocker.spy(pipeline, "fit")
+
+        with pytest.warns(UserWarning, match="Restarting pipeline with higher precision"):
+            final_mixture = pipeline.fit(sample_data_f16, initial_mixture_f16)
+
+        expected_count_calls = 2  # One original call, one recursive
+        assert fit_spy.call_count == expected_count_calls
+
+        # Check that the final model in float64
+        assert final_mixture.dtype == np.float64
+        assert final_mixture.weights.dtype == np.float64
+        for component in final_mixture.components:
+            assert component.dtype == np.float64
+
+        # Step logic worked after increasing the precision
+        assert final_mixture.components[0].loc == pytest.approx(2.0)
 
 
 # --- Tests for MaximizationStep clear_after_prune method ---

--- a/rework_tests/unit/estimators/test_ecm.py
+++ b/rework_tests/unit/estimators/test_ecm.py
@@ -21,6 +21,8 @@ from rework_pysatl_mpest.estimators.iterative import (
 )
 from rework_pysatl_mpest.optimizers import Optimizer
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
 # --- Mocks and Fixtures for testing ECM ---
 
 
@@ -58,21 +60,22 @@ def mock_pruners() -> list[Pruner]:
     return []
 
 
-@pytest.fixture
-def sample_mixture() -> MixtureModel:
-    """Provides a mixture model with two components for testing."""
+@pytest.fixture(params=DTYPES_TO_TEST)
+def sample_mixture(request) -> MixtureModel:
+    """Provides a mixture model with two components for testing with parametrized dtype."""
 
-    components = [Normal(loc=0, scale=1), Exponential(loc=10, rate=1)]
+    dtype = request.param
+    components = [Normal(loc=0, scale=1, dtype=dtype), Exponential(loc=10, rate=1, dtype=dtype)]
     # Fix a parameter in one component to test if `params_to_optimize` is correctly used.
     components[1].fix_param("rate")
-    return MixtureModel(components, weights=[0.4, 0.6])
+    return MixtureModel(components, weights=[0.4, 0.6], dtype=dtype)
 
 
-@pytest.fixture
-def sample_data() -> np.ndarray:
-    """Provides a simple NumPy array of data."""
-
-    return np.array([1, 2, 3, 11, 12, 13])
+@pytest.fixture(params=DTYPES_TO_TEST)
+def sample_data(request) -> np.ndarray:
+    """Provides a simple NumPy array of data with parametrized dtype."""
+    dtype = request.param
+    return np.array([1, 2, 3, 11, 12, 13], dtype=dtype)
 
 
 # --- Test Cases ---
@@ -130,6 +133,12 @@ class TestECMFit:
         MockPipeline.assert_called_once()
         mock_pipeline_instance.fit.assert_called_once_with(sample_data, sample_mixture)
         assert result is sample_mixture
+
+        # Check types
+        assert result.dtype == sample_mixture.dtype
+        assert result.weights.dtype == sample_mixture.dtype
+        for component in result.components:
+            assert component.dtype == sample_mixture.dtype
 
     def test_fit_configures_pipeline_steps_correctly(
         self,

--- a/tests/experimental_env/test_reproducibility_expenv.py
+++ b/tests/experimental_env/test_reproducibility_expenv.py
@@ -2,17 +2,16 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
-from mpest import MixtureDistribution
-from mpest.em.breakpointers import StepCountBreakpointer
-from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
-from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
-
 from experimental_env.experiment.estimators import LikelihoodEstimator, LMomentsEstimator
 from experimental_env.experiment.experiment_description import StepDescription
 from experimental_env.experiment.experiment_executors.random_executor import RandomExperimentExecutor
 from experimental_env.experiment.experiment_parser import ExperimentParser
 from experimental_env.preparation.dataset_generator import RandomDatasetGenerator
 from experimental_env.preparation.dataset_parser import SamplesDatasetParser
+from mpest import MixtureDistribution
+from mpest.em.breakpointers import StepCountBreakpointer
+from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
+from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
 
 
 def compare_mixtures(mxt_1: MixtureDistribution, mxt_2: MixtureDistribution):


### PR DESCRIPTION
This PR implements and tests the LikelihoodBreakpointer, which stops the EM-like iterative pipeline when the change in log-likelihood between consecutive iterations falls below a specified threshold (|L_{t+1} - L_t| < threshold).   

Key changes:   

* Added LikelihoodBreakpointer class with proper convergence logic and validation.  
  
* Wrote unit tests using mocked likelihood sequences to reliably verify convergence detection, first-call behavior, and instance reuse after reset.

Closes #52 