### PR TITLE
feat: move all distributions to new types

### DIFF
--- a/pysatl_mpest/core/mixture.py
+++ b/pysatl_mpest/core/mixture.py
@@ -9,19 +9,19 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from scipy.special import logsumexp, softmax
 
-from ..typings import DType
+from ..typings import FloatArray, FloatingType, Scalar, UnivariateFloatArray
 
 if TYPE_CHECKING:
     from ..distributions import ContinuousDistribution
 
 
-class MixtureModel(Generic[DType]):
+class MixtureModel[FloatT: FloatingType]:
     """Represents a finite mixture of continuous probability distributions.
 
     This class encapsulates a collection of distribution components and their
@@ -42,21 +42,21 @@ class MixtureModel(Generic[DType]):
         An array of initial weights for the components. The weights must be
         positive and sum to 1. If None, components are assigned equal
         weights. Defaults to None.
-    dtype : type[DType], optional
+    dtype : type[FloatT], optional
         The numpy data type used for internal calculations and
         output arrays (e.g., `np.float32` or `np.float64`).
         Defaults to `np.float64`.
 
     Attributes
     ----------
-    components : tuple[ContinuousDistribution[DType], ...]
+    components : tuple[ContinuousDistribution[FloatT], ...]
         A tuple of the distribution objects that form the mixture.
     n_components : int
         The number of components in the mixture.
-    weights : NDArray[DType]
+    weights : UnivariateFloatArray[FloatT]
         A NumPy array of the normalized weights for each component. The sum
         of weights is always 1.
-    log_weights : NDArray[DType]
+    log_weights : UnivariateFloatArray[FloatT]
         A NumPy array of the natural logarithm of the component weights.
 
     Raises
@@ -79,13 +79,13 @@ class MixtureModel(Generic[DType]):
         generate
     """
 
-    _dtype: type[DType]
+    _dtype: type[FloatT]
 
     def __init__(
         self,
         components: Sequence["ContinuousDistribution"],
         weights: ArrayLike | None = None,
-        dtype: type[DType] = np.float64,  # type: ignore[assignment]
+        dtype: type[FloatT] = np.float64,  # type: ignore[assignment]
     ):
         n_components = len(components)
         if n_components == 0:
@@ -101,18 +101,18 @@ class MixtureModel(Generic[DType]):
 
         self._components = [comp.astype(self.dtype) for comp in components]
         self._log_weights = np.log(weights + np.finfo(self.dtype).tiny)
-        self._cached_weights: NDArray[DType] | None = None
+        self._cached_weights: UnivariateFloatArray[FloatT] | None = None
 
-        self._sorted_pairs_cache: list[tuple[ContinuousDistribution[DType], DType]] | None = None
+        self._sorted_pairs_cache: list[tuple[ContinuousDistribution[FloatT], FloatT]] | None = None
 
-    def _validate_weights(self, n_components: int, weights: NDArray[DType]):
+    def _validate_weights(self, n_components: int, weights: UnivariateFloatArray[FloatT]):
         """Validates the component weights.
 
         Parameters
         ----------
         n_components : int
             The expected number of components.
-        weights : NDArray[DType]
+        weights : NDArray[FloatT]
             The array of weights to validate.
 
         Raises
@@ -132,8 +132,8 @@ class MixtureModel(Generic[DType]):
             raise ValueError(f"Sum of the weights must be equal 1, but it equal {np.sum(weights)}.")
 
     @property
-    def dtype(self) -> type[DType]:
-        """type[DType]: The numpy data type of the mixture's outputs."""
+    def dtype(self) -> type[FloatT]:
+        """type[FloatT]: The numpy data type of the mixture's outputs."""
 
         return self._dtype
 
@@ -145,13 +145,13 @@ class MixtureModel(Generic[DType]):
 
     @property
     def components(self):
-        """tuple[ContinuousDistribution[DType], ...]: The components of the mixture."""
+        """tuple[ContinuousDistribution[FloatT], ...]: The components of the mixture."""
 
         return tuple(self._components)
 
     @property
-    def weights(self) -> NDArray[DType]:
-        """NDArray[DType]: The normalized weights of the components.
+    def weights(self) -> UnivariateFloatArray[FloatT]:
+        """UnivariateFloatArray[FloatT]: The normalized weights of the components.
 
         The weights are computed from the log-weights using the softmax
         function and cached for efficiency.
@@ -163,8 +163,8 @@ class MixtureModel(Generic[DType]):
         return self._cached_weights  # type: ignore
 
     @property
