### PR TITLE
feat: Add likelihood breakpointer

### DIFF
--- a/docs/source/api/estimators/iterative/index.rst
+++ b/docs/source/api/estimators/iterative/index.rst
@@ -47,6 +47,7 @@ Breakpointers (`Breakpointer`):
    :template: class.rst
 
    ~StepBreakpointer
+   ~LikelihoodBreakpointer
 
 Pruners (`Pruner`):
 ~~~~~~~~~~~~~~~~~~~

--- a/rework_pysatl_mpest/core/mixture.py
+++ b/rework_pysatl_mpest/core/mixture.py
@@ -9,7 +9,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import TYPE_CHECKING, Generic, Optional
+from typing import TYPE_CHECKING, Generic
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -84,7 +84,7 @@ class MixtureModel(Generic[DType]):
     def __init__(
         self,
         components: Sequence["ContinuousDistribution"],
-        weights: Optional[ArrayLike] = None,
+        weights: ArrayLike | None = None,
         dtype: type[DType] = np.float64,  # type: ignore[assignment]
     ):
         n_components = len(components)
@@ -101,9 +101,9 @@ class MixtureModel(Generic[DType]):
 
         self._components = [comp.astype(self.dtype) for comp in components]
         self._log_weights = np.log(weights + np.finfo(self.dtype).tiny)
-        self._cached_weights: Optional[NDArray[DType]] = None
+        self._cached_weights: NDArray[DType] | None = None
 
-        self._sorted_pairs_cache: Optional[list[tuple[ContinuousDistribution[DType], DType]]] = None
+        self._sorted_pairs_cache: list[tuple[ContinuousDistribution[DType], DType]] | None = None
 
     def _validate_weights(self, n_components: int, weights: NDArray[DType]):
         """Validates the component weights.

--- a/rework_pysatl_mpest/core/parameter.py
+++ b/rework_pysatl_mpest/core/parameter.py
@@ -10,7 +10,8 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import TYPE_CHECKING, Callable, Optional, Union, overload
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Optional, Union, overload
 
 import numpy as np
 

--- a/rework_pysatl_mpest/distributions/continuous_dist.py
+++ b/rework_pysatl_mpest/distributions/continuous_dist.py
@@ -8,7 +8,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic, Union
+from typing import Generic
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -165,7 +165,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         return [getattr(self, name) for name in param_names]
 
-    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[Union[float, DType]]):
+    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float | DType]):
         """Sets parameter values from a sequence of floats.
 
         Updates the distribution's parameters using values from the provided

--- a/rework_pysatl_mpest/estimators/iterative/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/__init__.py
@@ -18,7 +18,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from .breakpointer import Breakpointer
-from .breakpointers import StepBreakpointer
+from .breakpointers import StepBreakpointer, LikelihoodBreakpointer
 from .pipeline import Pipeline
 from .pipeline_state import PipelineState
 from .pipeline_step import PipelineStep
@@ -38,4 +38,5 @@ __all__ = [
     "PriorThresholdPruner",
     "Pruner",
     "StepBreakpointer",
+    "LikelihoodBreakpointer"
 ]

--- a/rework_pysatl_mpest/estimators/iterative/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/__init__.py
@@ -18,7 +18,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from .breakpointer import Breakpointer
-from .breakpointers import StepBreakpointer, LikelihoodBreakpointer
+from .breakpointers import LikelihoodBreakpointer, StepBreakpointer
 from .pipeline import Pipeline
 from .pipeline_state import PipelineState
 from .pipeline_step import PipelineStep
