### PR TITLE
feat: move estimators module to new typehints

### DIFF
--- a/pysatl_mpest/core/mixture.py
+++ b/pysatl_mpest/core/mixture.py
@@ -9,19 +9,19 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from scipy.special import logsumexp, softmax
 
-from ..typings import DType
+from ..typings import FloatArray, FloatingType, Scalar, UnivariateFloatArray
 
 if TYPE_CHECKING:
     from ..distributions import ContinuousDistribution
 
 
-class MixtureModel(Generic[DType]):
+class MixtureModel[FloatT: FloatingType]:
     """Represents a finite mixture of continuous probability distributions.
 
     This class encapsulates a collection of distribution components and their
@@ -42,21 +42,21 @@ class MixtureModel(Generic[DType]):
         An array of initial weights for the components. The weights must be
         positive and sum to 1. If None, components are assigned equal
         weights. Defaults to None.
-    dtype : type[DType], optional
+    dtype : type[FloatT], optional
         The numpy data type used for internal calculations and
         output arrays (e.g., `np.float32` or `np.float64`).
         Defaults to `np.float64`.
 
     Attributes
     ----------
-    components : tuple[ContinuousDistribution[DType], ...]
+    components : tuple[ContinuousDistribution[FloatT], ...]
         A tuple of the distribution objects that form the mixture.
     n_components : int
         The number of components in the mixture.
-    weights : NDArray[DType]
+    weights : UnivariateFloatArray[FloatT]
         A NumPy array of the normalized weights for each component. The sum
         of weights is always 1.
-    log_weights : NDArray[DType]
+    log_weights : UnivariateFloatArray[FloatT]
         A NumPy array of the natural logarithm of the component weights.
 
     Raises
@@ -79,13 +79,13 @@ class MixtureModel(Generic[DType]):
         generate
     """
 
-    _dtype: type[DType]
+    _dtype: type[FloatT]
 
     def __init__(
         self,
         components: Sequence["ContinuousDistribution"],
         weights: ArrayLike | None = None,
-        dtype: type[DType] = np.float64,  # type: ignore[assignment]
+        dtype: type[FloatT] = np.float64,  # type: ignore[assignment]
     ):
         n_components = len(components)
         if n_components == 0:
@@ -101,18 +101,18 @@ class MixtureModel(Generic[DType]):
 
         self._components = [comp.astype(self.dtype) for comp in components]
         self._log_weights = np.log(weights + np.finfo(self.dtype).tiny)
-        self._cached_weights: NDArray[DType] | None = None
+        self._cached_weights: UnivariateFloatArray[FloatT] | None = None
 
-        self._sorted_pairs_cache: list[tuple[ContinuousDistribution[DType], DType]] | None = None
+        self._sorted_pairs_cache: list[tuple[ContinuousDistribution[FloatT], FloatT]] | None = None
 
-    def _validate_weights(self, n_components: int, weights: NDArray[DType]):
+    def _validate_weights(self, n_components: int, weights: UnivariateFloatArray[FloatT]):
         """Validates the component weights.
 
         Parameters
         ----------
         n_components : int
             The expected number of components.
-        weights : NDArray[DType]
+        weights : NDArray[FloatT]
             The array of weights to validate.
 
         Raises
@@ -132,8 +132,8 @@ class MixtureModel(Generic[DType]):
             raise ValueError(f"Sum of the weights must be equal 1, but it equal {np.sum(weights)}.")
 
     @property
-    def dtype(self) -> type[DType]:
-        """type[DType]: The numpy data type of the mixture's outputs."""
+    def dtype(self) -> type[FloatT]:
+        """type[FloatT]: The numpy data type of the mixture's outputs."""
 
         return self._dtype
 
@@ -145,13 +145,13 @@ class MixtureModel(Generic[DType]):
 
     @property
     def components(self):
-        """tuple[ContinuousDistribution[DType], ...]: The components of the mixture."""
+        """tuple[ContinuousDistribution[FloatT], ...]: The components of the mixture."""
 
         return tuple(self._components)
 
     @property
-    def weights(self) -> NDArray[DType]:
-        """NDArray[DType]: The normalized weights of the components.
+    def weights(self) -> UnivariateFloatArray[FloatT]:
+        """UnivariateFloatArray[FloatT]: The normalized weights of the components.
 
         The weights are computed from the log-weights using the softmax
         function and cached for efficiency.
@@ -163,8 +163,8 @@ class MixtureModel(Generic[DType]):
         return self._cached_weights  # type: ignore
 
     @property
-    def log_weights(self) -> NDArray[DType]:
-        """NDArray[DType]: The logarithm of the component weights."""
+    def log_weights(self) -> UnivariateFloatArray[FloatT]:
+        """UnivariateFloatArray[FloatT]: The logarithm of the component weights."""
 
         return self._log_weights
 
@@ -192,7 +192,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def add_component(self, component: "ContinuousDistribution", weight: float):
+    def add_component(self, component: "ContinuousDistribution", weight: Scalar):
         """Adds a new component to the mix, preserving the proportions of the existing component weights.
 
         If :attr:`weight` is specified for the new component, the old component
@@ -202,7 +202,7 @@ class MixtureModel(Generic[DType]):
         ----------
         component : ContinuousDistribution
             The distribution component to add.
-        weight : float
+        weight : Scalar
             The weight for the new component, a number in the range (0, 1).
 
         Raises
@@ -255,7 +255,7 @@ class MixtureModel(Generic[DType]):
         self._cached_weights = None
         self._sorted_pairs_cache = None
 
-    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Probability Density Function of the mixture.
 
         The PDF is computed as the weighted sum of the PDFs of its
@@ -268,7 +268,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -276,7 +276,7 @@ class MixtureModel(Generic[DType]):
         X = np.asarray(X, dtype=self.dtype)
         return np.exp(self.lpdf(X))
 
-    def lpdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Logarithms of the Probability Density Function.
 
         Parameters
@@ -286,7 +286,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -303,7 +303,7 @@ class MixtureModel(Generic[DType]):
             return result[()]
         return result
 
-    def loglikelihood(self, X: ArrayLike) -> DType:
+    def loglikelihood(self, X: ArrayLike) -> FloatT:
         """Log-likelihood of the complete data :attr:`X`.
 
         The log-likelihood is the sum of the log-PDF values for all data
@@ -316,14 +316,14 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType
+        FloatT
             The total log-likelihood value.
         """
 
         X = np.asarray(X, dtype=self.dtype)
         return np.sum(self.lpdf(X))
 
-    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> FloatT | FloatArray[FloatT]:
         """Generates random samples from the mixture model.
 
         First, a component is chosen based on the mixture weights. Then, a
@@ -340,7 +340,7 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A NumPy array containing the generated samples. Returns an
             empty array if :attr:`size` is not positive.
         """
@@ -370,7 +370,7 @@ class MixtureModel(Generic[DType]):
         target_shape = (size,) if isinstance(size, int) else size
         return samples.reshape(target_shape)
 
-    def astype(self, new_dtype: type[DType]) -> "MixtureModel[DType]":
+    def astype[NewFloatT: FloatingType](self, new_dtype: type[NewFloatT]) -> "MixtureModel[NewFloatT]":
         """Creates a copy of the MixtureModel with a new data type.
 
         If the specified `new_dtype` is the same as the instance's current `dtype`,
@@ -378,23 +378,23 @@ class MixtureModel(Generic[DType]):
 
         Parameters
         ----------
-        new_dtype : type[DType]
+        new_dtype : type[NewFloatT]
             The target NumPy data type for the new distribution instance.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[NewFloatT]
             A new MixtureModel instance with all components and weights converted to the
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
         if self.dtype is new_dtype:
-            return self
+            return self  # type: ignore[return-value]
 
         new_mixture = MixtureModel(components=self.components, weights=self.weights.copy(), dtype=new_dtype)
         return new_mixture
 
-    def __getitem__(self, key: int) -> "ContinuousDistribution[DType]":
+    def __getitem__(self, key: int) -> "ContinuousDistribution[FloatT]":
         """Retrieves components by index.
 
         Parameters
@@ -404,13 +404,13 @@ class MixtureModel(Generic[DType]):
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[FloatT]
             A single component of the mixture
         """
 
         return self.components[key]
 
-    def __iter__(self) -> Iterator["ContinuousDistribution[DType]"]:
+    def __iter__(self) -> Iterator["ContinuousDistribution[FloatT]"]:
         """Returns an iterator over the mixture components.
 
         This allows the `MixtureModel` instance to be used directly in
@@ -418,18 +418,18 @@ class MixtureModel(Generic[DType]):
 
         Yields
         ------
-        Iterator[ContinuousDistribution[DType]
+        Iterator[ContinuousDistribution[FloatT]
             An iterator that yields the components of the mixture model.
         """
 
         return iter(self.components)
 
-    def __copy__(self) -> "MixtureModel[DType]":
+    def __copy__(self) -> "MixtureModel[FloatT]":
         """Creates a copy of the mixture model instance.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             A new instance of the distribution, identical to the original.
         """
 
@@ -437,7 +437,7 @@ class MixtureModel(Generic[DType]):
         new_mixture = MixtureModel(components=copied_components, weights=self.weights.copy(), dtype=self.dtype)
         return new_mixture
 
-    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution[DType]", DType]]:
+    def _get_sorted_pairs(self, for_hashing: bool = False) -> list[tuple["ContinuousDistribution[FloatT]", FloatT]]:
         """Internal helper to get component-weight pairs, sorted by component hash."""
 
         if self._sorted_pairs_cache is None or for_hashing:

--- a/pysatl_mpest/core/parameter.py
+++ b/pysatl_mpest/core/parameter.py
@@ -17,7 +17,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ..distributions.continuous_dist import ContinuousDistribution
-from ..typings import DType
+from ..typings import BoolScalar, FloatingType, Scalar
 
 
 class Parameter:
@@ -30,7 +30,7 @@ class Parameter:
 
     Parameters
     ----------
-    invariant : Callable[[float], bool], optional
+    invariant : Callable[[Scalar], BoolScalar], optional
         A predicate function for validating parameter values.
         Defaults to `lambda x: True`.
     error_message : str, optional
@@ -39,7 +39,7 @@ class Parameter:
 
     Attributes
     ----------
-    invariant : Callable[[float], bool]
+    invariant : Callable[[Scalar], BoolScalar]
         A function that checks if the parameter value is valid.
         Returns True if the value is correct, and False otherwise.
     error_message : str
