### PR TITLE
refactor: remove DType

### DIFF
--- a/pysatl_mpest/typings.py
+++ b/pysatl_mpest/typings.py
@@ -4,7 +4,7 @@ __author__ = "Aleksandra Ri, Viktor Khanukaev, Totmyanin Danil"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 from numpy._typing import ArrayLike
@@ -21,8 +21,6 @@ type UnivariateIntArray = np.ndarray[tuple[int], np.dtype[np.integer]]
 type IntArray = np.ndarray[tuple[int, ...], np.dtype[np.integer]]
 
 type BoolArray = np.ndarray[tuple[int, ...], np.dtype[np.bool_]]
-
-DType = TypeVar("DType", bound=FloatingType)
 
 
 @runtime_checkable


### PR DESCRIPTION
This Pull Request cleans up the `typings` module by removing the legacy `DType` `TypeVar` definition. 

Since all packages (distributions, optimizers, and estimators) have successfully transitioned to the standard PEP 695 type parameter syntax (`[FloatT: FloatingType]`) introduced in Python 3.12, this legacy declaration is obsolete and has been removed.

---

## Changes

### 1. Legacy Type Parameter Removal
* Deleted the `DType` declaration bounded to `FloatingType` from [typings.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/typings.py):
  ```python
  - DType = TypeVar("DType", bound=FloatingType)
  ```

### 2. Clean Imports
* Removed the unused `TypeVar` import from the standard `typing` module in [typings.py](file:///home/iraedeus/Projects/rework-pysatl-mpest/pysatl_mpest/typings.py#L7).