### PR TITLE
Max pastukhov15/normal lmoments strat

### DIFF
--- a/pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -12,6 +12,7 @@ from ....optimizers import Optimizer
 from ....typings import DType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
+from .l_moments import lmoments_strategy as _lmoments_strategy
 from .moments import moments_strategy as _moments_strategy
 from .observed_data_likelihood import observed_data_likelihood_strategy as _observed_data_likelihood_strategy
 from .q_function import q_function_strategy as _q_function_strategy
@@ -28,5 +29,8 @@ moments_strategy: Callable[
     [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
 ] = _moments_strategy
 
+lmoments_strategy: Callable[
+    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
+] = _lmoments_strategy
 
-__all__ = ["moments_strategy", "observed_data_likelihood_strategy", "q_function_strategy"]
+__all__ = ["lmoments_strategy", "moments_strategy", "observed_data_likelihood_strategy", "q_function_strategy"]

--- a/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
@@ -1,0 +1,153 @@
+"""Provides strategies for the Maximization-step based on the Method of L-moments.
+
+This module implements the logic for updating component parameters by
+equating theoretical L-moments of the distribution to the empirical weighted
+L-moments of the data. It uses `functools.singledispatch` to provide a generic
+interface that can be specialized for specific distribution types.
+"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from functools import singledispatch
+
+import numpy as np
+
+from ....distributions import ContinuousDistribution, Exponential, Normal
+from ....optimizers import Optimizer
+from ....typings import DType
+from ..pipeline_state import PipelineState
+from ..steps import OptimizationBlock
+from .utils import handle_numerical_overflow
+
+NUMERICAL_TOLERANCE = 1e-9
+
+# ------------------------
+# function to compute 1-st and 2-nd l-moments
+# ------------------------
+def compute_sample_lmoments(X: np.ndarray, H: np.ndarray, N_j: DType) -> tuple[float, float]:
+    idx = np.argsort(X)
+    X_sorted = X[idx]
+    H_sorted = H[idx]
+
+    l1 = np.sum(H_sorted * X_sorted) / N_j
+
+    W_sum = np.cumsum(H_sorted)
+    rank_weights = (W_sum - 0.5 * H_sorted) / N_j
+
+    b1 = np.sum(H_sorted * X_sorted * rank_weights) / N_j
+    l2 = 2 * b1 - l1
+
+    return float(l1), float(l2)
+
+# ------------------------
+# Base L-moments strategy
+# ------------------------
+
+
+@singledispatch
+def lmoments_strategy(
+    component: ContinuousDistribution[DType],
+    state: PipelineState[DType],
+    block: OptimizationBlock,
+    optimizer: Optimizer[DType],
+) -> tuple[int, dict[str, DType]]:
+    """Generic M-step strategy based on L-moments.
+
+    Unlike the Q-function strategy, L-moments do not have a universal numerical
+    fallback because the relationship between L-moments and distribution
+    parameters is distribution-specific.
+
+    This function serves as a dispatcher. Specific implementations must be
+    registered for each distribution type.
+
+    Raises
+    ------
+    NotImplementedError
+        If no L-moment implementation exists for the given distribution type.
+    ValueError
+        If the responsibility matrix H is missing from the state.
+    """
+    if state.H is None:
+        raise ValueError("Responsibility matrix H is not computed.")
+
+    raise NotImplementedError(f"L-moments strategy for the {component.name} distribution is not implemented.")
+
+
+@lmoments_strategy.register(Normal)
+def _(
+    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
+) -> tuple[int, dict[str, DType]]:
+    """Specialized L-moments parameter estimation strategy for
+    the Normal distribution using an analytical solution.
+
+    This function provides a closed-form update for the parameters of a
+    `Normal` distribution based on the first two sample L-moments (l1, l2).
+    L-moments are often more robust to outliers and more efficient in small
+    samples compared to traditional moments or numerical MLE in certain
+    mixture contexts.
+
+    The implementation calculates the sample L-moments using the responsibility
+    matrix `H` from the E-step and maps them to the `loc` and `scale` parameters.
+
+    Notes
+    -----
+    The analytical updates depend on which parameters are being optimized:
+    - If both `loc` and `scale` are optimized:
+        - `loc = l1`
+        - `scale = sqrt(pi) * l2` (clipped to machine epsilon for numerical stability)
+    - If only `loc` is optimized (`scale` is fixed):
+        - `loc = l1`
+    - If only `scale` is optimized (`loc` is fixed):
+        - `scale = sqrt(pi) * l2` (clipped to machine epsilon)
+
+    Where:
+        - `l1` is the weighted mean (first L-moment).
+        - `l2` is the weighted L-scale (second L-moment).
+
+    This implementation ignores the `optimizer` parameter as it relies on
+    direct analytical mapping.
+
+    Raises
+    ------
+    ValueError
+        If the responsibility matrix `H` has not been computed.
+    """
+    
+    if state.H is None:
+        raise ValueError("Responsibility matrix H is not computed.")
+
+    dtype = component.dtype
+    MIN_SCALE = np.finfo(dtype).eps
+
+    X = state.X
+    H_j = state.H[:, block.component_id]
+    N_j = np.sum(H_j)
+
+    # If the component has negligible responsibility, do not update its parameters.
+    if np.isclose(N_j, 0.0, atol=NUMERICAL_TOLERANCE):
+        return block.component_id, {}
+
+    params_to_optimize = component.params_to_optimize.intersection(block.params_to_optimize)
+    new_params = {}
+
+    l1, l2 = compute_sample_lmoments(X, H_j, N_j)
+
+    if np.isinf(l1):
+        handle_numerical_overflow(state=state, context="Lmoments optimization")
+        return block.component_id, {}
+
+    if np.isinf(l2):
+        handle_numerical_overflow(state=state, context="Lmoments optimization")
+        return block.component_id, {}
+    
+    if component.PARAM_LOC in params_to_optimize:
+        new_loc = l1
+        new_params[component.PARAM_LOC] = dtype(new_loc)
+
+    if component.PARAM_SCALE in params_to_optimize:
+        new_scale = np.sqrt(np.pi) * l2
+        new_params[component.PARAM_SCALE] = dtype(max(new_scale, MIN_SCALE))
+    
+    return block.component_id, new_params

--- a/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
@@ -14,7 +14,7 @@ from functools import singledispatch
 
 import numpy as np
 
-from ....distributions import ContinuousDistribution, Exponential, Normal
+from ....distributions import ContinuousDistribution, Normal
 from ....optimizers import Optimizer
 from ....typings import DType
 from ..pipeline_state import PipelineState
@@ -22,6 +22,7 @@ from ..steps import OptimizationBlock
 from .utils import handle_numerical_overflow
 
 NUMERICAL_TOLERANCE = 1e-9
+
 
 # ------------------------
 # function to compute 1-st and 2-nd l-moments
@@ -40,6 +41,7 @@ def compute_sample_lmoments(X: np.ndarray, H: np.ndarray, N_j: DType) -> tuple[f
     l2 = 2 * b1 - l1
 
     return float(l1), float(l2)
+
 
 # ------------------------
 # Base L-moments strategy
@@ -114,7 +116,7 @@ def _(
     ValueError
         If the responsibility matrix `H` has not been computed.
     """
-    
+
     if state.H is None:
         raise ValueError("Responsibility matrix H is not computed.")
 
@@ -141,7 +143,7 @@ def _(
     if np.isinf(l2):
         handle_numerical_overflow(state=state, context="Lmoments optimization")
         return block.component_id, {}
-    
+
     if component.PARAM_LOC in params_to_optimize:
         new_loc = l1
         new_params[component.PARAM_LOC] = dtype(new_loc)
@@ -149,5 +151,5 @@ def _(
     if component.PARAM_SCALE in params_to_optimize:
         new_scale = np.sqrt(np.pi) * l2
         new_params[component.PARAM_SCALE] = dtype(max(new_scale, MIN_SCALE))
-    
+
     return block.component_id, new_params

--- a/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/l_moments.py
@@ -81,40 +81,97 @@ def lmoments_strategy(
 def _(
     component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
 ) -> tuple[int, dict[str, DType]]:
-    """Specialized L-moments parameter estimation strategy for
-    the Normal distribution using an analytical solution.
+    """
+    Update parameters of a univariate Normal component using L-moments.
 
-    This function provides a closed-form update for the parameters of a
-    `Normal` distribution based on the first two sample L-moments (l1, l2).
+    This strategy performs a closed-form (analytical) update of the Normal
+    distribution parameters by equating weighted sample L-moments to their
+    theoretical definitions. The update is performed for the component
+    associated with ``block.component_id`` and is limited to the intersection
+    of parameters requested by the component and the optimization block.
+
     L-moments are often more robust to outliers and more efficient in small
-    samples compared to traditional moments or numerical MLE in certain
-    mixture contexts.
+    samples compared to traditional moments or numerical Maximum Likelihood
+    Estimation (MLE) in certain mixture contexts.
 
-    The implementation calculates the sample L-moments using the responsibility
-    matrix `H` from the E-step and maps them to the `loc` and `scale` parameters.
+    If the total responsibility of the component is numerically negligible,
+    the function returns without updating any parameters.
 
-    Notes
-    -----
-    The analytical updates depend on which parameters are being optimized:
-    - If both `loc` and `scale` are optimized:
-        - `loc = l1`
-        - `scale = sqrt(pi) * l2` (clipped to machine epsilon for numerical stability)
-    - If only `loc` is optimized (`scale` is fixed):
-        - `loc = l1`
-    - If only `scale` is optimized (`loc` is fixed):
-        - `scale = sqrt(pi) * l2` (clipped to machine epsilon)
+    Parameters
+    ----------
+    component : Normal[DType]
+        Normal distribution component to be updated. The method may update
+        ``component.loc`` and/or ``component.scale`` depending on
+        ``component.params_to_optimize`` and the block configuration.
+    state : PipelineState[DType]
+        Current pipeline state containing:
 
-    Where:
-        - `l1` is the weighted mean (first L-moment).
-        - `l2` is the weighted L-scale (second L-moment).
+        - ``X`` : array-like
+        Observations used to compute L-moment estimates.
+        - ``H`` : array-like, shape (n_samples, n_components)
+        Responsibility matrix. Column ``block.component_id`` is used as
+        weights for this component.
+    block : OptimizationBlock
+        Optimization block describing which component is being optimized and
+        which parameters are allowed to change. The component index is taken
+        from ``block.component_id``.
+    optimizer : Optimizer[DType]
+        Optimizer instance provided by the pipeline. It is not used directly by
+        this analytical strategy but is included for API consistency.
 
-    This implementation ignores the `optimizer` parameter as it relies on
-    direct analytical mapping.
+    Returns
+    -------
+    component_id : int
+        The identifier of the optimized component, equal to
+        ``block.component_id``.
+    new_params : dict[str, DType]
+        Dictionary of updated parameters for the component. Keys correspond to
+        Normal parameter names (e.g., ``component.PARAM_LOC``,
+        ``component.PARAM_SCALE``). If no update is performed, an empty dict
+        is returned.
 
     Raises
     ------
     ValueError
-        If the responsibility matrix `H` has not been computed.
+        If ``state.H`` is ``None`` (i.e., the responsibility matrix has not been
+        computed).
+
+    Notes
+    -----
+    - Let :math:`l_1` be the weighted mean (first L-moment) and :math:`l_2`
+    be the weighted L-scale (second L-moment).
+
+    - **Location Update (:math:`\\mu$):**
+    The location is directly equal to the first L-moment:
+
+    .. math::
+
+        \\mu = l_1
+
+    - **Scale Update (:math:`\\sigma$):**
+    The relationship between the standard deviation and the second L-moment
+    for a Normal distribution is given by:
+
+    .. math::
+
+        \\sigma = l_2 \\sqrt{\\pi}
+
+    - The scale is lower-bounded by machine epsilon for the component dtype to
+    avoid degeneracy:
+
+    .. math::
+
+        \\sigma = \\max(\\sigma, \\text{np.finfo(dtype).eps})
+
+    - If the sum of responsibilities :math:`N_j` is close to zero (within
+    ``NUMERICAL_TOLERANCE``), the parameters are not updated.
+
+    Examples
+    --------
+    Update both location and scale for a Normal component using L-moments::
+
+        component_id, new_params = lmoments_strategy(normal_component, state, block, optimizer)
+        # new_params may contain {"loc": ..., "scale": ...}
     """
 
     if state.H is None:

--- a/pysatl_mpest/estimators/iterative/steps/block.py
+++ b/pysatl_mpest/estimators/iterative/steps/block.py
@@ -38,6 +38,7 @@ class MaximizationStrategy(Enum):
     QFUNCTION = auto()
     OBSERVED_DATA_LIKELIHOOD = auto()
     MOMENTS = auto()
+    LMOMENTS = auto()
 
 
 @dataclass

--- a/pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -23,7 +23,7 @@ import numpy as np
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
 from ....typings import DType
-from .._strategies import moments_strategy, observed_data_likelihood_strategy, q_function_strategy
+from .._strategies import lmoments_strategy, moments_strategy, observed_data_likelihood_strategy, q_function_strategy
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 from .block import MaximizationStrategy, OptimizationBlock
@@ -68,6 +68,7 @@ class MaximizationStep(PipelineStep[DType]):
             MaximizationStrategy.QFUNCTION: q_function_strategy,
             MaximizationStrategy.OBSERVED_DATA_LIKELIHOOD: observed_data_likelihood_strategy,
             MaximizationStrategy.MOMENTS: moments_strategy,
+            MaximizationStrategy.LMOMENTS: lmoments_strategy,
         }
     )
 

--- a/pysatl_mpest/initializers/clusterize/clusterize_initializer.py
+++ b/pysatl_mpest/initializers/clusterize/clusterize_initializer.py
@@ -6,9 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -131,7 +131,7 @@ class ClusterizeInitializer(Initializer):
         self.is_accurate = is_accurate
         self.clusterizer = clusterizer
         self.optimizer = optimizer
-        self.n_components: Optional[int] = None
+        self.n_components: int | None = None
         self.method: MatchingMethod = MatchingMethod.GREEDY
         self.score_func: ScoringMethod = ScoringMethod.LIKELIHOOD
         self.estimation_strategies: list[EstimationStrategy] = []

--- a/pysatl_mpest/initializers/clusterize/utils.py
+++ b/pysatl_mpest/initializers/clusterize/utils.py
@@ -6,8 +6,9 @@ __author__ = "Viktor Khanukaev"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from collections.abc import Callable
 from copy import copy
-from typing import Any, Callable, TypedDict
+from typing import Any, TypedDict
 
 import numpy as np
 

--- a/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
+++ b/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
@@ -15,6 +15,10 @@ from pysatl_mpest.exceptions import NumericalStabilityError
 
 DTYPES_TO_TEST = [np.float32, np.float64]
 
+# Constants for overflow testing (float16 limits)
+_FLOAT16_OVERFLOW_L1 = 65504.0  # Value causing overflow in first L-moment calculation
+_FLOAT16_OVERFLOW_L2 = 300.0  # Value causing overflow in second L-moment calculation
+
 
 @pytest.fixture(params=DTYPES_TO_TEST)
 def parametrized_normal_setup(request) -> tuple[Normal, PipelineState, np.floating]:
@@ -124,8 +128,8 @@ def test_lmoments_normal_handles_negligible_responsibility(parametrized_normal_s
 @pytest.mark.parametrize(
     "x_val, n_samples",
     [
-        pytest.param(65504.0, 2, id="overflow_first_lmoment"),
-        pytest.param(300.0, 220, id="overflow_second_lmoment"),
+        pytest.param(_FLOAT16_OVERFLOW_L1, 2, id="overflow_first_lmoment"),
+        pytest.param(_FLOAT16_OVERFLOW_L2, 220, id="overflow_second_lmoment"),
     ],
 )
 def test_lmoments_normal_overflow_handling(parametrized_normal_setup, x_val, n_samples):
@@ -133,7 +137,7 @@ def test_lmoments_normal_overflow_handling(parametrized_normal_setup, x_val, n_s
     dtype = np.float16
     component = Normal(loc=0.0, scale=1.0, dtype=dtype)
 
-    if x_val == 65504.0:
+    if x_val == _FLOAT16_OVERFLOW_L1:
         X_data = np.full(n_samples, x_val, dtype=dtype)
     else:
         X_data = np.array([x_val * (i + 1) for i in range(n_samples)], dtype=dtype)
@@ -154,14 +158,14 @@ def test_lmoments_normal_handles_inf_lmoments_directly(parametrized_normal_setup
     """Directly tests the branch where computed l1 or l2 is infinite."""
     component, state, dtype = parametrized_normal_setup
 
-    # Создаём искусственные данные, которые приведут к inf в l1 или l2
+    # Create artificial data that leads to inf in l1 or l2
     state.X = np.array([np.inf, 1.0, 2.0], dtype=dtype)
-    state.H = np.array([[1.0], [0.0], [0.0]], dtype=dtype)  # Только первая точка имеет вес
+    state.H = np.array([[1.0], [0.0], [0.0]], dtype=dtype)  # Only first point has weight
 
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
     _, new_params = lmoments_strategy(component, state, block, optimizer=None)
 
-    # Должна быть установлена ошибка и возвращён пустой словарь
+    # Error should be set and empty dict returned
     assert state.error is not None
     assert isinstance(state.error, NumericalStabilityError)
     assert new_params == {}
@@ -171,7 +175,7 @@ def test_lmoments_normal_scale_clipping_to_epsilon(parametrized_normal_setup):
     """Verifies that scale parameter is clipped to machine epsilon when L2 is near zero."""
     component, state, dtype = parametrized_normal_setup
 
-    # Все точки одинаковые → L2 ≈ 0 → scale должен быть зажат снизу
+    # All points identical -> L2 ~ 0 -> scale should be clipped to epsilon
     val = dtype(5.0)
     state.X = np.array([val, val, val, val], dtype=dtype)
     state.H = np.ones((4, 1), dtype=dtype)
@@ -188,10 +192,10 @@ def test_lmoments_normal_scale_clipping_to_epsilon(parametrized_normal_setup):
 def normal_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float64])):
     """Generates true Normal parameters and a synthetic dataset with full responsibility."""
     dtype = draw(dtype_strategy)
-    # Более консервативные диапазоны для стабильной оценки
+    # Conservative ranges for stable estimation
     true_loc = draw(st.floats(min_value=-20, max_value=20, allow_nan=False, allow_infinity=False))
     true_scale = draw(st.floats(min_value=0.5, max_value=20.0, allow_nan=False, allow_infinity=False))
-    sample_size = draw(st.integers(min_value=8000, max_value=15000))  # Увеличил размер выборки
+    sample_size = draw(st.integers(min_value=8000, max_value=15000))
 
     rng = np.random.default_rng(42)
     X = rng.normal(loc=true_loc, scale=true_scale, size=sample_size).astype(dtype)
@@ -218,9 +222,9 @@ def test_lmoments_normal_recovers_true_params_on_ideal_data(data):
 
     _, new_params = lmoments_strategy(start_component, state, block, optimizer=None)
 
-    # Адаптивные допуски: абсолютная погрешность растёт с true_scale
-    loc_atol = 0.3 + 0.02 * float(true_scale)  # ~0.3 базовая + 2% от scale
-    scale_rtol = 0.12 + 0.003 * float(true_scale)  # ~12% базовая + 0.3% от scale
+    # Adaptive tolerances: absolute error grows with true_scale
+    loc_atol = 0.3 + 0.02 * float(true_scale)  # ~0.3 base + 2% of scale
+    scale_rtol = 0.12 + 0.003 * float(true_scale)  # ~12% base + 0.3% of scale
 
     assert new_params[Normal.PARAM_LOC] == pytest.approx(true_loc, abs=loc_atol)
     assert new_params[Normal.PARAM_SCALE] == pytest.approx(true_scale, rel=scale_rtol)

--- a/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
+++ b/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
@@ -6,28 +6,29 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 import numpy as np
 import pytest
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from pysatl_mpest.distributions import Normal
 from pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
-# Импортируем именно lmoments_strategy
 from pysatl_mpest.estimators.iterative._strategies import lmoments_strategy
 
-DTYPES_TO_TEST = [np.float32, np.float64] # float16 часто недостаточно для точности L-моментов
+DTYPES_TO_TEST = [np.float32, np.float64]
+
 
 @pytest.fixture(params=DTYPES_TO_TEST)
 def parametrized_normal_setup(request):
     dtype = request.param
     component = Normal(loc=0.0, scale=1.0, dtype=dtype)
-    
-    # Подготовим простые данные для базовых тестов
+
     state = PipelineState(
         X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
         H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
-        prev_mixture=None, curr_mixture=None, error=None,
+        prev_mixture=None,
+        curr_mixture=None,
+        error=None,
     )
     return component, state, dtype
 
-# --- Базовые тесты интерфейса ---
 
 def test_lmoments_normal_raises_value_error_if_h_is_none(parametrized_normal_setup):
     normal_component, state, _ = parametrized_normal_setup
@@ -37,9 +38,10 @@ def test_lmoments_normal_raises_value_error_if_h_is_none(parametrized_normal_set
     with pytest.raises(ValueError, match="Responsibility matrix H is not computed."):
         lmoments_strategy(normal_component, state, block, optimizer=None)
 
+
 def test_lmoments_normal_respects_fixed_params(parametrized_normal_setup):
     normal_component, state, _ = parametrized_normal_setup
-    normal_component.fix_param("loc") # Фиксируем mu
+    normal_component.fix_param("loc")  # Фиксируем mu
 
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
     _, new_params = lmoments_strategy(normal_component, state, block, optimizer=None)
@@ -47,14 +49,13 @@ def test_lmoments_normal_respects_fixed_params(parametrized_normal_setup):
     assert "loc" not in new_params
     assert "scale" in new_params
 
-# --- Тест математической корректности (L-moments vs Normal) ---
 
 def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
     """
     Проверка конкретного примера.
     Для данных [10, 20] с весами [0.5, 0.5]:
     L1 = (10*0.5 + 20*0.5) / 1.0 = 15.0
-    rank_weights: 
+    rank_weights:
       w1 = (0.5 - 0.5*0.5)/1 = 0.25
       w2 = (1.0 - 0.5*0.5)/1 = 0.75
     b1 = (10*0.5*0.25 + 20*0.5*0.75) / 1.0 = 1.25 + 7.5 = 8.75
@@ -74,7 +75,6 @@ def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
     assert new_params[Normal.PARAM_LOC] == pytest.approx(expected_mu, rel=1e-4)
     assert new_params[Normal.PARAM_SCALE] == pytest.approx(expected_sigma, rel=1e-4)
 
-# --- Тесты на стабильность ---
 
 def test_lmoments_normal_handles_zero_variance(parametrized_normal_setup):
     """Если все точки одинаковые, L2 будет 0, sigma должна быть зажата eps."""
@@ -88,32 +88,26 @@ def test_lmoments_normal_handles_zero_variance(parametrized_normal_setup):
 
     assert new_params[Normal.PARAM_SCALE] >= np.finfo(dtype).eps
 
-# --- Hypothesis: Восстановление параметров из выборки ---
 
 @settings(max_examples=20, deadline=None)
-@given(
-    mu=st.floats(min_value=-10, max_value=10),
-    sigma=st.floats(min_value=1.0, max_value=5.0)
-)
+@given(mu=st.floats(min_value=-10, max_value=10), sigma=st.floats(min_value=1.0, max_value=5.0))
 def test_lmoments_normal_recovery_property(mu, sigma):
     """
-    Свойство: на большой выборке взвешенные L-моменты должны 
+    Свойство: на большой выборке взвешенные L-моменты должны
     восстанавливать параметры mu и sigma.
     """
     dtype = np.float64
     sample_size = 10000
     rng = np.random.default_rng(42)
-    
+
     X = rng.normal(loc=mu, scale=sigma, size=sample_size).astype(dtype)
-    H = np.ones((sample_size, 1), dtype=dtype) # Полная ответственность
-    
+    H = np.ones((sample_size, 1), dtype=dtype)  # Полная ответственность
+
     component = Normal(loc=0.0, scale=1.0, dtype=dtype)
     state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
-    
+
     _, new_params = lmoments_strategy(component, state, block, optimizer=None)
-    
-    # Для нормального распределения L-моменты очень эффективны, 
-    # поэтому точность должна быть высокой.
+
     assert new_params[Normal.PARAM_LOC] == pytest.approx(mu, abs=0.1)
     assert new_params[Normal.PARAM_SCALE] == pytest.approx(sigma, rel=0.05)

--- a/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
+++ b/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
@@ -52,8 +52,8 @@ def test_lmoments_normal_respects_fixed_params(parametrized_normal_setup):
 
 def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
     """
-    Проверка конкретного примера.
-    Для данных [10, 20] с весами [0.5, 0.5]:
+    Test case verification with a concrete example.
+    Given data [10, 20] and weights [0.5, 0.5]:
     L1 = (10*0.5 + 20*0.5) / 1.0 = 15.0
     rank_weights:
       w1 = (0.5 - 0.5*0.5)/1 = 0.25

--- a/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
+++ b/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
@@ -1,4 +1,4 @@
-"""Tests for L-moments optimization strategy for Normal distribution"""
+"""Tests for L-Moments optimization strategy for Normal distribution"""
 
 __author__ = "Maksim Pastukhov"
 __copyright__ = "Copyright (c) 2025 PySATL project"
@@ -11,12 +11,14 @@ from hypothesis import strategies as st
 from pysatl_mpest.distributions import Normal
 from pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
 from pysatl_mpest.estimators.iterative._strategies import lmoments_strategy
+from pysatl_mpest.exceptions import NumericalStabilityError
 
 DTYPES_TO_TEST = [np.float32, np.float64]
 
 
 @pytest.fixture(params=DTYPES_TO_TEST)
-def parametrized_normal_setup(request):
+def parametrized_normal_setup(request) -> tuple[Normal, PipelineState, np.floating]:
+    """Creates a parametrized fixture providing a Normal component and PipelineState for various dtypes."""
     dtype = request.param
     component = Normal(loc=0.0, scale=1.0, dtype=dtype)
 
@@ -31,6 +33,7 @@ def parametrized_normal_setup(request):
 
 
 def test_lmoments_normal_raises_value_error_if_h_is_none(parametrized_normal_setup):
+    """Verifies that a ValueError is raised if the responsibility matrix H has not been computed."""
     normal_component, state, _ = parametrized_normal_setup
     state.H = None
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
@@ -39,15 +42,21 @@ def test_lmoments_normal_raises_value_error_if_h_is_none(parametrized_normal_set
         lmoments_strategy(normal_component, state, block, optimizer=None)
 
 
-def test_lmoments_normal_respects_fixed_params(parametrized_normal_setup):
-    normal_component, state, _ = parametrized_normal_setup
-    normal_component.fix_param("loc")  # Фиксируем mu
-
+def test_lmoments_normal_returns_correct_types(parametrized_normal_setup):
+    """Verifies that the function returns a tuple with the correct data types (int, dict[str, DType])."""
+    normal_component, pipeline_state, dtype = parametrized_normal_setup
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
-    _, new_params = lmoments_strategy(normal_component, state, block, optimizer=None)
 
-    assert "loc" not in new_params
-    assert "scale" in new_params
+    result = lmoments_strategy(normal_component, pipeline_state, block, optimizer=None)
+
+    assert isinstance(result, tuple)
+    assert isinstance(result[0], int)
+    assert isinstance(result[1], dict)
+
+    if result[1]:
+        key, value = next(iter(result[1].items()))
+        assert isinstance(key, str)
+        assert isinstance(value, dtype)
 
 
 def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
@@ -76,38 +85,145 @@ def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
     assert new_params[Normal.PARAM_SCALE] == pytest.approx(expected_sigma, rel=1e-4)
 
 
-def test_lmoments_normal_handles_zero_variance(parametrized_normal_setup):
-    """Если все точки одинаковые, L2 будет 0, sigma должна быть зажата eps."""
+@pytest.mark.parametrize(
+    "params_to_optimize_in_block, fixed_params_on_component, expected_keys",
+    [
+        ({"loc", "scale"}, set(), {"loc", "scale"}),
+        ({"loc"}, set(), {"loc"}),
+        ({"scale"}, set(), {"scale"}),
+        ({"loc", "scale"}, {"loc"}, {"scale"}),
+        ({"loc", "scale"}, {"scale"}, {"loc"}),
+        ({"loc", "scale"}, {"loc", "scale"}, set()),
+        ({"non_existent_param", "loc"}, set(), {"loc"}),
+        (set(), set(), set()),
+    ],
+)
+def test_lmoments_normal_respects_fixed_and_optimizable_params(
+    parametrized_normal_setup, params_to_optimize_in_block, fixed_params_on_component, expected_keys
+):
+    """Verifies parameter update logic against component fixes and block constraints."""
+    normal_component, pipeline_state, _ = parametrized_normal_setup
+    for param in fixed_params_on_component:
+        normal_component.fix_param(param)
+
+    block = OptimizationBlock(0, params_to_optimize_in_block, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(normal_component, pipeline_state, block, optimizer=None)
+    assert set(new_params.keys()) == expected_keys
+
+
+def test_lmoments_normal_handles_negligible_responsibility(parametrized_normal_setup):
+    """Verifies that components with near-zero responsibility are not updated."""
+    normal_component, pipeline_state, dtype = parametrized_normal_setup
+    pipeline_state.H.fill(dtype(1e-10))
+
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(normal_component, pipeline_state, block, optimizer=None)
+    assert new_params == {}
+
+
+@pytest.mark.parametrize(
+    "x_val, n_samples",
+    [
+        pytest.param(65504.0, 2, id="overflow_first_lmoment"),
+        pytest.param(300.0, 220, id="overflow_second_lmoment"),
+    ],
+)
+def test_lmoments_normal_overflow_handling(parametrized_normal_setup, x_val, n_samples):
+    """Verifies NumericalStabilityError is set upon overflow in L-moment calculations."""
+    dtype = np.float16
+    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
+
+    if x_val == 65504.0:
+        X_data = np.full(n_samples, x_val, dtype=dtype)
+    else:
+        X_data = np.array([x_val * (i + 1) for i in range(n_samples)], dtype=dtype)
+
+    H = np.ones((n_samples, 1), dtype=dtype)
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    state = PipelineState(X=X_data, H=H, curr_mixture=None, prev_mixture=None, error=None)
+
+    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+    assert "Overflow detected during Lmoments optimization" in str(state.error)
+    assert new_params == {}
+
+
+def test_lmoments_normal_handles_inf_lmoments_directly(parametrized_normal_setup):
+    """Directly tests the branch where computed l1 or l2 is infinite."""
     component, state, dtype = parametrized_normal_setup
-    val = dtype(10.0)
-    state.X = np.array([val, val, val], dtype=dtype)
-    state.H = np.ones((3, 1), dtype=dtype)
+
+    # Создаём искусственные данные, которые приведут к inf в l1 или l2
+    state.X = np.array([np.inf, 1.0, 2.0], dtype=dtype)
+    state.H = np.array([[1.0], [0.0], [0.0]], dtype=dtype)  # Только первая точка имеет вес
+
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+
+    # Должна быть установлена ошибка и возвращён пустой словарь
+    assert state.error is not None
+    assert isinstance(state.error, NumericalStabilityError)
+    assert new_params == {}
+
+
+def test_lmoments_normal_scale_clipping_to_epsilon(parametrized_normal_setup):
+    """Verifies that scale parameter is clipped to machine epsilon when L2 is near zero."""
+    component, state, dtype = parametrized_normal_setup
+
+    # Все точки одинаковые → L2 ≈ 0 → scale должен быть зажат снизу
+    val = dtype(5.0)
+    state.X = np.array([val, val, val, val], dtype=dtype)
+    state.H = np.ones((4, 1), dtype=dtype)
 
     block = OptimizationBlock(0, {"scale"}, MaximizationStrategy.LMOMENTS)
     _, new_params = lmoments_strategy(component, state, block, optimizer=None)
 
-    assert new_params[Normal.PARAM_SCALE] >= np.finfo(dtype).eps
+    expected_min = np.finfo(dtype).eps
+    assert new_params[Normal.PARAM_SCALE] >= expected_min
+    assert new_params[Normal.PARAM_SCALE] == pytest.approx(expected_min, rel=1e-6)
 
 
-@settings(max_examples=20, deadline=None)
-@given(mu=st.floats(min_value=-10, max_value=10), sigma=st.floats(min_value=1.0, max_value=5.0))
-def test_lmoments_normal_recovery_property(mu, sigma):
-    """
-    Свойство: на большой выборке взвешенные L-моменты должны
-    восстанавливать параметры mu и sigma.
-    """
-    dtype = np.float64
-    sample_size = 10000
+@st.composite
+def normal_data_and_true_params(draw, dtype_strategy=st.sampled_from([np.float64])):
+    """Generates true Normal parameters and a synthetic dataset with full responsibility."""
+    dtype = draw(dtype_strategy)
+    # Более консервативные диапазоны для стабильной оценки
+    true_loc = draw(st.floats(min_value=-20, max_value=20, allow_nan=False, allow_infinity=False))
+    true_scale = draw(st.floats(min_value=0.5, max_value=20.0, allow_nan=False, allow_infinity=False))
+    sample_size = draw(st.integers(min_value=8000, max_value=15000))  # Увеличил размер выборки
+
     rng = np.random.default_rng(42)
+    X = rng.normal(loc=true_loc, scale=true_scale, size=sample_size).astype(dtype)
+    return X, dtype(true_loc), dtype(true_scale), dtype
 
-    X = rng.normal(loc=mu, scale=sigma, size=sample_size).astype(dtype)
-    H = np.ones((sample_size, 1), dtype=dtype)  # Полная ответственность
 
-    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
+@settings(max_examples=50, deadline=None)
+@given(data=normal_data_and_true_params())
+def test_lmoments_normal_recovers_true_params_on_ideal_data(data):
+    """
+    Statistical sanity check: verifies that L-moments recover ground-truth
+    parameters when all responsibility belongs to a single component.
+
+    Note: Tolerances are adaptive to account for sampling variability that
+    scales with the true parameter values.
+    """
+    X, true_loc, true_scale, dtype = data
+
+    H = np.ones((len(X), 1), dtype=dtype)
+    start_component = Normal(loc=-999.0, scale=0.001, dtype=dtype)
+
     state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
     block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
 
-    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+    _, new_params = lmoments_strategy(start_component, state, block, optimizer=None)
 
-    assert new_params[Normal.PARAM_LOC] == pytest.approx(mu, abs=0.1)
-    assert new_params[Normal.PARAM_SCALE] == pytest.approx(sigma, rel=0.05)
+    # Адаптивные допуски: абсолютная погрешность растёт с true_scale
+    loc_atol = 0.3 + 0.02 * float(true_scale)  # ~0.3 базовая + 2% от scale
+    scale_rtol = 0.12 + 0.003 * float(true_scale)  # ~12% базовая + 0.3% от scale
+
+    assert new_params[Normal.PARAM_LOC] == pytest.approx(true_loc, abs=loc_atol)
+    assert new_params[Normal.PARAM_SCALE] == pytest.approx(true_scale, rel=scale_rtol)
+
+    assert isinstance(new_params[Normal.PARAM_LOC], dtype)
+    assert isinstance(new_params[Normal.PARAM_SCALE], dtype)

--- a/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
+++ b/tests/unit/estimators/iterative/_strategies/lmoments/test_normal_lmoments.py
@@ -1,0 +1,119 @@
+"""Tests for L-moments optimization strategy for Normal distribution"""
+
+__author__ = "Maksim Pastukhov"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import numpy as np
+import pytest
+from hypothesis import given, settings, strategies as st
+from pysatl_mpest.distributions import Normal
+from pysatl_mpest.estimators.iterative import MaximizationStrategy, OptimizationBlock, PipelineState
+# Импортируем именно lmoments_strategy
+from pysatl_mpest.estimators.iterative._strategies import lmoments_strategy
+
+DTYPES_TO_TEST = [np.float32, np.float64] # float16 часто недостаточно для точности L-моментов
+
+@pytest.fixture(params=DTYPES_TO_TEST)
+def parametrized_normal_setup(request):
+    dtype = request.param
+    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
+    
+    # Подготовим простые данные для базовых тестов
+    state = PipelineState(
+        X=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype),
+        H=np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4], [0.5, 0.5]], dtype=dtype),
+        prev_mixture=None, curr_mixture=None, error=None,
+    )
+    return component, state, dtype
+
+# --- Базовые тесты интерфейса ---
+
+def test_lmoments_normal_raises_value_error_if_h_is_none(parametrized_normal_setup):
+    normal_component, state, _ = parametrized_normal_setup
+    state.H = None
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+
+    with pytest.raises(ValueError, match="Responsibility matrix H is not computed."):
+        lmoments_strategy(normal_component, state, block, optimizer=None)
+
+def test_lmoments_normal_respects_fixed_params(parametrized_normal_setup):
+    normal_component, state, _ = parametrized_normal_setup
+    normal_component.fix_param("loc") # Фиксируем mu
+
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(normal_component, state, block, optimizer=None)
+
+    assert "loc" not in new_params
+    assert "scale" in new_params
+
+# --- Тест математической корректности (L-moments vs Normal) ---
+
+def test_lmoments_normal_calculation_correctness(parametrized_normal_setup):
+    """
+    Проверка конкретного примера.
+    Для данных [10, 20] с весами [0.5, 0.5]:
+    L1 = (10*0.5 + 20*0.5) / 1.0 = 15.0
+    rank_weights: 
+      w1 = (0.5 - 0.5*0.5)/1 = 0.25
+      w2 = (1.0 - 0.5*0.5)/1 = 0.75
+    b1 = (10*0.5*0.25 + 20*0.5*0.75) / 1.0 = 1.25 + 7.5 = 8.75
+    L2 = 2*8.75 - 15.0 = 2.5
+    Sigma = L2 * sqrt(pi) = 2.5 * 1.77245... = 4.4311...
+    """
+    component, state, dtype = parametrized_normal_setup
+    state.X = np.array([10.0, 20.0], dtype=dtype)
+    state.H = np.array([[0.5], [0.5]], dtype=dtype)
+
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+
+    expected_mu = 15.0
+    expected_sigma = 2.5 * np.sqrt(np.pi)
+
+    assert new_params[Normal.PARAM_LOC] == pytest.approx(expected_mu, rel=1e-4)
+    assert new_params[Normal.PARAM_SCALE] == pytest.approx(expected_sigma, rel=1e-4)
+
+# --- Тесты на стабильность ---
+
+def test_lmoments_normal_handles_zero_variance(parametrized_normal_setup):
+    """Если все точки одинаковые, L2 будет 0, sigma должна быть зажата eps."""
+    component, state, dtype = parametrized_normal_setup
+    val = dtype(10.0)
+    state.X = np.array([val, val, val], dtype=dtype)
+    state.H = np.ones((3, 1), dtype=dtype)
+
+    block = OptimizationBlock(0, {"scale"}, MaximizationStrategy.LMOMENTS)
+    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+
+    assert new_params[Normal.PARAM_SCALE] >= np.finfo(dtype).eps
+
+# --- Hypothesis: Восстановление параметров из выборки ---
+
+@settings(max_examples=20, deadline=None)
+@given(
+    mu=st.floats(min_value=-10, max_value=10),
+    sigma=st.floats(min_value=1.0, max_value=5.0)
+)
+def test_lmoments_normal_recovery_property(mu, sigma):
+    """
+    Свойство: на большой выборке взвешенные L-моменты должны 
+    восстанавливать параметры mu и sigma.
+    """
+    dtype = np.float64
+    sample_size = 10000
+    rng = np.random.default_rng(42)
+    
+    X = rng.normal(loc=mu, scale=sigma, size=sample_size).astype(dtype)
+    H = np.ones((sample_size, 1), dtype=dtype) # Полная ответственность
+    
+    component = Normal(loc=0.0, scale=1.0, dtype=dtype)
+    state = PipelineState(X=X, H=H, prev_mixture=None, curr_mixture=None, error=None)
+    block = OptimizationBlock(0, {"loc", "scale"}, MaximizationStrategy.LMOMENTS)
+    
+    _, new_params = lmoments_strategy(component, state, block, optimizer=None)
+    
+    # Для нормального распределения L-моменты очень эффективны, 
+    # поэтому точность должна быть высокой.
+    assert new_params[Normal.PARAM_LOC] == pytest.approx(mu, abs=0.1)
+    assert new_params[Normal.PARAM_SCALE] == pytest.approx(sigma, rel=0.05)


### PR DESCRIPTION
### L-Moments Maximization Strategy

- Implemented a new `lmoments_strategy` using `functools.singledispatch`, establishing a modular and extensible interface where each distribution can register its own L-moment parameter estimation logic.
- Added a specialized implementation for the `Normal` distribution, providing closed-form analytical updates based on the direct mathematical relationship between sample L-moments and distribution parameters (`loc = l1`, `scale = √π * l2`). The strategy seamlessly supports joint optimization of both parameters, as well as independent updates when either `loc` or `scale` is fixed.
- Integrated weighted sample L-moment calculations that utilize the responsibility matrix `H` from the E-step, ensuring full compatibility with the EM-framework while preserving the outlier robustness inherent to L-moments.

### Numerical Robustness and Stability

- Added explicit checks for numerical overflows in computed L-moments (`l1`, `l2`), gracefully handling invalid states and returning empty update dictionaries to prevent pipeline corruption.
- Implemented safeguards for negligible component responsibility (`N_j ≈ 0`), skipping parameter updates when a component lacks sufficient data support to avoid degenerate or unstable estimates.
- Enforced strict type consistency by casting all computed values back to the component's native `DType`, ensuring seamless interoperability across `float32` and `float64` execution paths.
- Applied lower-bound clipping for `scale` updates using machine epsilon (`np.finfo(dtype).eps`), guaranteeing positive variance estimates and preventing numerical breakdown during subsequent E-steps.

### Testing
- Added comprehensive unit tests covering correct parameter recovery, fixed-parameter scenarios, zero-variance edge cases, and overflow handling.
- Integrated hypothesis-based property tests to verify asymptotic consistency of L-moment estimates against ground-truth `mu` and `sigma` on large synthetic samples.

Closes #43 