@@ -65,13 +65,13 @@ class Parameter:
 
     def __init__(
         self,
-        invariant: Callable[[float], bool] = lambda x: True,
+        invariant: Callable[[Scalar], BoolScalar] = lambda x: True,
         error_message: str = "Parameter value is not valid.",
     ):
         self.invariant = invariant
         self.error_message = error_message
 
-    def __set_name__(self, owner: type["ContinuousDistribution[DType]"], name: str):
+    def __set_name__[FloatT: FloatingType](self, owner: type["ContinuousDistribution[FloatT]"], name: str):
         """Sets the name for the public and private attributes.
 
         This method is automatically called when a descriptor instance is created
@@ -90,16 +90,20 @@ class Parameter:
         self.private_name = "_" + name
 
     @overload
-    def __get__(self, instance: None, owner: type["ContinuousDistribution[DType]"]) -> "Parameter":
+    def __get__[FloatT: FloatingType](
+        self, instance: None, owner: type["ContinuousDistribution[FloatT]"]
+    ) -> "Parameter":
         """If access is via a class, return the descriptor object itself."""
 
     @overload
-    def __get__(self, instance: "ContinuousDistribution[DType]", owner: type["ContinuousDistribution[DType]"]) -> DType:
+    def __get__[FloatT: FloatingType](
+        self, instance: "ContinuousDistribution[FloatT]", owner: type["ContinuousDistribution[FloatT]"]
+    ) -> FloatT:
         """If access is via an object, return the value."""
 
-    def __get__(
-        self, instance: Optional["ContinuousDistribution[DType]"], owner: type["ContinuousDistribution[DType]"]
-    ) -> Union[DType, "Parameter"]:
+    def __get__[FloatT: FloatingType](
+        self, instance: Optional["ContinuousDistribution[FloatT]"], owner: type["ContinuousDistribution[FloatT]"]
+    ) -> Union[FloatT, "Parameter"]:
         """Returns the parameter value or the descriptor itself.
 
         If access is through an instance of the class, it returns the
@@ -116,7 +120,7 @@ class Parameter:
 
         Returns
         -------
-        DType or Parameter
+        FloatT or Parameter
             The value of the parameter or the descriptor itself.
         """
 
@@ -125,7 +129,7 @@ class Parameter:
 
         return getattr(instance, self.private_name)
 
-    def __set__(self, instance: "ContinuousDistribution[DType]", value: float):
+    def __set__[FloatT: FloatingType](self, instance: "ContinuousDistribution[FloatT]", value: Scalar):
         """Sets the parameter value after validation.
 
         Before setting a new value, it checks whether the parameter is
@@ -133,9 +137,9 @@ class Parameter:
 
         Parameters
         ----------
-        instance : "ContinuousDistribution[DType]"
+        instance : "ContinuousDistribution[FloatT]"
             An instance of the owner class.
-        value : float
+        value : Scalar
             The new value for the parameter.
 
         Raises

--- a/pysatl_mpest/distributions/beta.py
+++ b/pysatl_mpest/distributions/beta.py
@@ -10,11 +10,11 @@ from scipy.special import digamma
 from scipy.stats import beta as beta_dist
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Beta(ContinuousDistribution):
+class Beta[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the four-parameteric beta distribution.
        Parameters
        ----------
@@ -67,7 +67,7 @@ class Beta(ContinuousDistribution):
         beta: float,
         left_border: float,
         right_border: float,
-        dtype: type[DType] = np.float64,  # type: ignore[assignment]
+        dtype: type[FloatT] = np.float64,  # type: ignore[assignment]
     ):
         super().__init__(dtype=dtype)
         if left_border >= right_border:
@@ -109,7 +109,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
 