@@ -29,6 +29,7 @@ from .steps import ExpectationStep, MaximizationStep, MaximizationStrategy, Opti
 __all__ = [
     "Breakpointer",
     "ExpectationStep",
+    "LikelihoodBreakpointer",
     "MaximizationStep",
     "MaximizationStrategy",
     "OptimizationBlock",
@@ -38,5 +39,4 @@ __all__ = [
     "PriorThresholdPruner",
     "Pruner",
     "StepBreakpointer",
-    "LikelihoodBreakpointer"
 ]

--- a/rework_pysatl_mpest/estimators/iterative/_logger.py
+++ b/rework_pysatl_mpest/estimators/iterative/_logger.py
@@ -11,7 +11,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Generic, Optional
+from typing import Generic
 
 from numpy.typing import NDArray
 
@@ -51,9 +51,9 @@ class IterationRecord(Generic[DType]):
     iteration: int
     mixture: MixtureModel[DType]
     X: NDArray[DType]
-    H: Optional[NDArray[DType]]
-    pruners_used: Optional[list[Pruner[DType]]]
-    error: Optional[Exception]
+    H: NDArray[DType] | None
+    pruners_used: list[Pruner[DType]] | None
+    error: Exception | None
 
 
 class IterationsHistory(Generic[DType]):

--- a/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
@@ -6,7 +6,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from .step_breakpointer import StepBreakpointer
 from .likelihood_breakpointer import LikelihoodBreakpointer
+from .step_breakpointer import StepBreakpointer
 
-__all__ = ["StepBreakpointer", "LikelihoodBreakpointer"]
+__all__ = ["LikelihoodBreakpointer", "StepBreakpointer"]

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/__init__.py
@@ -7,5 +7,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from .step_breakpointer import StepBreakpointer
+from .likelihood_breakpointer import LikelihoodBreakpointer
 
-__all__ = ["StepBreakpointer"]
+__all__ = ["StepBreakpointer", "LikelihoodBreakpointer"]

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -1,0 +1,94 @@
+"""Module that provides a :class:`rework_pysatl_mpest.estimators.iterative.Pipeline`
+stopping strategy based on when log-likelihood of the mixture converges"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from ..breakpointer import Breakpointer
+from ..pipeline_state import PipelineState
+
+
+class LikelihoodBreakpointer(Breakpointer):
+    """Stops the pipeline when the log-likelihood of the mixture converges.
+
+    This breakpointer terminates the iterative estimation process when the
+    absolute difference between the current and previous log-likelihood values
+    falls below a specified threshold:
+
+    .. math::
+        |L_{t+1} - L_t| < threshold
+
+    It tracks the log-likelihood of the current mixture model on the observed
+    data at each iteration and compares it to the previous value.
+
+    Parameters
+    ----------
+    threshold : float
+        The convergence threshold for the log-likelihood difference.
+        Must be a positive number.
+
+    Attributes
+    ----------
+    threshold : float
+        The convergence threshold.
+
+    Raises
+    ------
+    ValueError
+        If `threshold` is not greater than 0.
+
+    Methods
+    -------
+    .. autosummary::
+        :toctree: generated/
+
+        check
+    """
+
+    def __init__(self, threshold: float):
+        self._validate(threshold)
+        self.threshold = threshold
+        self._likelihood_old: float | None = None
+
+    def _validate(self, threshold: float):
+        """Validates the threshold parameter."""
+        if threshold <= 0:
+            raise ValueError("The threshold must be greater than 0")
+
+    def check(self, state: PipelineState) -> bool:
+        """Checks if the log-likelihood has converged.
+
+        Computes the current log-likelihood of the mixture on the data in
+        the pipeline state and compares it with the previous value.
+
+        Parameters
+        ----------
+        state : PipelineState
+            The current state of the pipeline, which must contain a valid
+            `curr_mixture` and data `X`.
+
+        Returns
+        -------
+        bool
+            .. math::
+                \text{True if } |L_{\text{new}} - L_{\text{old}}| < \text{threshold, False otherwise}
+
+            On the first call (no previous likelihood), returns False and
+            initializes internal state.
+        """
+        self._likelihood_new: float | None = state.curr_mixture.loglikelihood(state.X)
+
+        # First iteration: cannot compare, so just store and continue
+        if self._likelihood_old is None:
+            self._likelihood_old = self._likelihood_new
+            return False
+
+        if abs(self._likelihood_new - self._likelihood_old) < self.threshold:
+            self._likelihood_old = None
+            self._likelihood_new = None
+            return True
+        else:
+            self._likelihood_old = self._likelihood_new
+            return False

--- a/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/rework_pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -6,11 +6,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
+from ....typings import DType
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
 
 
-class LikelihoodBreakpointer(Breakpointer):
+class LikelihoodBreakpointer(Breakpointer[DType]):
     """Stops the pipeline when the log-likelihood of the mixture converges.
 
     This breakpointer terminates the iterative estimation process when the
@@ -25,13 +26,13 @@ class LikelihoodBreakpointer(Breakpointer):
 
     Parameters
     ----------
-    threshold : float
+    threshold : DType
         The convergence threshold for the log-likelihood difference.
         Must be a positive number.
 
     Attributes
     ----------
-    threshold : float
+    threshold : DType
         The convergence threshold.
 
     Raises
@@ -47,17 +48,17 @@ class LikelihoodBreakpointer(Breakpointer):
         check
     """
 
-    def __init__(self, threshold: float):
+    def __init__(self, threshold: DType):
         self._validate(threshold)
         self.threshold = threshold
-        self._likelihood_old: float | None = None
+        self._likelihood_old: DType | None = None
 
-    def _validate(self, threshold: float):
+    def _validate(self, threshold: DType):
         """Validates the threshold parameter."""
-        if threshold <= 0:
+        if threshold <= 0.0:
             raise ValueError("The threshold must be greater than 0")
 
-    def check(self, state: PipelineState) -> bool:
+    def check(self, state: PipelineState[DType]) -> bool:
         """Checks if the log-likelihood has converged.
 
         Computes the current log-likelihood of the mixture on the data in
@@ -65,7 +66,7 @@ class LikelihoodBreakpointer(Breakpointer):
 
         Parameters
         ----------
-        state : PipelineState
+        state : PipelineState[DType]
             The current state of the pipeline, which must contain a valid
             `curr_mixture` and data `X`.
 
@@ -78,17 +79,16 @@ class LikelihoodBreakpointer(Breakpointer):
             On the first call (no previous likelihood), returns False and
             initializes internal state.
         """
-        self._likelihood_new: float | None = state.curr_mixture.loglikelihood(state.X)
+        _likelihood_new: DType = state.curr_mixture.loglikelihood(state.X)
 
         # First iteration: cannot compare, so just store and continue
         if self._likelihood_old is None:
-            self._likelihood_old = self._likelihood_new
+            self._likelihood_old = _likelihood_new
             return False
 
-        if abs(self._likelihood_new - self._likelihood_old) < self.threshold:
+        if abs(_likelihood_new - self._likelihood_old) < self.threshold:
             self._likelihood_old = None
-            self._likelihood_new = None
             return True
         else:
-            self._likelihood_old = self._likelihood_new
+            self._likelihood_old = _likelihood_new
             return False

--- a/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
+++ b/rework_pysatl_mpest/estimators/iterative/pipeline_state.py
@@ -11,7 +11,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Generic, Optional
+from typing import Generic
 
 from numpy.typing import NDArray
 
@@ -51,7 +51,7 @@ class PipelineState(Generic[DType]):
     """
 
     X: NDArray[DType]
-    H: Optional[NDArray[DType]]
-    prev_mixture: Optional[MixtureModel[DType]]
+    H: NDArray[DType] | None
+    prev_mixture: MixtureModel[DType] | None
     curr_mixture: MixtureModel[DType]
-    error: Optional[Exception]
+    error: Exception | None

--- a/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/rework_pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -14,9 +14,9 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from types import MappingProxyType
-from typing import Callable, ClassVar
+from typing import ClassVar
 
 import numpy as np
 

--- a/rework_pysatl_mpest/initializers/cluster_match_strategy.py
+++ b/rework_pysatl_mpest/initializers/cluster_match_strategy.py
@@ -6,9 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from collections.abc import Callable
 from copy import copy
 from itertools import permutations
-from typing import Callable
 
 import numpy as np
 

--- a/rework_pysatl_mpest/initializers/clusterize_initializer.py
+++ b/rework_pysatl_mpest/initializers/clusterize_initializer.py
@@ -6,9 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -118,7 +118,7 @@ class ClusterizeInitializer(Initializer):
         self.is_soft = is_soft
         self.is_accurate = is_accurate
         self.clusterizer = clusterizer
-        self.n_components: Optional[int] = None
+        self.n_components: int | None = None
         self.cluster_match_strategy: ClusterMatchStrategy = ClusterMatchStrategy.LIKELIHOOD
         self.estimation_strategies: list[EstimationStrategy] = []
         self.models: list[ContinuousDistribution] = []

--- a/rework_pysatl_mpest/optimizers/optimizer.py
+++ b/rework_pysatl_mpest/optimizers/optimizer.py
@@ -11,7 +11,8 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from abc import ABC, abstractmethod
-from typing import Callable, Generic
+from collections.abc import Callable
+from typing import Generic
 
 from ..typings import DType
 

--- a/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
+++ b/rework_pysatl_mpest/optimizers/scipy_nelder_mead.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from scipy.optimize import minimize

--- a/rework_pysatl_mpest/optimizers/scipy_powell.py
+++ b/rework_pysatl_mpest/optimizers/scipy_powell.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from scipy.optimize import minimize

--- a/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
+++ b/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
@@ -11,6 +11,8 @@ import pytest
 from rework_pysatl_mpest.estimators.iterative import PipelineState
 from rework_pysatl_mpest.estimators.iterative.breakpointers.likelihood_breakpointer import LikelihoodBreakpointer
 
+DTYPES_TO_TEST = [np.float16, np.float32, np.float64]
+
 
 @pytest.fixture
 def mock_mixture_with_likelihood():
@@ -40,52 +42,54 @@ def dummy_state_factory():
 # --- Initialization Tests ---
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestInitialization:
     @pytest.mark.parametrize("threshold", [0.01, 0.5, 10.0])
-    def test_initialization_with_valid_threshold(self, threshold: float):
-        bp = LikelihoodBreakpointer(threshold)
+    def test_initialization_with_valid_threshold(self, dtype, threshold):
+        bp = LikelihoodBreakpointer[dtype](threshold)
         assert bp.threshold == threshold
         assert bp._likelihood_old is None
 
-    def test_initialization_rejects_non_positive_threshold(self):
+    def test_initialization_rejects_non_positive_threshold(self, dtype):
         with pytest.raises(ValueError, match="The threshold must be greater than 0"):
-            LikelihoodBreakpointer(0.0)
+            LikelihoodBreakpointer[dtype](0.0)
         with pytest.raises(ValueError, match="The threshold must be greater than 0"):
-            LikelihoodBreakpointer(-1.0)
+            LikelihoodBreakpointer[dtype](-1.0)
 
 
 # --- Core Logic Tests ---
 
 
+@pytest.mark.parametrize("dtype", DTYPES_TO_TEST)
 class TestCheckLogic:
-    def test_first_call_never_stops(self, mock_mixture_with_likelihood, dummy_state_factory):
+    def test_first_call_never_stops(self, mock_mixture_with_likelihood, dummy_state_factory, dtype):
         FIRST_CALL = 5.0
         mixture = mock_mixture_with_likelihood([5.0])
         state = dummy_state_factory(mixture)
-        bp = LikelihoodBreakpointer(0.1)
+        bp = LikelihoodBreakpointer[dtype](0.1)
         assert not bp.check(state)
         assert bp._likelihood_old == FIRST_CALL
 
-    def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory):
+    def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory, dtype):
         mixture = mock_mixture_with_likelihood([10.0, 10.05])
         state = dummy_state_factory(mixture)
