### PR TITLE
chore: update python version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11", "3.12", "3.13" ]
+        python-version: [ "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install Poetry
         run: pip install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.11"
+python = ">=3.12"
 matplotlib = ">=3.10.0,<4.0.0"
 numpy = ">=2.2.3,<3.0.0"
 scikit-learn = ">=1.6.1,<2.0.0"


### PR DESCRIPTION
Bumps the minimum supported Python version to **3.12**. Python **3.11** support is dropped in order to adopt the new PEP 695 Type Parameter Syntax (the `type` statement) for declaring  generic type aliases in the codebase.
  
### Key Changes
1. **Dependencies:**
       - Updated Python requirement in `pyproject.toml` from `>=3.11` to `>=3.12`.
2. **CI/CD Workflows:**
       - Removed Python `3.11` from the test matrix in `.github/workflows/check.yml`.
       - Bumped the Python version to `3.12` in `.github/workflows/docs.yml`.