@@ -139,7 +139,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -186,7 +186,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -227,7 +227,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`alpha` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -272,7 +272,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`beta` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -315,7 +315,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -359,7 +359,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -394,7 +394,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -436,7 +436,7 @@ class Beta(ContinuousDistribution):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/cauchy.py
+++ b/pysatl_mpest/distributions/cauchy.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import cauchy
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Cauchy(ContinuousDistribution[DType]):
+class Cauchy[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter cauchy distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Cauchy(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0.0, "Scale parameter should be positive")
 
-    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
@@ -82,7 +82,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -109,7 +109,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -150,7 +150,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -190,8 +190,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`loc` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -225,8 +225,8 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -254,7 +254,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -294,7 +294,7 @@ class Cauchy(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/continuous_dist.py
+++ b/pysatl_mpest/distributions/continuous_dist.py
@@ -8,15 +8,14 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
-from ..typings import DType
+from ..typings import FloatArray, FloatingType
 
 
-class ContinuousDistribution(ABC, Generic[DType]):
+class ContinuousDistribution[FloatT: FloatingType](ABC):
     """Abstract base class for continuous distributions.
 
     This class defines the basic mathematical functions of distributions
@@ -88,16 +87,16 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
     """
 
-    _dtype: type[DType]
+    _dtype: type[FloatT]
 
-    def __init__(self, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         """This constructor must be called by all descendants to ensure
         proper initialization of common attributes like `fixed_params`
         and `dtype`.
 
         Parameters
         ----------
-        dtype : Type[DType], optional
+        dtype : Type[FloatT], optional
             The numpy data type used for internal calculations and
             output arrays (e.g., `np.float32` or `np.float64`).
             Defaults to `np.float64`.
@@ -138,7 +137,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         self._fixed_params.discard(name)
 
-    def get_params_vector(self, param_names: Sequence[str]) -> list[DType]:
+    def get_params_vector(self, param_names: Sequence[str]) -> list[FloatT]:
         """Retrieves specified parameter values as a list.
 
         Parameters
@@ -165,7 +164,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         return [getattr(self, name) for name in param_names]
 
-    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float | DType]):
+    def set_params_from_vector(self, param_names: Sequence[str], vector: Sequence[float | FloatT]):
         """Sets parameter values from a sequence of floats.
 
         Updates the distribution's parameters using values from the provided
@@ -200,8 +199,8 @@ class ContinuousDistribution(ABC, Generic[DType]):
             setattr(self, name, self.dtype(value))
 
     @property
-    def dtype(self) -> type[DType]:
-        """type[DType]: The numpy data type of the distribution's outputs."""
+    def dtype(self) -> type[FloatT]:
+        """type[FloatT]: The numpy data type of the distribution's outputs."""
 
         return self._dtype
 
@@ -222,7 +221,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         return self.params - self._fixed_params
 
     @abstractmethod
-    def pdf(self, X: ArrayLike) -> DType | NDArray[DType]:
+    def pdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Probability Density Function.
 
         Parameters
@@ -232,13 +231,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def ppf(self, P: ArrayLike) -> NDArray[DType]:
+    def ppf(self, P: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Percent Point Function (PPF) or quantile function.
 
         This is the inverse of the Cumulative Distribution Function (CDF).
@@ -251,13 +250,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def lpdf(self, X: ArrayLike) -> NDArray[DType]:
+    def lpdf(self, X: ArrayLike) -> FloatT | FloatArray[FloatT]:
         """Logarithm of the Probability Density Function.
 
         Evaluating the log-PDF is often more numerically stable than
@@ -271,13 +270,13 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
     @abstractmethod
-    def log_gradients(self, X: ArrayLike) -> NDArray[DType]:
+    def log_gradients(self, X: ArrayLike) -> FloatArray[FloatT]:
         """Calculates the gradients of the log-PDF with respect to its parameters.
 
         The gradients are computed for the parameters that are not fixed.
@@ -289,7 +288,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X` and
             each column corresponds to the gradient with respect to a specific
             optimizable parameter. The order of columns corresponds to the
@@ -297,7 +296,7 @@ class ContinuousDistribution(ABC, Generic[DType]):
         """
 
     @abstractmethod
-    def generate(self, size: int | tuple[int, ...] | None = None) -> DType | NDArray[DType]:
+    def generate(self, size: int | tuple[int, ...] | None = None) -> FloatT | FloatArray[FloatT]:
         """Generates random samples from the distribution.
 
         Parameters
@@ -310,11 +309,11 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 
-    def astype(self, new_dtype: type[DType]) -> "ContinuousDistribution[DType]":
+    def astype[NewFloatT: FloatingType](self, new_dtype: type[NewFloatT]) -> "ContinuousDistribution[NewFloatT]":
         """Creates a copy of the distribution with a new data type.
 
         If the specified `new_dtype` is the same as the instance's current `dtype`,
@@ -322,33 +321,33 @@ class ContinuousDistribution(ABC, Generic[DType]):
 
         Parameters
         ----------
-        new_dtype : type[DType]
+        new_dtype : type[NewFloatT]
             The target NumPy data type for the new distribution instance.
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[NewFloatT]
             A new distribution instance with all parameters converted to the
             specified `new_dtype`, or the original instance if the `dtype` is
             unchanged.
         """
 
         if self._dtype is new_dtype:
-            return self
+            return self  # type: ignore[return-value]
 
         params_dict = {p: new_dtype(getattr(self, p)) for p in self.params}
 
-        new_instance = self.__class__(**params_dict, dtype=new_dtype)
+        new_instance = self.__class__(**params_dict, dtype=new_dtype)  # type: ignore[arg-type]
         new_instance._fixed_params = self._fixed_params.copy()
 
-        return new_instance
+        return new_instance  # type: ignore[return-value]
 
-    def __copy__(self) -> "ContinuousDistribution[DType]":
+    def __copy__(self) -> "ContinuousDistribution[FloatT]":
         """Creates a copy of the distribution instance.
 
         Returns
         -------
-        ContinuousDistribution[DType]
+        ContinuousDistribution[FloatT]
             A new instance of the distribution, identical to the original.
         """
 

--- a/pysatl_mpest/distributions/exponential.py
+++ b/pysatl_mpest/distributions/exponential.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import expon
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Exponential(ContinuousDistribution[DType]):
+class Exponential[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter exponential distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Exponential(ContinuousDistribution[DType]):
     loc = Parameter()
     rate = Parameter(lambda x: x > 0, "Rate parameter must be a positive")
 
-    def __init__(self, loc: float, rate: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, rate: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.rate = rate
@@ -82,7 +82,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
         """
 
@@ -105,7 +105,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -135,7 +135,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -167,8 +167,8 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
-            The gradient of the lpdf with respect to :attr:`loc` for each point in ::attr`X`.
+        FloatT | FloatArray[FloatT]
+            The gradient of the lpdf with respect to :attr:`loc` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
 
@@ -199,7 +199,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`rate` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -225,7 +225,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -265,7 +265,7 @@ class Exponential(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/normal.py
+++ b/pysatl_mpest/distributions/normal.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import norm
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Normal(ContinuousDistribution[DType]):
+class Normal[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the Normal (Gaussian) distribution.
 
     Parameters
@@ -50,7 +50,7 @@ class Normal(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.loc = loc
         self.scale = scale
@@ -83,7 +83,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -105,7 +105,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -135,7 +135,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -186,7 +186,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -228,7 +228,7 @@ class Normal(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/pareto.py
+++ b/pysatl_mpest/distributions/pareto.py
@@ -10,10 +10,10 @@ from scipy.stats import pareto
 
 from ..core.parameter import Parameter
 from ..distributions.continuous_dist import ContinuousDistribution
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class Pareto(ContinuousDistribution[DType]):
+class Pareto[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the two-parameter Pareto distribution.
 
     The Pareto distribution is a power-law probability distribution commonly used
@@ -53,7 +53,7 @@ class Pareto(ContinuousDistribution[DType]):
     shape = Parameter(lambda x: x > 0, "Shape parameter must be a positive")
     scale = Parameter(lambda x: x > 0, "Scale parameter must be a positive")
 
-    def __init__(self, shape: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, shape: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.shape = shape
         self.scale = scale
@@ -85,7 +85,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -109,7 +109,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -143,7 +143,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -182,7 +182,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`shape` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -216,7 +216,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`scale` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -242,7 +242,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -282,7 +282,7 @@ class Pareto(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/uniform.py
+++ b/pysatl_mpest/distributions/uniform.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import uniform
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Uniform(ContinuousDistribution[DType]):
+class Uniform[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """
     The Uniform continuous probability distribution.
 
@@ -60,7 +60,7 @@ class Uniform(ContinuousDistribution[DType]):
     left_border = Parameter()
     right_border = Parameter()
 
-    def __init__(self, left_border: float, right_border: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, left_border: float, right_border: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         if left_border >= right_border:
             raise ValueError("right_border parameter must be strictly greater than left_border")
@@ -97,7 +97,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -124,7 +124,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -161,7 +161,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -195,7 +195,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`left_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -228,7 +228,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The gradient of the lpdf with respect to :attr:`right_border` for each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -256,7 +256,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -296,7 +296,7 @@ class Uniform(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/distributions/weibull.py
+++ b/pysatl_mpest/distributions/weibull.py
@@ -9,11 +9,11 @@ import numpy as np
 from scipy.stats import weibull_min
 
 from ..core import Parameter
-from ..typings import DType
+from ..typings import FloatingType
 from .continuous_dist import ContinuousDistribution
 
 
-class Weibull(ContinuousDistribution[DType]):
+class Weibull[FloatT: FloatingType](ContinuousDistribution[FloatT]):
     """Class for the three-parameter Weibull distribution.
 
     Parameters
@@ -55,7 +55,7 @@ class Weibull(ContinuousDistribution[DType]):
     loc = Parameter()
     scale = Parameter(lambda x: x > 0, "Scale parameter must be positive")
 
-    def __init__(self, shape: float, loc: float, scale: float, dtype: type[DType] = np.float64):  # type: ignore[assignment]
+    def __init__(self, shape: float, loc: float, scale: float, dtype: type[FloatT] = np.float64):  # type: ignore[assignment]
         super().__init__(dtype=dtype)
         self.shape = shape
         self.loc = loc
@@ -91,7 +91,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -116,7 +116,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The PPF values corresponding to each probability in :attr:`P`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -150,7 +150,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             The log-PDF values corresponding to each point in :attr:`X`.
             Return a scalar when given a scalar, and to return an array when given an array.
         """
@@ -238,7 +238,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        NDArray[DType]
+        FloatArray[FloatT]
             An array where each row corresponds to a data point in :attr:`X`
             and each column corresponds to the gradient with respect to a
             specific optimizable parameter. The order of columns corresponds
@@ -279,7 +279,7 @@ class Weibull(ContinuousDistribution[DType]):
 
         Returns
         -------
-        DType | NDArray[DType]
+        FloatT | FloatArray[FloatT]
             A scalar or NumPy array containing the generated samples.
         """
 

--- a/pysatl_mpest/estimators/__init__.py
+++ b/pysatl_mpest/estimators/__init__.py
@@ -28,5 +28,6 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from .base_estimator import BaseEstimator
 from .ecm import ECM
+from .ecme import ECME
 
-__all__ = ["ECM", "BaseEstimator"]
+__all__ = ["ECM", "ECME", "BaseEstimator"]

--- a/pysatl_mpest/estimators/base_estimator.py
+++ b/pysatl_mpest/estimators/base_estimator.py
@@ -5,15 +5,14 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
-from typing import Generic
 
 from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class BaseEstimator(ABC, Generic[DType]):
+class BaseEstimator[FloatT: FloatingType](ABC):
     """Abstract class for a mixture model parameter estimator.
 
     This class defines the interface for all estimator algorithms. Estimators are responsible for
@@ -37,7 +36,7 @@ class BaseEstimator(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def fit(self, X: ArrayLike, mixture: MixtureModel[DType]) -> MixtureModel[DType]:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[FloatT]) -> MixtureModel[FloatT]:
         """Fits the mixture model to the provided data.
 
         This method estimates the parameters of the model's components and their
@@ -47,11 +46,11 @@ class BaseEstimator(ABC, Generic[DType]):
         ----------
         X : ArrayLike
             The input data sample for fitting the model.
-        mixture : MixtureModel[DType]
+        mixture : MixtureModel[FloatT]
             The initial mixture model to be fitted.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             The mixture model with estimated parameters.
         """

--- a/pysatl_mpest/estimators/ecm.py
+++ b/pysatl_mpest/estimators/ecm.py
@@ -17,7 +17,7 @@ from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
 from ..optimizers import Optimizer
-from ..typings import DType
+from ..typings import FloatingType
 from .base_estimator import BaseEstimator
 from .iterative import (
     Breakpointer,
@@ -31,7 +31,7 @@ from .iterative import (
 from .iterative._iteration_history import IterationsHistory
 
 
-class ECM(BaseEstimator[DType]):
+class ECM[FloatT: FloatingType](BaseEstimator[FloatT]):
     """An estimator that implements the Expectation-Conditional Maximization (ECM) algorithm.
 
     This class encapsulates the logic for the ECM algorithm, a variant of the
@@ -51,25 +51,25 @@ class ECM(BaseEstimator[DType]):
 
     Parameters
     ----------
-    breakpointers : Sequence[Breakpointer[DType]]
+    breakpointers : Sequence[Breakpointer[FloatT]]
         A sequence of strategies that define the stopping conditions for the
         iterative process.
-    pruners : Sequence[Pruner[DType]]
+    pruners : Sequence[Pruner[FloatT]]
         A sequence of strategies for removing (pruning) components from the
         mixture model during fitting.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         A numerical optimizer instance used in the maximization step to find
         the optimal parameters.
 
     Attributes
     ----------
-    breakpointers : list[Breakpointer[DType]]
+    breakpointers : list[Breakpointer[FloatT]]
         The list of objects that determine when the fitting process should
         terminate.
-    pruners : list[Pruner[DType]]
+    pruners : list[Pruner[FloatT]]
         The list of objects that may remove components from the mixture during
         the fitting process.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer used for parameter estimation.
     history: IterationsHistory | None
         An object that collects information about each iteration.
@@ -86,17 +86,17 @@ class ECM(BaseEstimator[DType]):
 
     def __init__(
         self,
-        breakpointers: Sequence[Breakpointer[DType]],
-        pruners: Sequence[Pruner[DType]],
-        optimizer: Optimizer[DType],
+        breakpointers: Sequence[Breakpointer[FloatT]],
+        pruners: Sequence[Pruner[FloatT]],
+        optimizer: Optimizer[FloatT],
     ) -> None:
         self.breakpointers = list(breakpointers)
         self.pruners = list(pruners)
         self.optimizer = optimizer
-        self._history: IterationsHistory[DType] | None = None
+        self._history: IterationsHistory[FloatT] | None = None
 
     @property
-    def history(self) -> IterationsHistory[DType]:
+    def history(self) -> IterationsHistory[FloatT]:
         """An object that collects information about each iteration.
 
         Raises
@@ -109,7 +109,7 @@ class ECM(BaseEstimator[DType]):
             raise AttributeError("History is not available. Call the 'fit' method first.")
         return self._history
 
-    def fit(self, X: ArrayLike, mixture: MixtureModel[DType], once_in_iterations: int = 1) -> MixtureModel[DType]:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[FloatT], once_in_iterations: int = 1) -> MixtureModel[FloatT]:
         """Fits the mixture model to the data using the ECM algorithm.
 
         This method sets up and runs an iterative pipeline to estimate the
@@ -121,7 +121,7 @@ class ECM(BaseEstimator[DType]):
         ----------
         X : ArrayLike
             The input dataset for fitting the model.
-        mixture : MixtureModel[DType]
+        mixture : MixtureModel[FloatT]
             The initial mixture model to be fitted.
         once_in_iterations : int, optional
             The iteration recording frequency. A value of `n` means recording occurs every
@@ -129,7 +129,7 @@ class ECM(BaseEstimator[DType]):
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             The mixture model with the estimated parameters.
         """
 
@@ -138,7 +138,7 @@ class ECM(BaseEstimator[DType]):
             block = OptimizationBlock(i, comp.params_to_optimize, MaximizationStrategy.QFUNCTION)
             blocks.append(block)
 
-        pipeline: Pipeline[DType] = Pipeline(
+        pipeline: Pipeline[FloatT] = Pipeline(
             [ExpectationStep(), MaximizationStep(blocks, self.optimizer)],
             self.breakpointers,
             self.pruners,

--- a/pysatl_mpest/estimators/ecme.py
+++ b/pysatl_mpest/estimators/ecme.py
@@ -19,7 +19,7 @@ from numpy.typing import ArrayLike
 
 from ..core import MixtureModel
 from ..optimizers import Optimizer
-from ..typings import DType
+from ..typings import FloatingType
 from .base_estimator import BaseEstimator
 from .iterative import (
     Breakpointer,
@@ -33,7 +33,7 @@ from .iterative import (
 from .iterative._iteration_history import IterationsHistory
 
 
-class ECME(BaseEstimator[DType]):
+class ECME[FloatT: FloatingType](BaseEstimator[FloatT]):
     """An estimator that implements the Expectation-Conditional Maximization Either (ECME) algorithm.
 
     ECME is a generalized iterative algorithm for maximum likelihood estimation.
@@ -49,13 +49,13 @@ class ECME(BaseEstimator[DType]):
 
     Parameters
     ----------
-    breakpointers : Sequence[Breakpointer[DType]]
+    breakpointers : Sequence[Breakpointer[FloatT]]
         A sequence of strategies that define the stopping conditions for the
         iterative fitting process.
-    pruners : Sequence[Pruner[DType]]
+    pruners : Sequence[Pruner[FloatT]]
         A sequence of strategies for removing (pruning) components from the
         mixture model during fitting.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer used to solve the maximization problems in the
         M-step (or CM-steps).
     default_strategy : Literal["q-func", "odl"], optional
@@ -65,15 +65,15 @@ class ECME(BaseEstimator[DType]):
 
     Attributes
     ----------
-    breakpointers : list[Breakpointer[DType]]
+    breakpointers : list[Breakpointer[FloatT]]
         The list of stopping criteria used by the estimator.
-    pruners : list[Pruner[DType]]
+    pruners : list[Pruner[FloatT]]
         The list of pruning strategies used by the estimator.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer instance.
     default_strategy_name : str
         The name of the default strategy ("q-func" or "odl").
-    history : IterationsHistory[DType]
+    history : IterationsHistory[FloatT]
         The history of the fitting process, containing snapshots of the model
         and metrics for each iteration. Only available after :meth:`fit` is called.
 
@@ -87,9 +87,9 @@ class ECME(BaseEstimator[DType]):
 
     def __init__(
         self,
-        breakpointers: Sequence[Breakpointer[DType]],
-        pruners: Sequence[Pruner[DType]],
-        optimizer: Optimizer[DType],
+        breakpointers: Sequence[Breakpointer[FloatT]],
+        pruners: Sequence[Pruner[FloatT]],
+        optimizer: Optimizer[FloatT],
         default_strategy: Literal["q-func", "odl"] = "odl",
     ):
         self.breakpointers = list(breakpointers)
@@ -101,11 +101,11 @@ class ECME(BaseEstimator[DType]):
 
         self.default_strategy_name = default_strategy
 
-        self._history: IterationsHistory[DType] | None = None
+        self._history: IterationsHistory[FloatT] | None = None
 
     @property
-    def history(self) -> IterationsHistory[DType]:
-        """IterationsHistory[DType]: The history of the last fitting process.
+    def history(self) -> IterationsHistory[FloatT]:
+        """IterationsHistory[FloatT]: The history of the last fitting process.
 
         Returns the history of iterations recorded during the last call to :meth:`fit`.
 
@@ -172,11 +172,11 @@ class ECME(BaseEstimator[DType]):
     def fit(
         self,
         X: ArrayLike,
-        mixture: MixtureModel[DType],
+        mixture: MixtureModel[FloatT],
         q_indices_raw: Sequence[int] | int | None = None,
         odl_indices_raw: Sequence[int] | int | None = None,
         once_in_iterations: int = 1,
-    ) -> MixtureModel[DType]:
+    ) -> MixtureModel[FloatT]:
         """Fits the mixture model to the data using the ECME algorithm.
 
         This method configures and executes an iterative pipeline. It assigns
@@ -189,7 +189,7 @@ class ECME(BaseEstimator[DType]):
         ----------
         X : ArrayLike
             The input data sample to fit.
-        mixture : MixtureModel[DType]
+        mixture : MixtureModel[FloatT]
             The initial mixture model configuration.
         q_indices_raw : Sequence[int] | int | None, optional
             Indices of components that should be optimized by maximizing the
@@ -205,7 +205,7 @@ class ECME(BaseEstimator[DType]):
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             The fitted mixture model with estimated parameters.
 
         Raises
@@ -251,7 +251,7 @@ class ECME(BaseEstimator[DType]):
                 )
             )
 
-        pipeline: Pipeline[DType] = Pipeline(
+        pipeline: Pipeline[FloatT] = Pipeline(
             [ExpectationStep(), MaximizationStep(blocks, self.optimizer)],
             self.breakpointers,
             self.pruners,

--- a/pysatl_mpest/estimators/iterative/_iteration_history.py
+++ b/pysatl_mpest/estimators/iterative/_iteration_history.py
@@ -11,17 +11,14 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Generic
-
-from numpy.typing import NDArray
 
 from ...core import MixtureModel
-from ...typings import DType
+from ...typings import FloatingType, MultivariateFloatArray, UnivariateFloatArray
 from .pruner import Pruner
 
 
 @dataclass
-class IterationRecord(Generic[DType]):
+class IterationRecord[FloatT: FloatingType]:
     """Data class representing a single pipeline iteration snapshot.
 
     This class captures the complete state of a pipeline iteration after
@@ -32,15 +29,15 @@ class IterationRecord(Generic[DType]):
     ----------
     iteration : int
         The iteration number (0-based index).
-    mixture : MixtureModel[DType]
+    mixture : MixtureModel[FloatT]
         The state of the mixture model after pruning in this iteration.
-    X : NDArray[DType]
+    X : UnivariateFloatArray[FloatT]
         The input data sample being processed (conventionally named `X`).
-    H : Optional[NDArray[DType]]
+    H : Optional[MultivariateFloatArray[FloatT]]
         The responsibility matrix (posterior probabilities) if available,
         where `H[i, j]` represents the probability that data point `i`
         belongs to component `j`. May be `None` if not computed.
-    pruners_used : Optional[list[Pruner[DType]]]
+    pruners_used : Optional[list[Pruner[FloatT]]]
         List of pruner instances that were applied during this iteration.
         `None` or empty if no pruning occurred.
     error : Optional[Exception]
@@ -49,14 +46,14 @@ class IterationRecord(Generic[DType]):
     """
 
     iteration: int
-    mixture: MixtureModel[DType]
-    X: NDArray[DType]
-    H: NDArray[DType] | None
-    pruners_used: list[Pruner[DType]] | None
+    mixture: MixtureModel[FloatT]
+    X: UnivariateFloatArray[FloatT]
+    H: MultivariateFloatArray[FloatT] | None
+    pruners_used: list[Pruner[FloatT]] | None
     error: Exception | None
 
 
-class IterationsHistory(Generic[DType]):
+class IterationsHistory[FloatT: FloatingType]:
     """A container for storing and accessing pipeline iteration history.
 
     `IterationsHistory` collects and stores snapshots of each pipeline iteration
@@ -98,7 +95,7 @@ class IterationsHistory(Generic[DType]):
     _counter : int
         Internal counter tracking the total number of `save_record()` calls
         (i.e., total iterations processed, not just recorded ones).
-    _history : list[IterationRecord[DType]]
+    _history : list[IterationRecord[FloatT]]
         List of stored iteration records. Only iterations matching the
         recording frequency are appended.
 
@@ -120,11 +117,11 @@ class IterationsHistory(Generic[DType]):
         if once_in_iterations < 1:
             raise ValueError("Parameter once_in_iterations must be a positive integer")
 
-        self._history: list[IterationRecord[DType]] = []
+        self._history: list[IterationRecord[FloatT]] = []
         self._counter: int = 0
         self.once_in_iterations = once_in_iterations
 
-    def save_record(self, record: IterationRecord[DType]) -> None:
+    def save_record(self, record: IterationRecord[FloatT]) -> None:
         """Store an iteration record based on the configured frequency.
 
         The record is stored only if the current internal counter is divisible
@@ -133,7 +130,7 @@ class IterationsHistory(Generic[DType]):
 
         Parameters
         ----------
-        record : IterationRecord[DType]
+        record : IterationRecord[FloatT]
             The iteration snapshot to potentially store. The `record.iteration`
             should ideally match the instance's internal state, though this is
             not enforced.
@@ -168,7 +165,7 @@ class IterationsHistory(Generic[DType]):
 
         return len(self._history)
 
-    def __getitem__(self, index: int) -> IterationRecord[DType]:
+    def __getitem__(self, index: int) -> IterationRecord[FloatT]:
         """Access a stored iteration record by index.
 
         Supports both positive (0-based) and negative indexing (e.g., `-1` for last).
@@ -181,7 +178,7 @@ class IterationsHistory(Generic[DType]):
 
         Returns
         -------
-        IterationRecord[DType]
+        IterationRecord[FloatT]
             The recorded state of the specified iteration.
 
         Raises

--- a/pysatl_mpest/estimators/iterative/_strategies/__init__.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/__init__.py
@@ -6,27 +6,24 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from collections.abc import Callable
+from typing import Any
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
-from ..steps import OptimizationBlock
+from ..steps.block import OptimizationBlock
 from .moments import moments_strategy as _moments_strategy
 from .observed_data_likelihood import observed_data_likelihood_strategy as _observed_data_likelihood_strategy
 from .q_function import q_function_strategy as _q_function_strategy
 
-q_function_strategy: Callable[
-    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
-] = _q_function_strategy
+type StrategyFunction[FloatT: FloatingType] = Callable[
+    [ContinuousDistribution[FloatT], PipelineState[FloatT], OptimizationBlock, Optimizer[FloatT]],
+    tuple[int, dict[str, FloatT]],
+]
 
-observed_data_likelihood_strategy: Callable[
-    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
-] = _observed_data_likelihood_strategy
+q_function_strategy: StrategyFunction[Any] = _q_function_strategy
+observed_data_likelihood_strategy: StrategyFunction[Any] = _observed_data_likelihood_strategy
+moments_strategy: StrategyFunction[Any] = _moments_strategy
 
-moments_strategy: Callable[
-    [ContinuousDistribution, PipelineState, OptimizationBlock, Optimizer], tuple[int, dict[str, DType]]
-] = _moments_strategy
-
-
-__all__ = ["moments_strategy", "observed_data_likelihood_strategy", "q_function_strategy"]
+__all__ = ["StrategyFunction", "moments_strategy", "observed_data_likelihood_strategy", "q_function_strategy"]

--- a/pysatl_mpest/estimators/iterative/_strategies/moments.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/moments.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from ....distributions import ContinuousDistribution, Exponential, Normal
 from ....optimizers import Optimizer
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
 from .utils import handle_numerical_overflow
@@ -31,12 +31,12 @@ NUMERICAL_TOLERANCE = 1e-9
 
 
 @singledispatch
-def moments_strategy(
-    component: ContinuousDistribution[DType],
-    state: PipelineState[DType],
+def moments_strategy[FloatT: FloatingType](
+    component: ContinuousDistribution[FloatT],
+    state: PipelineState[FloatT],
     block: OptimizationBlock,
-    optimizer: Optimizer[DType],
-) -> tuple[int, dict[str, DType]]:
+    optimizer: Optimizer[FloatT],
+) -> tuple[int, dict[str, FloatT]]:
     """Generic M-step strategy that uses the Method of Moments.
 
     This function serves as the base dispatcher. Since the Method of Moments
@@ -46,13 +46,13 @@ def moments_strategy(
 
     Parameters
     ----------
-    component : ContinuousDistribution[DType]
+    component : ContinuousDistribution[FloatT]
         The distribution component whose parameters are to be optimized.
     state : PipelineState
         The current state of the pipeline.
     block : OptimizationBlock
         The configuration block defining which component to optimize.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer (unused in this strategy).
 
     Raises
@@ -70,9 +70,9 @@ def moments_strategy(
 
 
 @moments_strategy.register(Exponential)
-def _(
-    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Exponential[FloatT], state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """Specialized Moments parameter estimation strategy for the Exponential distribution
     using an analytical solution.
 
@@ -162,9 +162,9 @@ def _(
 
 
 @moments_strategy.register(Normal)
-def _(
-    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Normal[FloatT], state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """
     Update parameters of a univariate Normal component using weighted moments.
 
@@ -184,11 +184,11 @@ def _(
 
     Parameters
     ----------
-    component : Normal[DType]
+    component : Normal[FloatT]
         Normal distribution component to be updated. The method may update
         ``component.loc`` and/or ``component.scale`` depending on
         ``component.params_to_optimize`` and the block configuration.
-    state : PipelineState[DType]
+    state : PipelineState[FloatT]
         Current pipeline state containing:
 
         - ``X`` : array-like
@@ -200,7 +200,7 @@ def _(
         Optimization block describing which component is being optimized and
         which parameters are allowed to change. The component index is taken
         from ``block.component_id``.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         Optimizer instance provided by the pipeline. It is not used directly by
         this moments-based strategy but is included for API consistency.
 
@@ -209,7 +209,7 @@ def _(
     component_id : int
         The identifier of the optimized component, equal to
         ``block.component_id``.
-    new_params : dict[str, DType]
+    new_params : dict[str, FloatT]
         Dictionary of updated parameters for the component. Keys correspond to
         Normal parameter names (e.g., ``component.PARAM_LOC``,
         ``component.PARAM_SCALE``). If no update is performed (e.g., negligible

--- a/pysatl_mpest/estimators/iterative/_strategies/observed_data_likelihood.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/observed_data_likelihood.py
@@ -15,18 +15,18 @@ import numpy as np
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
 from .utils import handle_numerical_overflow
 
 
-def observed_data_likelihood_strategy(
-    component: ContinuousDistribution[DType],
-    state: PipelineState[DType],
+def observed_data_likelihood_strategy[FloatT: FloatingType](
+    component: ContinuousDistribution[FloatT],
+    state: PipelineState[FloatT],
     block: OptimizationBlock,
-    optimizer: Optimizer[DType],
-) -> tuple[int, dict[str, DType]]:
+    optimizer: Optimizer[FloatT],
+) -> tuple[int, dict[str, FloatT]]:
     """Generic strategy that calculates optimized parameters by maximizing observed data log-likelihood.
 
     This function calculates the new parameters for a component by directly
@@ -38,19 +38,19 @@ def observed_data_likelihood_strategy(
 
     Parameters
     ----------
-    component : ContinuousDistribution[DType]
+    component : ContinuousDistribution[FloatT]
         The distribution component type/instance used for dispatch and parameter metadata.
-    state : PipelineState[DType]
+    state : PipelineState[FloatT]
         The current state containing data X and current mixture parameters.
         (Note: Responsibilities H are not used in this strategy).
     block : OptimizationBlock
         Configuration defining which parameters to optimize (component_id and param names).
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         Numerical optimizer instance.
 
     Returns
     -------
-    tuple[int, dict[str, DType]]
+    tuple[int, dict[str, FloatT]]
         Component ID and a dictionary of the optimized parameters.
     """
 

--- a/pysatl_mpest/estimators/iterative/_strategies/q_function.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/q_function.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from ....distributions import ContinuousDistribution, Exponential, Normal, Pareto, Weibull
 from ....optimizers import Optimizer
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
 from ..steps import OptimizationBlock
 from .utils import handle_numerical_overflow
@@ -34,12 +34,12 @@ NUMERICAL_TOLERANCE = 1e-9
 
 
 @singledispatch
-def q_function_strategy(
-    component: ContinuousDistribution[DType],
-    state: PipelineState[DType],
+def q_function_strategy[FloatT: FloatingType](
+    component: ContinuousDistribution[FloatT],
+    state: PipelineState[FloatT],
     block: OptimizationBlock,
-    optimizer: Optimizer[DType],
-) -> tuple[int, dict[str, DType]]:
+    optimizer: Optimizer[FloatT],
+) -> tuple[int, dict[str, FloatT]]:
     """Generic M-step strategy that maximizes the Q-function numerically.
 
     This function serves as the default implementation for updating a
@@ -52,7 +52,7 @@ def q_function_strategy(
 
     Parameters
     ----------
-    component : ContinuousDistribution[DType]
+    component : ContinuousDistribution[FloatT]
         The distribution component whose parameters are to be optimized.
     state : PipelineState
         The current state of the pipeline, containing the data :attr:`X` and the
@@ -60,12 +60,12 @@ def q_function_strategy(
     block : OptimizationBlock
         The configuration block defining which component and which of its
         parameters to optimize.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer instance used to perform the maximization.
 
     Returns
     -------
-    tuple[int, dict[str, DType]]
+    tuple[int, dict[str, FloatT]]
         A tuple containing the component's ID and a dictionary of the
         optimized parameter names and their new values.
 
@@ -106,9 +106,9 @@ def q_function_strategy(
 
 
 @q_function_strategy.register(Exponential)
-def _(
-    component: Exponential[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Exponential[FloatT], state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """Specialized Q-function parameter estimation strategy for
     the Exponential distribution using an analytical solution.
 
@@ -181,9 +181,9 @@ def _(
 
 
 @q_function_strategy.register(Normal)
-def _(
-    component: Normal[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Normal[FloatT], state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """Specialized Q-function parameter estimation strategy for
     the normal distribution using an analytical solution.
 
@@ -254,9 +254,9 @@ def _(
 
 
 @q_function_strategy.register(Weibull)
-def _(
-    component: Weibull[DType], state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Weibull[FloatT], state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """Specialized Q-function parameter estimation strategy for
     the Weibull distribution using an analytical solution.
     """
@@ -330,9 +330,9 @@ def _(
 
 
 @q_function_strategy.register(Pareto)
-def _(
-    component: Pareto, state: PipelineState[DType], block: OptimizationBlock, optimizer: Optimizer[DType]
-) -> tuple[int, dict[str, DType]]:
+def _[FloatT: FloatingType](
+    component: Pareto, state: PipelineState[FloatT], block: OptimizationBlock, optimizer: Optimizer[FloatT]
+) -> tuple[int, dict[str, FloatT]]:
     """Specialized Q-function parameter estimation strategy for
     the Pareto type 1 distribution using an analytical solution.
 

--- a/pysatl_mpest/estimators/iterative/_strategies/utils.py
+++ b/pysatl_mpest/estimators/iterative/_strategies/utils.py
@@ -5,11 +5,13 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from ....exceptions import NumericalStabilityError
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
 
 
-def handle_numerical_overflow(state: PipelineState[DType], context: str = "optimization") -> None:
+def handle_numerical_overflow[FloatT: FloatingType](
+    state: PipelineState[FloatT], context: str = "optimization"
+) -> None:
     """Creates and registers a numerical stability error in the pipeline state.
 
     This helper function is called when a numerical instability (e.g., infinity)
@@ -22,7 +24,7 @@ def handle_numerical_overflow(state: PipelineState[DType], context: str = "optim
 
     Parameters
     ----------
-    state : PipelineState[DType]
+    state : PipelineState[FloatT]
         The current pipeline state where the error will be recorded.
     context : str
         The context name to include in the error message (e.g. 'Moments optimization', 'Q-function optimization').

--- a/pysatl_mpest/estimators/iterative/breakpointer.py
+++ b/pysatl_mpest/estimators/iterative/breakpointer.py
@@ -10,13 +10,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
-from typing import Generic
 
-from ...typings import DType
+from ...typings import FloatingType
 from .pipeline_state import PipelineState
 
 
-class Breakpointer(ABC, Generic[DType]):
+class Breakpointer[FloatT: FloatingType](ABC):
     """Abstract base class for a pipeline stopping condition.
 
     A Breakpointer is responsible for inspecting the :class:`PipelineState` after each
@@ -42,12 +41,12 @@ class Breakpointer(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def check(self, state: PipelineState[DType]) -> bool:
+    def check(self, state: PipelineState[FloatT]) -> bool:
         """Evaluates the pipeline state to determine if it should stop.
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline after a full iteration,
             containing the current and previous mixture models.
 

--- a/pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
+++ b/pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py
@@ -6,12 +6,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from ....typings import DType
+from ....typings import FloatingType, Scalar
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
 
 
-class LikelihoodBreakpointer(Breakpointer[DType]):
+class LikelihoodBreakpointer[FloatT: FloatingType](Breakpointer[FloatT]):
     """Stops the pipeline when the log-likelihood of the mixture converges.
 
     This breakpointer terminates the iterative estimation process when the
@@ -26,13 +26,13 @@ class LikelihoodBreakpointer(Breakpointer[DType]):
 
     Parameters
     ----------
-    threshold : DType
+    threshold : Scalar
         The convergence threshold for the log-likelihood difference.
         Must be a positive number.
 
     Attributes
     ----------
-    threshold : DType
+    threshold : Scalar
         The convergence threshold.
 
     Raises
@@ -48,17 +48,19 @@ class LikelihoodBreakpointer(Breakpointer[DType]):
         check
     """
 
-    def __init__(self, threshold: DType):
+    threshold: Scalar
+
+    def __init__(self, threshold: Scalar):
         self._validate(threshold)
         self.threshold = threshold
-        self._likelihood_old: DType | None = None
+        self._likelihood_old: FloatT | None = None
 
-    def _validate(self, threshold: DType):
+    def _validate(self, threshold: Scalar):
         """Validates the threshold parameter."""
         if threshold <= 0.0:
             raise ValueError("The threshold must be greater than 0")
 
-    def check(self, state: PipelineState[DType]) -> bool:
+    def check(self, state: PipelineState[FloatT]) -> bool:
         """Checks if the log-likelihood has converged.
 
         Computes the current log-likelihood of the mixture on the data in
@@ -66,7 +68,7 @@ class LikelihoodBreakpointer(Breakpointer[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline, which must contain a valid
             `curr_mixture` and data `X`.
 
@@ -79,7 +81,7 @@ class LikelihoodBreakpointer(Breakpointer[DType]):
             On the first call (no previous likelihood), returns False and
             initializes internal state.
         """
-        _likelihood_new: DType = state.curr_mixture.loglikelihood(state.X)
+        _likelihood_new: FloatT = state.curr_mixture.loglikelihood(state.X)
 
         # First iteration: cannot compare, so just store and continue
         if self._likelihood_old is None:

--- a/pysatl_mpest/estimators/iterative/breakpointers/step_breakpointer.py
+++ b/pysatl_mpest/estimators/iterative/breakpointers/step_breakpointer.py
@@ -6,12 +6,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from ....typings import DType
+from ....typings import FloatingType
 from ..breakpointer import Breakpointer
 from ..pipeline_state import PipelineState
 
 
-class StepBreakpointer(Breakpointer[DType]):
+class StepBreakpointer[FloatT: FloatingType](Breakpointer[FloatT]):
     """Stops the pipeline after a fixed number of iterations.
 
     This breakpointer terminates the iterative process once a specified
@@ -58,7 +58,7 @@ class StepBreakpointer(Breakpointer[DType]):
         if max_steps <= 0:
             raise ValueError("The maximum number of steps must be greater than or equal to 1")
 
-    def check(self, state: PipelineState[DType]) -> bool:
+    def check(self, state: PipelineState[FloatT]) -> bool:
         """Checks if the maximum number of iterations has been reached.
 
         This method increments the internal step counter and compares it with
@@ -67,7 +67,7 @@ class StepBreakpointer(Breakpointer[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline. This parameter is unused in
             this specific breakpointer but required by the base class interface.
 

--- a/pysatl_mpest/estimators/iterative/pipeline.py
+++ b/pysatl_mpest/estimators/iterative/pipeline.py
@@ -20,7 +20,7 @@ from numpy.typing import ArrayLike
 
 from ...core import MixtureModel
 from ...exceptions import NumericalStabilityError
-from ...typings import DType
+from ...typings import FloatingType
 from ..base_estimator import BaseEstimator
 from ._iteration_history import IterationRecord, IterationsHistory
 from .breakpointer import Breakpointer
@@ -29,7 +29,7 @@ from .pipeline_step import PipelineStep
 from .pruner import Pruner
 
 
-class Pipeline(BaseEstimator[DType]):
+class Pipeline[FloatT: FloatingType](BaseEstimator[FloatT]):
     """An estimator that fits a mixture model via a configurable iterative process.
 
     The pipeline executes a sequence of defined steps in a loop. After each full
@@ -46,13 +46,13 @@ class Pipeline(BaseEstimator[DType]):
 
     Parameters
     ----------
-    steps : Sequence[PipelineStep[DType]]
+    steps : Sequence[PipelineStep[FloatT]]
         An ordered sequence of steps to be executed in each iteration of the
         pipeline.
-    breakpointers : Sequence[Breakpointer[DType]]
+    breakpointers : Sequence[Breakpointer[FloatT]]
         A sequence of strategies that define the stopping conditions for the
         iterative process. This list cannot be empty.
-    pruners : Sequence[Pruner[DType]] | None, optional
+    pruners : Sequence[Pruner[FloatT]] | None, optional
         A sequence of strategies for removing components from the mixture model
         during fitting. Defaults to None, meaning no pruning is performed.
     once_in_iterations: int, optional
@@ -61,15 +61,15 @@ class Pipeline(BaseEstimator[DType]):
 
     Attributes
     ----------
-    steps : list[PipelineStep[DType]]
+    steps : list[PipelineStep[FloatT]]
         The ordered list of operations to be performed in each iteration.
-    breakpointers : list[Breakpointer[DType]]
+    breakpointers : list[Breakpointer[FloatT]]
         The list of objects that determine when the fitting process should
         terminate.
-    pruners : list[Pruner[DType]]
+    pruners : list[Pruner[FloatT]]
         The list of objects that may remove components from the mixture during
         the fitting process.
-    history : IterationsHistory[DType]
+    history : IterationsHistory[FloatT]
         object that collects comprehensive information about each
         iteration of a :class:`Pipeline` estimator.
     Raises
@@ -89,9 +89,9 @@ class Pipeline(BaseEstimator[DType]):
 
     def __init__(
         self,
-        steps: Sequence[PipelineStep[DType]],
-        breakpointers: Sequence[Breakpointer[DType]],
-        pruners: Sequence[Pruner[DType]] | None = None,
+        steps: Sequence[PipelineStep[FloatT]],
+        breakpointers: Sequence[Breakpointer[FloatT]],
+        pruners: Sequence[Pruner[FloatT]] | None = None,
         once_in_iterations: int = 1,
     ):
         self._validate_steps(list(steps))
@@ -105,9 +105,9 @@ class Pipeline(BaseEstimator[DType]):
         self.breakpointers = list(breakpointers)
         self.pruners = list(pruners) if pruners else []  # self.pruners will always be list
         self.steps = list(steps)
-        self.history = IterationsHistory[DType](once_in_iterations)
+        self.history = IterationsHistory[FloatT](once_in_iterations)
 
-    def _validate_steps(self, steps: list[PipelineStep[DType]]):
+    def _validate_steps(self, steps: list[PipelineStep[FloatT]]):
         """Validates the sequence of pipeline steps.
 
         Checks if each step in the pipeline can legally be followed by the next
@@ -140,7 +140,7 @@ class Pipeline(BaseEstimator[DType]):
                     f"available next steps:'{curr_step.available_next_steps}', but got '{next_step}'"
                 )
 
-    def fit(self, X: ArrayLike, mixture: MixtureModel[DType]) -> MixtureModel[DType]:
+    def fit(self, X: ArrayLike, mixture: MixtureModel[FloatT]) -> MixtureModel[FloatT]:
         """Fits the mixture model to the data using the configured pipeline.
 
         This method initializes the pipeline's state and runs the main loop.
@@ -152,13 +152,13 @@ class Pipeline(BaseEstimator[DType]):
         ----------
         X : ArrayLike
             The input data sample.
-        mixture : MixtureModel[DType]
+        mixture : MixtureModel[FloatT]
             The initial mixture model to be fitted. An internal copy of this
             model will be modified throughout the process.
 
         Returns
         -------
-        MixtureModel[DType]
+        MixtureModel[FloatT]
             The fitted mixture model after the pipeline has converged or been
             stopped.
         """

--- a/pysatl_mpest/estimators/iterative/pipeline_state.py
+++ b/pysatl_mpest/estimators/iterative/pipeline_state.py
@@ -11,16 +11,13 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from dataclasses import dataclass
-from typing import Generic
-
-from numpy.typing import NDArray
 
 from ...core import MixtureModel
-from ...typings import DType
+from ...typings import FloatingType, MultivariateFloatArray, UnivariateFloatArray
 
 
 @dataclass
-class PipelineState(Generic[DType]):
+class PipelineState[FloatT: FloatingType]:
     """Represents the state of a pipeline at a specific point in its execution.
 
     This dataclass is a mutable container that centralizes all information
@@ -30,18 +27,18 @@ class PipelineState(Generic[DType]):
 
     Args
     ----------
-    X : NDArray[DType]
+    X : UnivariateFloatArray[FloatT]
         The input data sample. This data is typically treated as read-only
         throughout the pipeline's execution.
-    H : NDArray[DType] | None
+    H : MultivariateFloatArray[FloatT] | None
         The responsibility matrix (posterior probabilities). `H[i, j]`
         represents the probability that data point `i` belongs to component
         `j`. It may not be computed at every step.
-    prev_mixture : MixtureModel[DType] | None
+    prev_mixture : MixtureModel[FloatT] | None
         A snapshot of the mixture model from the previous iteration. This is
         useful for convergence checks, such as comparing log-likelihood values.
         It is `None` at the start of the pipeline.
-    curr_mixture : MixtureModel[DType]
+    curr_mixture : MixtureModel[FloatT]
         The current state of the mixture model that is being actively
         optimized by the pipeline steps.
     error : Exception | None
@@ -50,8 +47,8 @@ class PipelineState(Generic[DType]):
         here to signal the pipeline to terminate gracefully.
     """
 
-    X: NDArray[DType]
-    H: NDArray[DType] | None
-    prev_mixture: MixtureModel[DType] | None
-    curr_mixture: MixtureModel[DType]
+    X: UnivariateFloatArray[FloatT]
+    H: MultivariateFloatArray[FloatT] | None
+    prev_mixture: MixtureModel[FloatT] | None
+    curr_mixture: MixtureModel[FloatT]
     error: Exception | None

--- a/pysatl_mpest/estimators/iterative/pipeline_step.py
+++ b/pysatl_mpest/estimators/iterative/pipeline_step.py
@@ -11,13 +11,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
-from typing import Generic
 
-from ...typings import DType
+from ...typings import FloatingType
 from .pipeline_state import PipelineState
 
 
-class PipelineStep(ABC, Generic[DType]):
+class PipelineStep[FloatT: FloatingType](ABC):
     """Abstract base class for a single step in a processing pipeline.
 
     This class defines the interface for an operation that can be executed as
@@ -54,7 +53,7 @@ class PipelineStep(ABC, Generic[DType]):
         """
 
     @abstractmethod
-    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
+    def run(self, state: PipelineState[FloatT]) -> PipelineState[FloatT]:
         """Executes the logic of the pipeline step.
 
         This method processes the given pipeline state. Implementations can
@@ -67,13 +66,13 @@ class PipelineStep(ABC, Generic[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline to be processed. Note that this
             object can be mutated by the method.
 
         Returns
         -------
-        PipelineState[DType]
+        PipelineState[FloatT]
             The updated state of the pipeline. This can be the mutated input
             `state` object or a completely new instance.
         """

--- a/pysatl_mpest/estimators/iterative/pruner.py
+++ b/pysatl_mpest/estimators/iterative/pruner.py
@@ -10,13 +10,12 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
-from typing import Generic
 
-from ...typings import DType
+from ...typings import FloatingType
 from .pipeline_state import PipelineState
 
 
-class Pruner(ABC, Generic[DType]):
+class Pruner[FloatT: FloatingType](ABC):
     """Abstract base class for component pruning strategies.
 
     Pruner subclasses implement the logic for identifying and removing
@@ -41,7 +40,7 @@ class Pruner(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def prune(self, state: PipelineState[DType]) -> tuple[PipelineState[DType], list[int]]:
+    def prune(self, state: PipelineState[FloatT]) -> tuple[PipelineState[FloatT], list[int]]:
         """Analyzes the pipeline state and prunes components from the mixture.
 
         This method is called by the :class:`Pipeline` to inspect the current mixture
@@ -51,13 +50,13 @@ class Pruner(ABC, Generic[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline, containing the data, mixture
             model, and other relevant information.
 
         Returns
         -------
-        PipelineState[DType]
+        PipelineState[FloatT]
             The new pipeline state. If components were removed, this state
             contains the updated mixture model. Otherwise, it returns the
             original state.

--- a/pysatl_mpest/estimators/iterative/pruners/prior_threshold_pruner.py
+++ b/pysatl_mpest/estimators/iterative/pruners/prior_threshold_pruner.py
@@ -14,12 +14,12 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from copy import copy
 
-from ....typings import DType
+from ....typings import FloatingType, Scalar
 from ..pipeline_state import PipelineState
 from ..pruner import Pruner
 
 
-class PriorThresholdPruner(Pruner[DType]):
+class PriorThresholdPruner[FloatT: FloatingType](Pruner[FloatT]):
     """A pruner that removes mixture components based on a weight threshold.
 
     This pruner iterates through the components of a :class:`pysatl_mpest.core.MixtureModel`
@@ -30,7 +30,7 @@ class PriorThresholdPruner(Pruner[DType]):
 
     Parameters
     ----------
-    threshold : float
+    threshold : Scalar
         The minimum weight a component must have to be retained. This value
         must be in the exclusive range (0, 1).
 
@@ -53,12 +53,12 @@ class PriorThresholdPruner(Pruner[DType]):
         prune
     """
 
-    def __init__(self, threshold: float) -> None:
-        if not (0 < threshold < 1):
+    def __init__(self, threshold: Scalar) -> None:
+        self.threshold = float(threshold)
+        if not (0 < self.threshold < 1):
             raise ValueError("Threshold must be between 0 and 1.")
-        self.threshold = threshold
 
-    def prune(self, state: PipelineState[DType]) -> tuple[PipelineState[DType], list[int]]:
+    def prune(self, state: PipelineState[FloatT]) -> tuple[PipelineState[FloatT], list[int]]:
         """Removes components from the mixture whose weights are below the threshold.
 
         This method inspects :attr:`state.curr_mixture` and removes any component
@@ -69,13 +69,13 @@ class PriorThresholdPruner(Pruner[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline, containing the mixture model
             to be pruned.
 
         Returns
         -------
-        tuple[PipelineState[DType], list[int]]
+        tuple[PipelineState[FloatT], list[int]]
         A tuple containing:
         - The updated pipeline state. If components were removed,
           :attr:`state.curr_mixture` will be a new,

--- a/pysatl_mpest/estimators/iterative/steps/expectation_step.py
+++ b/pysatl_mpest/estimators/iterative/steps/expectation_step.py
@@ -8,12 +8,12 @@ __license__ = "SPDX-License-Identifier: MIT"
 import numpy as np
 from scipy.special import logsumexp
 
-from ....typings import DType
+from ....typings import FloatingType
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 
 
-class ExpectationStep(PipelineStep[DType]):
+class ExpectationStep[FloatT: FloatingType](PipelineStep[FloatT]):
     """A pipeline step that performs the Expectation (E-step).
 
     This step calculates the responsibility matrix H, where H[i, j] is
@@ -58,7 +58,7 @@ class ExpectationStep(PipelineStep[DType]):
 
         return [MaximizationStep]
 
-    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
+    def run(self, state: PipelineState[FloatT]) -> PipelineState[FloatT]:
         """Executes the E-step by calculating the responsibility matrix H.
 
         This method computes the log-likelihood of each data point under each
@@ -68,13 +68,13 @@ class ExpectationStep(PipelineStep[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline, which must contain the input
             data X and the current mixture model curr_mixture.
 
         Returns
         -------
-        PipelineState[DType]
+        PipelineState[FloatT]
             The updated pipeline state with the H attribute computed and set.
         """
 

--- a/pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -14,16 +14,16 @@ __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from types import MappingProxyType
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 import numpy as np
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
 from ....typings import FloatingType
-from .._strategies import moments_strategy, observed_data_likelihood_strategy, q_function_strategy
+from .._strategies import StrategyFunction, moments_strategy, observed_data_likelihood_strategy, q_function_strategy
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 from .block import MaximizationStrategy, OptimizationBlock
@@ -63,7 +63,7 @@ class MaximizationStep[FloatT: FloatingType](PipelineStep[FloatT]):
         run
     """
 
-    _strategies: ClassVar[Mapping[MaximizationStrategy, Callable]] = MappingProxyType(
+    _strategies: ClassVar[Mapping[MaximizationStrategy, StrategyFunction[Any]]] = MappingProxyType(
         {
             MaximizationStrategy.QFUNCTION: q_function_strategy,
             MaximizationStrategy.OBSERVED_DATA_LIKELIHOOD: observed_data_likelihood_strategy,
@@ -130,13 +130,13 @@ class MaximizationStep[FloatT: FloatingType](PipelineStep[FloatT]):
             state.error = error
             return state
 
-        results = []
+        results: list[tuple[int, dict[str, FloatT]]] = []
         curr_mixture = state.curr_mixture
 
         dtype = curr_mixture.dtype
 
         for block in self.blocks:
-            strategy = self._strategies[block.maximization_strategy]
+            strategy = cast(StrategyFunction[FloatT], self._strategies[block.maximization_strategy])
             component_id, new_params = strategy(curr_mixture[block.component_id], state, block, self.optimizer)
             if state.error:
                 return state

--- a/pysatl_mpest/estimators/iterative/steps/maximization_step.py
+++ b/pysatl_mpest/estimators/iterative/steps/maximization_step.py
@@ -22,14 +22,14 @@ import numpy as np
 
 from ....distributions import ContinuousDistribution
 from ....optimizers import Optimizer
-from ....typings import DType
+from ....typings import FloatingType
 from .._strategies import moments_strategy, observed_data_likelihood_strategy, q_function_strategy
 from ..pipeline_state import PipelineState
 from ..pipeline_step import PipelineStep
 from .block import MaximizationStrategy, OptimizationBlock
 
 
-class MaximizationStep(PipelineStep[DType]):
+class MaximizationStep[FloatT: FloatingType](PipelineStep[FloatT]):
     """A pipeline step that performs the Maximization (M-step).
 
     This step updates the parameters of each component in the mixture model,
@@ -44,7 +44,7 @@ class MaximizationStep(PipelineStep[DType]):
         A sequence of configuration blocks that define the optimization tasks.
         Each block specifies a component, its parameters to optimize, and the
         maximization strategy to use.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         A numerical optimizer instance used to find the optimal parameters
         when an analytical solution is not available for a given strategy.
 
@@ -52,7 +52,7 @@ class MaximizationStep(PipelineStep[DType]):
     ----------
     blocks : list[OptimizationBlock]
         The list of optimization tasks to be performed.
-    optimizer : Optimizer[DType]
+    optimizer : Optimizer[FloatT]
         The numerical optimizer used for parameter estimation.
 
     Methods
@@ -71,7 +71,7 @@ class MaximizationStep(PipelineStep[DType]):
         }
     )
 
-    def __init__(self, blocks: Sequence[OptimizationBlock], optimizer: Optimizer[DType]):
+    def __init__(self, blocks: Sequence[OptimizationBlock], optimizer: Optimizer[FloatT]):
         self.blocks = list(blocks)
         self.optimizer = optimizer
 
@@ -88,14 +88,14 @@ class MaximizationStep(PipelineStep[DType]):
 
         return [ExpectationStep]
 
-    def _update_components_params(self, component: ContinuousDistribution, params: dict[str, DType]):
+    def _update_components_params(self, component: ContinuousDistribution[FloatT], params: dict[str, FloatT]):
         """Helper method to update parameters for a single component.
 
         Parameters
         ----------
         component : ContinuousDistribution
             The component whose parameters are to be updated.
-        params : dict[str, DType]
+        params : dict[str, FloatT]
             A dictionary mapping parameter names to their new optimized values.
         """
 
@@ -103,7 +103,7 @@ class MaximizationStep(PipelineStep[DType]):
         param_values = list(params.values())
         component.set_params_from_vector(param_names, param_values)
 
-    def run(self, state: PipelineState[DType]) -> PipelineState[DType]:
+    def run(self, state: PipelineState[FloatT]) -> PipelineState[FloatT]:
         """Executes the M-step.
 
         This method iterates through the configured optimization blocks,
@@ -113,13 +113,13 @@ class MaximizationStep(PipelineStep[DType]):
 
         Parameters
         ----------
-        state : PipelineState[DType]
+        state : PipelineState[FloatT]
             The current state of the pipeline. Must contain the responsibility
             matrix :attr:`H` and the mixture model :attr:`curr_mixture`.
 
         Returns
         -------
-        PipelineState[DType]
+        PipelineState[FloatT]
             The updated pipeline state with the modified :attr:`curr_mixture`. If the
             :attr:`H` matrix is not available in the input state, the state is
             returned with an error set, and no modifications are made.

--- a/pysatl_mpest/optimizers/optimizer.py
+++ b/pysatl_mpest/optimizers/optimizer.py
@@ -12,12 +12,11 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Generic
 
-from ..typings import DType
+from ..typings import FloatingType
 
 
-class Optimizer(ABC, Generic[DType]):
+class Optimizer[FloatT: FloatingType](ABC):
     """Abstract base class for numerical optimizers.
 
     This class defines the standard interface for all optimizer implementations.
@@ -36,7 +35,7 @@ class Optimizer(ABC, Generic[DType]):
     """
 
     @abstractmethod
-    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
+    def minimize(self, target: Callable, params: list[FloatT]) -> list[FloatT]:
         """Finds the parameters that minimize a target function.
 
         This abstract method must be implemented by subclasses to perform the
@@ -48,7 +47,7 @@ class Optimizer(ABC, Generic[DType]):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[DType]
+        params : list[FloatT]
             A list of initial values for the parameters to be optimized. This
             serves as the starting point for the optimization algorithm.
 

--- a/pysatl_mpest/optimizers/scipy_nelder_mead.py
+++ b/pysatl_mpest/optimizers/scipy_nelder_mead.py
@@ -10,11 +10,11 @@ from collections.abc import Callable
 import numpy as np
 from scipy.optimize import minimize
 
-from ..typings import DType
+from ..typings import FloatingType
 from .optimizer import Optimizer
 
 
-class ScipyNelderMead(Optimizer[DType]):
+class ScipyNelderMead[FloatT: FloatingType](Optimizer[FloatT]):
     """An optimizer that uses the Nelder-Mead simplex algorithm from SciPy.
 
     This class serves as a wrapper for the `scipy.optimize.minimize` function,
@@ -31,7 +31,7 @@ class ScipyNelderMead(Optimizer[DType]):
         minimize
     """
 
-    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
+    def minimize(self, target: Callable, params: list[FloatT]) -> list[FloatT]:
         """Minimizes a target function using the Nelder-Mead algorithm.
 
         This method leverages the `scipy.optimize.minimize` function to find
@@ -43,13 +43,13 @@ class ScipyNelderMead(Optimizer[DType]):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[DType]
+        params : list[FloatT]
             A list of initial values for the parameters that serves as the
             starting point for the optimization.
 
         Returns
         -------
-        list[DType]
+        list[FloatT]
             A list containing the set of parameters that minimizes the target
             function, as found by the Nelder-Mead algorithm.
         """

--- a/pysatl_mpest/optimizers/scipy_powell.py
+++ b/pysatl_mpest/optimizers/scipy_powell.py
@@ -10,11 +10,11 @@ from collections.abc import Callable
 import numpy as np
 from scipy.optimize import minimize
 
-from ..typings import DType
+from ..typings import FloatingType
 from .optimizer import Optimizer
 
 
-class ScipyPowell(Optimizer[DType]):
+class ScipyPowell[FloatT: FloatingType](Optimizer[FloatT]):
     """An optimizer that uses Powell's conjugate direction method from SciPy.
 
     This class serves as a wrapper for the `scipy.optimize.minimize` function,
@@ -31,7 +31,7 @@ class ScipyPowell(Optimizer[DType]):
         minimize
     """
 
-    def minimize(self, target: Callable, params: list[DType]) -> list[DType]:
+    def minimize(self, target: Callable, params: list[FloatT]) -> list[FloatT]:
         """Minimizes a target function using Powell's method.
 
         This method leverages the `scipy.optimize.minimize` function to find
@@ -43,13 +43,13 @@ class ScipyPowell(Optimizer[DType]):
             The objective function to minimize. It must be a callable that
             accepts a list or NumPy array of parameters and returns a single
             scalar value.
-        params : list[DType]
+        params : list[FloatT]
             A list of initial values for the parameters that serves as the
             starting point for the optimization.
 
         Returns
         -------
-        list[DType]
+        list[FloatT]
             A list containing the set of parameters that minimizes the target
             function, as found by Powell's method.
         """

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
+Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -1,6 +1,6 @@
 """A module that provides custom types for the project."""
 
-__author__ = "Aleksandra Ri, Viktor Khanukaev"
+__author__ = "Aleksandra Ri, Viktor Khanukaev, Totmyanin Danil"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -9,7 +9,18 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy._typing import ArrayLike
 
-DType = TypeVar("DType", bound=np.floating)
+FloatingType = np.floating
+
+type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
+type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]
+type FloatArray[T: FloatingType] = np.ndarray[tuple[int, ...], np.dtype[T]]
+
+type UnivariateIntArray = np.ndarray[tuple[int], np.dtype[np.integer]]
+type IntArray = np.ndarray[tuple[int, ...], np.dtype[np.integer]]
+
+type BoolArray = np.ndarray[tuple[int, ...], np.dtype[np.bool_]]
+
+DType = TypeVar("DType", bound=FloatingType)
 
 
 @runtime_checkable

--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -11,6 +11,7 @@ from numpy._typing import ArrayLike
 
 Scalar = int | float | np.floating | np.integer
 FloatingType = np.floating
+BoolScalar = bool | np.bool_
 
 type UnivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int], np.dtype[T]]
 type MultivariateFloatArray[T: FloatingType] = np.ndarray[tuple[int, int], np.dtype[T]]

--- a/tests/unit/estimators/iterative/_strategies/moments/test_exponential_moments.py
+++ b/tests/unit/estimators/iterative/_strategies/moments/test_exponential_moments.py
@@ -63,7 +63,7 @@ def test_moments_exponential_raises_value_error_if_h_is_none(parametrized_expone
 def test_moments_exponential_returns_correct_types(parametrized_exponential_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
     exponential_component, pipeline_state, dtype = parametrized_exponential_setup
 

--- a/tests/unit/estimators/iterative/_strategies/moments/test_normal_moments.py
+++ b/tests/unit/estimators/iterative/_strategies/moments/test_normal_moments.py
@@ -64,7 +64,7 @@ def test_moments_normal_raises_value_error_if_h_is_none(parametrized_normal_setu
 def test_moments_normal_returns_correct_types(parametrized_normal_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
 
     normal_component, pipeline_state, dtype = parametrized_normal_setup

--- a/tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
+++ b/tests/unit/estimators/iterative/_strategies/q_function/test_exponential_q_function.py
@@ -63,7 +63,7 @@ def test_q_function_exponential_raises_value_error_if_h_is_none(parametrized_exp
 def test_q_function_exponential_returns_correct_types(parametrized_exponential_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
     exponential_component, pipeline_state, dtype = parametrized_exponential_setup
 

--- a/tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
+++ b/tests/unit/estimators/iterative/_strategies/q_function/test_normal_q_function.py
@@ -63,7 +63,7 @@ def test_q_function_normal_raises_value_error_if_h_is_none(parametrized_normal_s
 def test_q_function_normal_returns_correct_types(parametrized_normal_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
     normal_component, pipeline_state, dtype = parametrized_normal_setup
 

--- a/tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
+++ b/tests/unit/estimators/iterative/_strategies/q_function/test_weibull_q_function.py
@@ -70,7 +70,7 @@ def test_q_function_weibull_raises_value_error_if_h_is_none(parametrized_weibull
 def test_q_function_weibull_returns_correct_types(parametrized_weibull_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
 
     weibull_component, pipeline_state, mock_optimizer, dtype = parametrized_weibull_setup

--- a/tests/unit/estimators/iterative/_strategies/test_observed_data_likelihood.py
+++ b/tests/unit/estimators/iterative/_strategies/test_observed_data_likelihood.py
@@ -138,7 +138,7 @@ def test_odl_strategy_calls_optimizer_minimize_once(parametrized_setup):
 def test_odl_strategy_returns_correct_types(parametrized_setup):
     """
     Verifies that the function returns a tuple with the correct
-    data types (int, dict[str, DType]).
+    data types (int, dict[str, FloatT]).
     """
 
     target_comp, state, block, optimizer, dtype = parametrized_setup


### PR DESCRIPTION
## Summary
This Pull Request migrates the entire `estimators` module to use modern PEP 695 generic type parameters (`[FloatT: FloatingType]`) introduced in Python 3.12, fully replacing the legacy `DType = TypeVar("DType", bound=FloatingType)` references.

It covers the base estimator class, concrete iterative estimators (`ECM`, `ECME`), the execution pipeline components (steps, breakpointers, pruners), optimization strategies, and all associated unit tests.

---

## Key Changes

### 1. Estimator Exports
* Exposed [ECME](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/ecme.py) in the estimators package initialization [__init__.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/__init__.py).

### 2. Core Estimator Classes
* Refactored [BaseEstimator](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/base_estimator.py), [ECM](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/ecm.py), and [ECME](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/ecme.py) to use the `[FloatT: FloatingType]` signature constraint.
* Replaced `DType` imports and type hints with `FloatT`.

### 3. Pipeline & State Management
* Migrated the iterative estimation pipeline framework to PEP 695:
  * [Pipeline](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/pipeline.py)
  * [PipelineState](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/pipeline_state.py)
  * [PipelineStep](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/pipeline_step.py)
  * [_iteration_history.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/_iteration_history.py)
* Updated execution steps:
  * [ExpectationStep](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/steps/expectation_step.py)
  * [MaximizationStep](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/steps/maximization_step.py)

### 4. Stopping Criteria & Pruners
* Updated abstract classes and their concrete subclasses to use PEP 695 generic parameter bindings:
  * [Breakpointer](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/breakpointer.py)
  * [LikelihoodBreakpointer](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/breakpointers/likelihood_breakpointer.py)
  * [StepBreakpointer](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/breakpointers/step_breakpointer.py)
  * [Pruner](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/pruner.py)
  * [PriorThresholdPruner](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/pruners/prior_threshold_pruner.py)

### 5. Maximization Strategies & Type Definitions
* Refactored maximization strategy functions to generic forms using `FloatT`:
  * [moments_strategy](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/_strategies/moments.py)
  * [observed_data_likelihood_strategy](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/_strategies/observed_data_likelihood.py)
  * [q_function_strategy](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/_strategies/q_function.py)
* Introduced a clean type alias `StrategyFunction` in [_strategies/__init__.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/estimators/iterative/_strategies/__init__.py) and leveraged explicit typing casts within `MaximizationStep` for better compatibility with static analysis tools.