-        bp = LikelihoodBreakpointer(0.1)
+        bp = LikelihoodBreakpointer[dtype](0.1)
 
         assert not bp.check(state)
         assert bp.check(state)
 
-    def test_no_convergence_continues(self, mock_mixture_with_likelihood, dummy_state_factory):
+    def test_no_convergence_continues(self, mock_mixture_with_likelihood, dummy_state_factory, dtype):
         mixture = mock_mixture_with_likelihood([5.0, 6.0])
         state = dummy_state_factory(mixture)
-        bp = LikelihoodBreakpointer(0.5)
+        bp = LikelihoodBreakpointer[dtype](0.5)
 
         assert not bp.check(state)
         assert not bp.check(state)
 
-    def test_reset_after_convergence_enables_reuse(self, mock_mixture_with_likelihood, dummy_state_factory):
+    def test_reset_after_convergence_enables_reuse(self, mock_mixture_with_likelihood, dummy_state_factory, dtype):
         mixture = mock_mixture_with_likelihood([10.0, 10.01, 20.0, 20.005])
         state = dummy_state_factory(mixture)
-        bp = LikelihoodBreakpointer(0.02)
+        bp = LikelihoodBreakpointer[dtype](0.02)
 
         # First cycle
         assert not bp.check(state)
@@ -97,4 +101,3 @@ class TestCheckLogic:
 
         # Internal state reset
         assert bp._likelihood_old is None