-    def log_weights(self) -> NDArray[DType]:
-        """NDArray[DType]: The logarithm of the component weights."""
+    def log_weights(self) -> UnivariateFloatArray[FloatT]:
+        """UnivariateFloatArray[FloatT]: The logarithm of the component weights."""
 
         return self._log_weights
 
@@ -192,7 +192,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def add_component(self, component: "ContinuousDistribution", weight: float):
+    def add_component(self, component: "ContinuousDistribution", weight: Scalar):
         """Adds a new component to the mix, preserving the proportions of the existing component weights.
 
         If :attr:`weight` is specified for the new component, the old component
@@ -202,7 +202,7 @@ class MixtureModel(Generic[DType]):
         ----------
         component : ContinuousDistribution
             The distribution component to add.
-        weight : float
+        weight : Scalar
             The weight for the new component, a number in the range (0, 1).
 
         Raises
@@ -255,7 +255,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Probability Density Function of the mixture.
 
         The PDF is computed as the weighted sum of the PDFs of its
@@ -268,7 +268,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -276,7 +276,7 @@ class MixtureModel(Generic[DType]):
         X = np.asarray(X, dtype=self.dtype)
         return np.exp(self.lpdf(X))
 
-    def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Logarithms of the Probability Density Function.
 
         Parameters
@@ -286,7 +286,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -303,7 +303,7 @@ class MixtureModel(Generic[DType]):
             return result[()]
         return result
 
-    def loglikelihood(self, X: ArrayLike) -> DType:
+    def loglikelihood(self, X: ArrayLike) -> FloatT:
         """Log-likelihood of the complete data :attr:`X`.
 
         The log-likelihood is the sum of the log-PDF values for all data
@@ -316,14 +316,14 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType
+        FloatT
             The total log-likelihood value.
         """
 
         X = np.asarray(X, dtype=self.dtype)
         return np.sum(self.lpdf(X))
 
-    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> FloatT | FloatArray[FloatT]:
         """Generates random samples from the mixture model.
 
         First, a component is chosen based on the mixture weights. Then, a
@@ -340,7 +340,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A NumPy array containing the generated samples. Returns an
             empty array if :attr:`size` is not positive.
         """
@@ -370,7 +370,7 @@ class MixtureModel(Generic[DType]):
         target_shape = (size,) if isinstance(size, int) else size
         return samples.reshape(target_shape)
 
-    def astype(self, new_dtype: type[DType]) -> "MixtureModel[DType]":
+    def astype[NewFloatT: FloatingType](self, new_dtype: type[NewFloatT]) -> "MixtureModel[NewFloatT]":
         """Creates a copy of the MixtureModel with a new data type.
 
         If the specified `new_dtype` is the same as the instance's current `dtype`,
@@ -378,23 +378,23 @@ class MixtureModel(Generic[DType]):
 
         Parameters
         ----------
-        new_dtype : type[DType]
+        new_dtype : type[NewFloatT]
             The target NumPy data type for the new distribution instance.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[NewFloatT]
             A new MixtureModel instance with all components and weights converted to the
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
         if self.dtype is new_dtype:
-            return self
+            return self  # type: ignore[return-value]
 
         new_mixture = MixtureModel(components=self.components, weights=self.weights.copy(), dtype=new_dtype)
         return new_mixture
 
-    def __getitem__(self, key: int) -> "ContinuousDistribution[DType]":
+    def __getitem__(self, key: int) -> "ContinuousDistribution[FloatT]":
         """Retrieves components by index.
 
         Parameters
@@ -404,13 +404,13 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[FloatT]
             A single component of the mixture
         """
 
         return self.components[key]
 
-    def __iter__(self) -> Iterator["ContinuousDistribution[DType]"]:
+    def __iter__(self) -> Iterator["ContinuousDistribution[FloatT]"]:
         """Returns an iterator over the mixture components.
 
         This allows the `MixtureModel` instance to be used directly in
@@ -418,18 +418,18 @@ class MixtureModel(Generic[DType]):
 
         Yields
         ------
-        Iterator[ContinuousDistribution[DType]
+        Iterator[ContinuousDistribution[FloatT]
             An iterator that yields the components of the mixture model.
         """
 
         return iter(self.components)
 
-    def __copy__(self) -> "MixtureModel[DType]":
+    def __copy__(self) -> "MixtureModel[FloatT]":
         """Creates a copy of the mixture model instance.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             A new instance of the distribution, identical to the original.
         """
 
