### PR TITLE
feat: introduce type aliases for numpy ndarrays

### DIFF
--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
+Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -1,6 +1,6 @@
 """A module that provides custom types for the project."""
 
-__author__ = "Aleksandra Ri, Viktor Khanukaev"
+__author__ = "Aleksandra Ri, Viktor Khanukaev, Totmyanin Danil"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,7 +9,18 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
-DType = TypeVar("DType", bound=np.floating)
+FloatingType = np.floating
+
+type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
+type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]
+type FloatArray[T: FloatingType] = np.ndarray[tuple[int, ...], np.dtype[T]]
+
+type UnivariateIntArray = np.ndarray[tuple[int], np.dtype[np.integer]]
+type IntArray = np.ndarray[tuple[int, ...], np.dtype[np.integer]]
+
+type BoolArray = np.ndarray[tuple[int, ...], np.dtype[np.bool_]]
+
+DType = TypeVar("DType", bound=FloatingType)
 
 
 @runtime_checkable

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -11,6 +11,7 @@ from numpy._typing import ArrayLike
 
 Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
+BoolScalar = bool | np.bool_
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
 type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]


### PR DESCRIPTION
This PR introduces custom type aliases for various NumPy ndarrays and updates the authors list in `typings.py`.

## Key Changes
- **Introduced PEP 695 type aliases** for specialized NumPy `ndarray` structures:
  - `UnivariateFloatArray[T]`: 1D float arrays.
  - `MultivariateFloatArray[T]`: 2D float arrays.
  - `FloatArray[T]`: $n$-dimensional float arrays.
  - `UnivariateIntArray`: 1D integer arrays.
  - `IntArray`: $n$-dimensional integer arrays.
  - `BoolArray`: $n$-dimensional boolean arrays.
- **Refactored `DType` TypeVar**: Extracted `FloatingType = np.floating` to improve readability and consistency.
- **Added new alias `Scalar`**: this will used for distribution parameters.
- **Added new alias `BoolScalar`**: which is equal with `bool | np.bool_`
- **Updated metadata**: Added `Totmyanin Danil` to the `__author__` list in [pysatl_mpest/typings.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/typings.py#L3)