-        assert bp._likelihood_new is None

--- a/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
+++ b/rework_tests/unit/estimators/iterative/breakpointers/test_likelihood_breakpointer.py
@@ -1,0 +1,100 @@
+"""Tests for LikelihoodBreakpointer"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from rework_pysatl_mpest.estimators.iterative import PipelineState
+from rework_pysatl_mpest.estimators.iterative.breakpointers.likelihood_breakpointer import LikelihoodBreakpointer
+
+
+@pytest.fixture
+def mock_mixture_with_likelihood():
+    """Returns a mock mixture that returns predefined log-likelihoods."""
+
+    def make_mixture(ll_values):
+        mixture = Mock()
+        gen = iter(ll_values)
+        mixture.loglikelihood = lambda X: next(gen)
+        return mixture
+
+    return make_mixture
+
+
+@pytest.fixture
+def dummy_state_factory():
+    """Factory to create PipelineState with custom mixture."""
+
+    def _make_state(mixture, X=None):
+        if X is None:
+            X = np.array([1.0, 2.0, 3.0])
+        return PipelineState(X, None, None, mixture, None)
+
+    return _make_state
+
+
+# --- Initialization Tests ---
+
+
+class TestInitialization:
+    @pytest.mark.parametrize("threshold", [0.01, 0.5, 10.0])
+    def test_initialization_with_valid_threshold(self, threshold: float):
+        bp = LikelihoodBreakpointer(threshold)
+        assert bp.threshold == threshold
+        assert bp._likelihood_old is None
+
+    def test_initialization_rejects_non_positive_threshold(self):
+        with pytest.raises(ValueError, match="The threshold must be greater than 0"):
+            LikelihoodBreakpointer(0.0)
+        with pytest.raises(ValueError, match="The threshold must be greater than 0"):
+            LikelihoodBreakpointer(-1.0)
+
+
+# --- Core Logic Tests ---
+
+
+class TestCheckLogic:
+    def test_first_call_never_stops(self, mock_mixture_with_likelihood, dummy_state_factory):
+        FIRST_CALL = 5.0
+        mixture = mock_mixture_with_likelihood([5.0])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.1)
+        assert not bp.check(state)
+        assert bp._likelihood_old == FIRST_CALL
+
+    def test_convergence_detected(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([10.0, 10.05])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.1)
+
+        assert not bp.check(state)
+        assert bp.check(state)
+
+    def test_no_convergence_continues(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([5.0, 6.0])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.5)
+
+        assert not bp.check(state)
+        assert not bp.check(state)
+
+    def test_reset_after_convergence_enables_reuse(self, mock_mixture_with_likelihood, dummy_state_factory):
+        mixture = mock_mixture_with_likelihood([10.0, 10.01, 20.0, 20.005])
+        state = dummy_state_factory(mixture)
+        bp = LikelihoodBreakpointer(0.02)
+
+        # First cycle
+        assert not bp.check(state)
+        assert bp.check(state)
+
+        # After reset, should behave like new
+        assert not bp.check(state)
+        assert bp.check(state)
+
+        # Internal state reset
+        assert bp._likelihood_old is None
+        assert bp._likelihood_new is None

--- a/rework_tests/unit/estimators/iterative/test_pipeline.py
+++ b/rework_tests/unit/estimators/iterative/test_pipeline.py
@@ -5,8 +5,8 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
+from collections.abc import Callable
 from copy import copy
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/experimental_env/test_reproducibility_expenv.py
+++ b/tests/experimental_env/test_reproducibility_expenv.py
@@ -2,17 +2,16 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
-from mpest import MixtureDistribution
-from mpest.em.breakpointers import StepCountBreakpointer
-from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
-from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
-
 from experimental_env.experiment.estimators import LikelihoodEstimator, LMomentsEstimator
 from experimental_env.experiment.experiment_description import StepDescription
 from experimental_env.experiment.experiment_executors.random_executor import RandomExperimentExecutor
 from experimental_env.experiment.experiment_parser import ExperimentParser
 from experimental_env.preparation.dataset_generator import RandomDatasetGenerator
 from experimental_env.preparation.dataset_parser import SamplesDatasetParser
+from mpest import MixtureDistribution
+from mpest.em.breakpointers import StepCountBreakpointer
+from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
+from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
 
 
 def compare_mixtures(mxt_1: MixtureDistribution, mxt_2: MixtureDistribution):

--- a/tests/experimental_env/test_reproducibility_expenv.py
+++ b/tests/experimental_env/test_reproducibility_expenv.py
@@ -2,16 +2,17 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+from mpest import MixtureDistribution
+from mpest.em.breakpointers import StepCountBreakpointer
+from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
+from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
+
 from experimental_env.experiment.estimators import LikelihoodEstimator, LMomentsEstimator
 from experimental_env.experiment.experiment_description import StepDescription
 from experimental_env.experiment.experiment_executors.random_executor import RandomExperimentExecutor
 from experimental_env.experiment.experiment_parser import ExperimentParser
 from experimental_env.preparation.dataset_generator import RandomDatasetGenerator
 from experimental_env.preparation.dataset_parser import SamplesDatasetParser
-from mpest import MixtureDistribution
-from mpest.em.breakpointers import StepCountBreakpointer
-from mpest.em.distribution_checkers import FiniteChecker, PriorProbabilityThresholdChecker
-from mpest.models import ExponentialModel, GaussianModel, WeibullModelExp
 
 
 def compare_mixtures(mxt_1: MixtureDistribution, mxt_2: MixtureDistribution):


### PR DESCRIPTION
This PR implements and tests the LikelihoodBreakpointer, which stops the EM-like iterative pipeline when the change in log-likelihood between consecutive iterations falls below a specified threshold (|L_{t+1} - L_t| < threshold).

Key changes:

   * Added LikelihoodBreakpointer class with proper convergence logic and validation.

    
   * Wrote unit tests using mocked likelihood sequences to reliably verify convergence detection, first-call behavior, and instance reuse after reset.

Closes https://github.com/PySATL/rework-pysatl-mpest/issues/52