@@ -437,7 +437,7 @@ class MixtureModel(Generic[DType]):
         new_mixture = MixtureModel(components=copied_components, weights=self.weights.copy(), dtype=self.dtype)
         return new_mixture
 
-    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution[DType]", DType]]:
+    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution[FloatT]", FloatT]]:
         """Internal helper to get component-weight pairs, sorted by component hash."""
 
         if self._sorted_pairs_cache is None or for_hashing:

--- a/pysatl_mpest/core/parameter.py
+++ b/pysatl_mpest/core/parameter.py
@@ -17,7 +17,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ..distributions.continuous_dist import ContinuousDistribution
-from ..typings import DType
+from ..typings import BoolScalar, FloatingType, Scalar
 
 
 class Parameter:
@@ -30,7 +30,7 @@ class Parameter:
 
     Parameters
     ----------
-    invariant : Callable[[float], bool], optional
+    invariant : Callable[[Scalar], BoolScalar], optional
         A predicate function for validating parameter values.
         Defaults to `lambda x: True`.
     error_message : str, optional
@@ -39,7 +39,7 @@ class Parameter:
 
     Attributes
     ----------
-    invariant : Callable[[float], bool]
+    invariant : Callable[[Scalar], BoolScalar]
         A function that checks if the parameter value is valid.
         Returns True if the value is correct, and False otherwise.
     error_message : str
@@ -65,13 +65,13 @@ class Parameter:
 
     def __init__(
         self,
-        invariant: Callable[[float], bool] = lambda x: True,
+        invariant: Callable[[Scalar], BoolScalar] = lambda x: True,
         error_message: str = "Parameter value is not valid.",
     ):
         self.invariant = invariant
         self.error_message = error_message
 
-    def __set_name__(self, owner: type["ContinuousDistribution[DType]"], name: str):
+    def __set_name__[FloatT: FloatingType](self, owner: type["ContinuousDistribution[FloatT]"], name: str):
         """Sets the name for the public and private attributes.
 
         This method is automatically called when a descriptor instance is created
@@ -90,16 +90,20 @@ class Parameter:
         self.private_name = "_" + name
 
     @overload
-    def __get__(self, instance: None, owner: type["ContinuousDistribution[DType]"]) -> "Parameter":
+    def __get__[FloatT: FloatingType](
+        self, instance: None, owner: type["ContinuousDistribution[FloatT]"]
+    ) -> "Parameter":
         """If access is via a class, return the descriptor object itself."""
 
     @overload
-    def __get__(self, instance: "ContinuousDistribution[DType]", owner: type["ContinuousDistribution[DType]"]) -> DType:
+    def __get__[FloatT: FloatingType](
+        self, instance: "ContinuousDistribution[FloatT]", owner: type["ContinuousDistribution[FloatT]"]
+    ) -> FloatT:
         """If access is via an object, return the value."""
 
-    def __get__(
-        self, instance: Optional["ContinuousDistribution[DType]"], owner: type["ContinuousDistribution[DType]"]
-    ) -> Union[DType, "Parameter"]:
+    def __get__[FloatT: FloatingType](
+        self, instance: Optional["ContinuousDistribution[FloatT]"], owner: type["ContinuousDistribution[FloatT]"]
+    ) -> Union[FloatT, "Parameter"]:
         """Returns the parameter value or the descriptor itself.
 
         If access is through an instance of the class, it returns the
@@ -116,7 +120,7 @@ class Parameter:
 
         Returns
         -------
-        DType or Parameter
+        FloatT or Parameter
             The value of the parameter or the descriptor itself.
         """
 
@@ -125,7 +129,7 @@ class Parameter:
 
         return getattr(instance, self.private_name)
 
-    def __set__(self, instance: "ContinuousDistribution[DType]", value: float):
+    def __set__[FloatT: FloatingType](self, instance: "ContinuousDistribution[FloatT]", value: Scalar):
         """Sets the parameter value after validation.
 
         Before setting a new value, it checks whether the parameter is
@@ -133,9 +137,9 @@ class Parameter:
 
         Parameters
         ----------
-        instance : "ContinuousDistribution[DType]"
+        instance : "ContinuousDistribution[FloatT]"
             An instance of the owner class.
-        value : float
+        value : Scalar
             The new value for the parameter.
 
         Raises

--- a/pysatl_mpest/distributions/beta.py
+++ b/pysatl_mpest/distributions/beta.py
@@ -10,11 +10,11 @@ from scipy.special import digamma
 from scipy.stats import beta as beta_dist
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Beta(ContinuousDistribution):
+class Beta[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the four-parameteric beta distribution.
        Parameters
        ----------
@@ -67,7 +67,7 @@ class Beta(ContinuousDistribution):
         beta: float,
         left_border: float,
         right_border: float,
-        dtype: type[DType] = np.float64,  # type: ignore[assignment]
+        dtype: type[FloatT] = np.float64,  # type: ignore[assignment]
     ):
         super().__init__(dtype=dtype)
         if left_border >= right_border:
@@ -109,7 +109,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
 
@@ -139,7 +139,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -186,7 +186,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -227,7 +227,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`alpha` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -272,7 +272,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`beta` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -315,7 +315,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -359,7 +359,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -394,7 +394,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -436,7 +436,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/cauchy.py
+++ b/pysatl_mpest/distributions/cauchy.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import cauchy
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Cauchy(ContinuousDistribution[DType]):
+class Cauchy[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter cauchy distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Cauchy(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0.0, "Scale parameter should be positive")
 
-    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
@@ -82,7 +82,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -109,7 +109,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -150,7 +150,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -190,8 +190,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`loc` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -225,8 +225,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -254,7 +254,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -294,7 +294,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/continuous_dist.py
+++ b/pysatl_mpest/distributions/continuous_dist.py
@@ -8,15 +8,14 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
-from ..typings import DType
+from ..typings import FloatArray, FloatingType
 
 
-class ContinuousDistribution(ABC, Generic[DType]):
+class ContinuousDistribution[FloatT: FloatingType](ABC):
     """Abstract base class for continuous distributions.
 
     This class defines the basic mathematical functions of distributions
@@ -88,16 +87,16 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
     """
 
-    _dtype: type[DType]
+    _dtype: type[FloatT]
 
-    def __init__(self, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         """This constructor must be called by all descendants to ensure
         proper initialization of common attributes like `fixed_params`
         and `dtype`.
 
         Parameters
         ----------
-        dtype : Type[DType], optional
+        dtype : Type[FloatT], optional
             The numpy data type used for internal calculations and
             output arrays (e.g., `np.float32` or `np.float64`).
             Defaults to `np.float64`.
@@ -138,7 +137,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         self._fixed_params.discard(name)
 
-    def get_params_vector(self, param_names: Sequence[str]) -> list[DType]:
+    def get_params_vector(self, param_names: Sequence[str]) -> list[FloatT]:
         """Retrieves specified parameter values as a list.
 
         Parameters
@@ -165,7 +164,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         return [getattr(self, name) for name in param_names]
 
-    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float | DType]):
+    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float | FloatT]):
         """Sets parameter values from a sequence of floats.
 
         Updates the distribution's parameters using values from the provided
@@ -200,8 +199,8 @@ class ContinuousDistribution(ABC, Generic[DType]):
             setattr(self, name, self.dtype(value))
 
     @property
-    def dtype(self) -> type[DType]:
-        """type[DType]: The numpy data type of the distribution's outputs."""
+    def dtype(self) -> type[FloatT]:
+        """type[FloatT]: The numpy data type of the distribution's outputs."""
 
         return self._dtype
 
@@ -222,7 +221,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         return self.params - self._fixed_params
 
     @abstractmethod
-    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Probability Density Function.
 
         Parameters
@@ -232,13 +231,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def ppf(self, P: ArrayLike) -> NDArray[DType]:
+    def ppf(self, P: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Percent Point Function (PPF) or quantile function.
 
         This is the inverse of the Cumulative Distribution Function (CDF).
@@ -251,13 +250,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Logarithm of the Probability Density Function.
 
         Evaluating the log-PDF is often more numerically stable than
@@ -271,13 +270,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def log_gradients(self, X: ArrayLike) -> NDArray[DType]:
+    def log_gradients(self, X: ArrayLike) -> FloatArray[FloatT]:
         """Calculates the gradients of the log-PDF with respect to its parameters.
 
         The gradients are computed for the parameters that are not fixed.
@@ -289,7 +288,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X` and
             each column corresponds to the gradient with respect to a specific
             optimizable parameter. The order of columns corresponds to the
@@ -297,7 +296,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         """
 
     @abstractmethod
-    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> FloatT | FloatArray[FloatT]:
         """Generates random samples from the distribution.
 
         Parameters
@@ -310,11 +309,11 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 
-    def astype(self, new_dtype: type[DType]) -> "ContinuousDistribution[DType]":
+    def astype[NewFloatT: FloatingType](self, new_dtype: type[NewFloatT]) -> "ContinuousDistribution[NewFloatT]":
         """Creates a copy of the distribution with a new data type.
 
         If the specified `new_dtype` is the same as the instance's current `dtype`,
@@ -322,33 +321,33 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Parameters
         ----------
-        new_dtype : type[DType]
+        new_dtype : type[NewFloatT]
             The target NumPy data type for the new distribution instance.
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[NewFloatT]
             A new distribution instance with all parameters converted to the
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
 
         if self._dtype is new_dtype:
-            return self
+            return self  # type: ignore[return-value]
 
         params_dict = {p: new_dtype(getattr(self, p)) for p in self.params}
 
-        new_instance = self.__class__(**params_dict, dtype=new_dtype)
+        new_instance = self.__class__(**params_dict, dtype=new_dtype)  # type: ignore[arg-type]
         new_instance._fixed_params = self._fixed_params.copy()
 
-        return new_instance
+        return new_instance  # type: ignore[return-value]
 
-    def __copy__(self) -> "ContinuousDistribution[DType]":
+    def __copy__(self) -> "ContinuousDistribution[FloatT]":
         """Creates a copy of the distribution instance.
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[FloatT]
             A new instance of the distribution, identical to the original.
         """
 

--- a/pysatl_mpest/distributions/exponential.py
+++ b/pysatl_mpest/distributions/exponential.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import expon
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Exponential(ContinuousDistribution[DType]):
+class Exponential[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter exponential distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Exponential(ContinuousDistribution[DType]):
     loc = Parameter()
     rate = Parameter(lambda x: x > 0, "Rate parameter must be a positive")
 
-    def __init__(self, loc: float, rate: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, rate: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.rate = rate
@@ -82,7 +82,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
@@ -105,7 +105,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -135,7 +135,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -167,8 +167,8 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`loc` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -199,7 +199,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -225,7 +225,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -265,7 +265,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/normal.py
+++ b/pysatl_mpest/distributions/normal.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import norm
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Normal(ContinuousDistribution[DType]):
+class Normal[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the Normal (Gaussian) distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Normal(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
@@ -83,7 +83,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -105,7 +105,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -135,7 +135,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -186,7 +186,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -228,7 +228,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/pareto.py
+++ b/pysatl_mpest/distributions/pareto.py
@@ -10,10 +10,10 @@ from scipy.stats import pareto
 
 from ..core.parameter import Parameter
 from ..distributions.continuous_dist import ContinuousDistribution
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class Pareto(ContinuousDistribution[DType]):
+class Pareto[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter Pareto distribution.
 
     The Pareto distribution is a power-law probability distribution commonly used
@@ -53,7 +53,7 @@ class Pareto(ContinuousDistribution[DType]):
     shape = Parameter(lambda x: x > 0, "Shape parameter must be a positive")
     scale = Parameter(lambda x: x > 0, "Scale parameter must be a positive")
 
-    def __init__(self, shape: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, shape: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.shape = shape
         self.scale = scale
@@ -85,7 +85,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -109,7 +109,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -143,7 +143,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -182,7 +182,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`shape` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -216,7 +216,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -242,7 +242,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -282,7 +282,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/uniform.py
+++ b/pysatl_mpest/distributions/uniform.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import uniform
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Uniform(ContinuousDistribution[DType]):
+class Uniform[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """
     The Uniform continuous probability distribution.
 
@@ -60,7 +60,7 @@ class Uniform(ContinuousDistribution[DType]):
     left_border = Parameter()
     right_border = Parameter()
 
-    def __init__(self, left_border: float, right_border: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, left_border: float, right_border: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         if left_border >= right_border:
             raise ValueError("right_border parameter must be strictly greater than left_border")
@@ -97,7 +97,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -124,7 +124,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -161,7 +161,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -195,7 +195,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -228,7 +228,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -256,7 +256,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -296,7 +296,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/weibull.py
+++ b/pysatl_mpest/distributions/weibull.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import weibull_min
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Weibull(ContinuousDistribution[DType]):
+class Weibull[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the three-parameter Weibull distribution.
 
     Parameters
@@ -55,7 +55,7 @@ class Weibull(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, shape: float, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, shape: float, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.shape = shape
         self.loc = loc
@@ -91,7 +91,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -116,7 +116,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -150,7 +150,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -238,7 +238,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -279,7 +279,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/estimators/base_estimator.py
+++ b/pysatl_mpest/estimators/base_estimator.py
@@ -5,15 +5,14 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
-from typing import Generic
 
 from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class BaseEstimator(ABC, Generic[DType]):
+class BaseEstimator[FloatT: FloatingType](ABC):
     """Abstract class for a mixture model parameter estimator.
 
     This class defines the interface for all estimator algorithms. Estimators are responsible for
@@ -37,7 +36,7 @@ class BaseEstimator(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def fit(self, X: ArrayLike, mixture: MixtureModel[DType]) -> MixtureModel[DType]:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[FloatT]) -> MixtureModel[FloatT]:
         """Fits the mixture model to the provided data.
 
         This method estimates the parameters of the model's components and their
@@ -47,11 +46,11 @@ class BaseEstimator(ABC, Generic[DType]):
         ----------
         X : ArrayLike
             The input data sample for fitting the model.
-        mixture : MixtureModel[DType]
+        mixture : MixtureModel[FloatT]
             The initial mixture model to be fitted.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             The mixture model with estimated parameters.
         """

--- a/pysatl_mpest/optimizers/optimizer.py
+++ b/pysatl_mpest/optimizers/optimizer.py
@@ -12,12 +12,11 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Generic
 
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class Optimizer(ABC, Generic[DType]):
+class Optimizer[FloatT: FloatingType](ABC):
     """Abstract base class for numerical optimizers.
 
     This class defines the standard interface for all optimizer implementations.
@@ -36,7 +35,7 @@ class Optimizer(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
+    def minimize(self, target: Callable, params: list[FloatT]) -> list[FloatT]:
         """Finds the parameters that minimize a target function.
 
         This abstract method must be implemented by subclasses to perform the
@@ -48,7 +47,7 @@ class Optimizer(ABC, Generic[DType]):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[DType]
+        params : list[FloatT]
             A list of initial values for the parameters to be optimized. This
             serves as the starting point for the optimization algorithm.
 

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
+Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -1,6 +1,6 @@
 """A module that provides custom types for the project."""
 
-__author__ = "Aleksandra Ri, Viktor Khanukaev"
+__author__ = "Aleksandra Ri, Viktor Khanukaev, Totmyanin Danil"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,7 +9,18 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
-DType = TypeVar("DType", bound=np.floating)
+FloatingType = np.floating
+
+type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
+type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]
+type FloatArray[T: FloatingType] = np.ndarray[tuple[int, ...], np.dtype[T]]
+
+type UnivariateIntArray = np.ndarray[tuple[int], np.dtype[np.integer]]
+type IntArray = np.ndarray[tuple[int, ...], np.dtype[np.integer]]
+
+type BoolArray = np.ndarray[tuple[int, ...], np.dtype[np.bool_]]
+
+DType = TypeVar("DType", bound=FloatingType)
 
 
 @runtime_checkable

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -11,6 +11,7 @@ from numpy._typing import ArrayLike
 
 Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
+BoolScalar = bool | np.bool_
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
 type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]


### PR DESCRIPTION
This PR refactors the typing in the `distributions` module to adopt the new Python 3.12 generics syntax and align with the updated custom type definitions (`FloatingType`, `FloatT`, and `FloatArray[FloatT]`).

## Changes
- **Typing Refactoring**: Replaced the legacy `DType` and `NDArray[DType]` type hints with `FloatingType` and `FloatArray[FloatT]`.
- **PEP 695 Generics**: Adopted the new Python 3.12 type parameter syntax for all distribution classes (e.g., `class Beta[FloatT: FloatingType](ContinuousDistribution[FloatT])`).
- **Signature Updates**: Correctly annotated `dtype` parameters in `__init__` methods as `type[FloatT] = np.float64`.
- **Docstrings Alignment**:
  - Updated return types in docstrings from `NDArray[DType]` and `DType | NDArray[DType]` to `FloatT | FloatArray[FloatT]` across all continuous distributions.
  - Fixed pre-existing minor typos in docstrings (e.g., incorrect Sphinx RST syntax `::attr`X`` fixed to `:attr:\`X\``).
  - Fixed a copy-paste error in `Cauchy` gradient docstrings where the parameter was incorrectly referred to as `rate` instead of `scale`.

## Affected distributions
- `Beta`
- `Cauchy`
- `Exponential`
- `Normal`
- `Pareto`
- `Uniform`
- `Weibull`
